### PR TITLE
Disable CI linter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,8 @@ jobs:
           # Pillow is needed by render_quote.py (imported at test time)
           pip install Pillow
 
-      - name: Run linter
-        run: ruff check . --ignore=E501
+      # - name: Run linter
+      #   run: ruff check . --ignore=E501
 
       - name: Run tests with coverage
         run: |


### PR DESCRIPTION
Comment out the ruff linter step in the GitHub Actions workflow to disable linting checks during CI runs. Tests will continue to run as normal.

https://claude.ai/code/session_01H3LXs6RMn5ZP7k2oasMh7D