### PR TITLE
Add linting (ruff) to CI and fix import ordering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,12 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest pytest-cov
+          pip install pytest pytest-cov ruff
           # Pillow is needed by render_quote.py (imported at test time)
           pip install Pillow
+
+      - name: Run linter
+        run: ruff check . --ignore=E501
 
       - name: Run tests with coverage
         run: |

--- a/gutenberg_time_miner.py
+++ b/gutenberg_time_miner.py
@@ -23,10 +23,9 @@ import urllib.error
 import urllib.request
 from dataclasses import dataclass
 from pathlib import Path
-
-BASE_DIR = Path(__file__).resolve().parent
 from typing import Iterable, Iterator, Sequence
 
+BASE_DIR = Path(__file__).resolve().parent
 
 NUMBER_WORDS = {
     "zero": 0,

--- a/merge_candidates.py
+++ b/merge_candidates.py
@@ -8,9 +8,9 @@ import re
 from collections import Counter
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Iterable
 
 BASE_DIR = Path(__file__).resolve().parent
-from typing import Iterable
 
 
 @dataclass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,3 +13,11 @@ exclude_lines = [
     "if __name__ == .__main__.:",
     "raise SystemExit",
 ]
+
+[tool.ruff]
+line-length = 130
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I"]
+ignore = ["E501"]  # Line too long (handled separately if needed)

--- a/render_quote.py
+++ b/render_quote.py
@@ -398,7 +398,7 @@ def render(time_str: str, quote_row: dict, width: int, height: int, mode: str = 
     mark_font = load_font(ORNAMENT_FONT_CANDIDATES, size=mark_size)
 
     open_bb = draw.textbbox((0, 0), "“", font=mark_font)
-    open_w = open_bb[2] - open_bb[0]
+    open_bb[2] - open_bb[0]
     open_h = open_bb[3] - open_bb[1]
     open_x = SIDE_MARGIN + 18
     open_y = quote_top - open_h // 3

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,8 +2,9 @@
 from __future__ import annotations
 
 import json
-import pytest
 from pathlib import Path
+
+import pytest
 
 
 def make_row(**kwargs) -> dict:

--- a/tests/test_bucket_coverage.py
+++ b/tests/test_bucket_coverage.py
@@ -1,7 +1,6 @@
 """Tests for bucket_coverage.py"""
 from __future__ import annotations
 
-import pytest
 from bucket_coverage import build_summary, expected_buckets, render_markdown
 
 

--- a/tests/test_clean_display_quotes.py
+++ b/tests/test_clean_display_quotes.py
@@ -1,9 +1,7 @@
 """Tests for clean_display_quotes.py — sentence extraction and fragment detection."""
 from __future__ import annotations
 
-import pytest
 import clean_display_quotes as cdq
-
 
 # ---------------------------------------------------------------------------
 # split_sentences

--- a/tests/test_enrich_metadata.py
+++ b/tests/test_enrich_metadata.py
@@ -2,8 +2,7 @@
 from __future__ import annotations
 
 import json
-import pytest
-from pathlib import Path
+
 from enrich_metadata import parse_header
 
 
@@ -81,8 +80,9 @@ class TestParseHeader:
 
 class TestMain:
     def test_enriches_rows_with_metadata(self, tmp_path):
-        from enrich_metadata import main
         import sys
+
+        from enrich_metadata import main
 
         gutenberg_dir = tmp_path / "gutenberg"
         gutenberg_dir.mkdir()
@@ -108,8 +108,9 @@ class TestMain:
         assert result["author"] == "Jane Austen"
 
     def test_preserves_existing_title_author(self, tmp_path):
-        from enrich_metadata import main
         import sys
+
+        from enrich_metadata import main
 
         gutenberg_dir = tmp_path / "gutenberg"
         gutenberg_dir.mkdir()
@@ -140,8 +141,9 @@ class TestMain:
         assert result["author"] == "Custom Author"
 
     def test_no_source_id_leaves_nulls(self, tmp_path):
-        from enrich_metadata import main
         import sys
+
+        from enrich_metadata import main
 
         gutenberg_dir = tmp_path / "gutenberg"
         gutenberg_dir.mkdir()

--- a/tests/test_fix_substring_time_matches.py
+++ b/tests/test_fix_substring_time_matches.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import json
-import pytest
+
 from fix_substring_time_matches import (
     bucket_for_minute,
     infer_time_from_quote,
@@ -144,8 +144,9 @@ class TestInferTimeFromQuote:
 class TestMain:
     def test_fixes_substring_collision(self, tmp_path):
         """A row whose matched_text is a sub-string of the longer phrase gets updated."""
-        from fix_substring_time_matches import main
         import sys
+
+        from fix_substring_time_matches import main
 
         row = {
             "display_quote": "It was thirty-five minutes past two in the afternoon.",
@@ -168,8 +169,9 @@ class TestMain:
         assert result["fuzzy_bucket"] == "h2_half_pastish"
 
     def test_leaves_non_collision_rows_unchanged(self, tmp_path):
-        from fix_substring_time_matches import main
         import sys
+
+        from fix_substring_time_matches import main
 
         row = {
             "display_quote": "It was ten minutes past three.",

--- a/tests/test_gutenberg_time_miner.py
+++ b/tests/test_gutenberg_time_miner.py
@@ -2,10 +2,8 @@
 from __future__ import annotations
 
 import re
-import pytest
 
 import gutenberg_time_miner as gtm
-
 
 # ---------------------------------------------------------------------------
 # normalize_number_phrase

--- a/tests/test_import_targeted_hits.py
+++ b/tests/test_import_targeted_hits.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import json
-import pytest
+
 from import_targeted_hits import minute_for_bucket, row_from_targeted
 
 
@@ -98,7 +98,7 @@ class TestRowFromTargeted:
         assert row["daypart_bucket"] == "noon"
 
     def test_daypart_midnight(self):
-        row = row_from_targeted(self._raw(resolved_bucket="h12_half_pastish"))
+        row_from_targeted(self._raw(resolved_bucket="h12_half_pastish"))
         # h12 maps to noon in DAYPARTS
         row2 = row_from_targeted(self._raw(resolved_bucket="h1_exact"))
         assert row2["daypart_bucket"] == "night"
@@ -126,8 +126,9 @@ class TestRowFromTargeted:
 
 class TestMain:
     def test_converts_rows(self, tmp_path):
-        from import_targeted_hits import main
         import sys
+
+        from import_targeted_hits import main
 
         raw = {
             "resolved_bucket": "h3_exact",

--- a/tests/test_merge_candidates.py
+++ b/tests/test_merge_candidates.py
@@ -1,11 +1,8 @@
 """Tests for merge_candidates.py — text normalization and deduplication."""
 from __future__ import annotations
 
-import pytest
-from tests.conftest import make_row
-
 import merge_candidates as mc
-
+from tests.conftest import make_row
 
 # ---------------------------------------------------------------------------
 # normalize_text

--- a/tests/test_pick_quote.py
+++ b/tests/test_pick_quote.py
@@ -2,10 +2,9 @@
 from __future__ import annotations
 
 import pytest
-from tests.conftest import make_row
 
 import pick_quote as pq
-
+from tests.conftest import make_row
 
 # ---------------------------------------------------------------------------
 # minute_bucket

--- a/tests/test_quality_filter.py
+++ b/tests/test_quality_filter.py
@@ -1,7 +1,6 @@
 """Tests for quality_filter.py — penalty scoring logic."""
 from __future__ import annotations
 
-import pytest
 import quality_filter as qf
 
 

--- a/tests/test_render_quote.py
+++ b/tests/test_render_quote.py
@@ -3,16 +3,15 @@ from __future__ import annotations
 
 import pytest
 
+import render_quote as rq
+
 try:
-    from PIL import Image, ImageDraw, ImageFont
+    from PIL import Image
     PIL_AVAILABLE = True
 except ImportError:
     PIL_AVAILABLE = False
 
 pytestmark = pytest.mark.skipif(not PIL_AVAILABLE, reason="Pillow not installed")
-
-import render_quote as rq
-
 
 # ---------------------------------------------------------------------------
 # choose_layout

--- a/tests/test_render_quote.py
+++ b/tests/test_render_quote.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 
 import pytest
 
-import render_quote as rq
-
 try:
     from PIL import Image
     PIL_AVAILABLE = True
@@ -12,6 +10,8 @@ except ImportError:
     PIL_AVAILABLE = False
 
 pytestmark = pytest.mark.skipif(not PIL_AVAILABLE, reason="Pillow not installed")
+
+import render_quote as rq  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # choose_layout

--- a/tests/test_run_clock.py
+++ b/tests/test_run_clock.py
@@ -1,11 +1,7 @@
 """Tests for run_clock.py"""
 from __future__ import annotations
 
-import subprocess
-import sys
-from unittest.mock import MagicMock, call, patch
-
-import pytest
+from unittest.mock import patch
 
 import run_clock
 

--- a/tests/test_target_sparse_buckets.py
+++ b/tests/test_target_sparse_buckets.py
@@ -1,7 +1,6 @@
 """Tests for target_sparse_buckets.py"""
 from __future__ import annotations
 
-import pytest
 from target_sparse_buckets import expected_targets, sentence_window, templates_for_bucket
 
 


### PR DESCRIPTION
- Configure ruff with line-length=130 and checks for E,W,F,I
- Ignore E501 (line too long) as many long lines are unavoidable regex patterns
- Add linting step to GitHub Actions CI workflow
- Fix E402 import ordering violations (move typing imports to top)
- Remove unused imports and variables (F401, F841)

https://claude.ai/code/session_01FEsF6tkvfcsU3xGz1GFaXG