### PR TITLE
Rewrite README around runtime and deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,94 +1,36 @@
 # LitClock
 
-LitClock is a literary clock built from public-domain text. It picks a time-matched quote, renders it as a designed image, and can display it on eInk hardware like the Pimoroni Inky Impression 7.3.
+LitClock is a literary clock built from public-domain text. It picks a quote that matches the current fuzzy time bucket, renders it into an 800×480 image, and can push that image to an eInk display such as the Pimoroni Inky Impression 7.3.
 
 ![LitClock render preview](assets/preview.png)
 
-## What it does
+## What this repo is
 
-- picks a quote for the current fuzzy time bucket
-- renders it in a centered, editorial QOTD-style layout tuned for the 800×480 Inky Impression 7.3 panel
-- highlights the operative time phrase inside the quote
-- snaps the final render to the exact Spectra 6 palette for cleaner hardware output
-- supports `debug` and cleaner `production` render modes
-- can run as a hands-free boot appliance on a Pi
+This repo contains both:
 
-## How it works
+- the **runtime clock** that picks and renders quotes for the current time
+- the **corpus/build tooling** used to mine, clean, enrich, and improve the quote dataset
 
-In plain English, LitClock was built in stages:
+If you are deploying or operating the clock, you mostly care about the runtime and the prebuilt assets in `assets/`.
 
-1. **Mine public-domain books for time references**
-   - A custom miner scans books, looking for phrases like "quarter past seven" or "ten minutes to midnight".
-   - Every hit gets sorted into a fuzzy time bucket rather than a single exact minute.
+## Repo map
 
-2. **Clean and score the candidate quotes**
-   - Raw matches are often ugly, repetitive, or overly dialogue-heavy.
-   - Cleanup scripts trim them into displayable quotes, add metadata, and rank them for readability and fit.
+### Runtime
 
-3. **Build a quote set that covers the whole clock**
-   - Coverage tools show which time buckets are strong, weak, or empty.
-   - When a bucket is missing or poor, targeted mining/backfill scripts hunt for better material.
+- `run_clock.py` - long-running clock loop, bucket-change refresh logic, optional display handoff
+- `render_quote.py` - quote renderer, typography, highlighting, theme handling, Spectra 6 palette snapping
+- `pick_quote.py` - runtime quote selection from the attributed dataset
+- `display_inky.py` - thin bridge that sends a rendered image to the Inky display
+- `buckets.py` - fuzzy time bucket mapping
 
-4. **Pick the best quote for the current time**
-   - At runtime, LitClock figures out the current fuzzy bucket, selects the best available quote for that bucket, and falls back nearby if one bucket is still weak or empty.
+### Runtime assets
 
-5. **Render it as a designed display image**
-   - The renderer lays out the quote, highlights the matching time phrase, applies the current typography/theme, and prepares a final 800×480 image.
+- `assets/candidates-attributed.jsonl` - shipped runtime quote dataset
+- `assets/selection_overrides.json` - selection tweaks/overrides used at runtime
+- `assets/preview.png` - README preview image
 
-6. **Display it on the eInk panel**
-   - On the Pi, the runtime can hand that image to the Inky display script.
-   - In appliance mode, the service simply refreshes whenever the fuzzy time bucket changes.
+### Build and corpus tools
 
-So the short version is: **mine quotes, clean them up, organize them by fuzzy time, pick the best one for now, render it nicely, and push it to the display.**
-
-## Quick start
-
-### Local render test
-
-```bash
-python3 run_clock.py --once
-```
-
-### Push to Inky once
-
-```bash
-python3 run_clock.py --once --display-script display_inky.py --mode production
-```
-
-### Run the full loop locally
-
-```bash
-python3 run_clock.py --display-script display_inky.py --mode production
-```
-
-## Raspberry Pi / Inky setup
-
-If Inky is already installed and working on the Pi, the short path is:
-
-```bash
-source ~/.virtualenvs/pimoroni/bin/activate
-git clone git@github.com:gkoch02/LitClock.git
-cd LitClock
-python3 run_clock.py --once
-python3 display_inky.py output/current.png
-python3 run_clock.py --once --display-script display_inky.py --mode production
-```
-
-For full Pi setup and appliance boot instructions, see:
-
-- [pi_setup_inky_impression.md](pi_setup_inky_impression.md)
-- [`litclock.service.example`](litclock.service.example)
-- [`bootstrap_pi_inky.sh`](bootstrap_pi_inky.sh)
-
-## Project structure
-
-### Core runtime
-- `run_clock.py` - runtime loop, bucket-change refresh behavior, optional display handoff, and service entrypoint
-- `render_quote.py` - centered quote rendering, typography, highlighting, and Spectra 6 palette snapping
-- `pick_quote.py` - quote selection from the attributed corpus
-- `display_inky.py` - thin Inky display bridge
-
-### Corpus and mining tools
 - `gutenberg_time_miner.py`
 - `clean_display_quotes.py`
 - `quality_filter.py`
@@ -96,24 +38,124 @@ For full Pi setup and appliance boot instructions, see:
 - `merge_candidates.py`
 - `bucket_coverage.py`
 - `fix_substring_time_matches.py`
+- `target_sparse_buckets.py`
+- `import_targeted_hits.py`
 
-### Runtime data contract
-- The shipped runtime picker dataset is `assets/candidates-attributed.jsonl`.
-- Runtime selection config lives in `assets/selection_overrides.json`.
-- Normal Pi deployments should treat those files as prebuilt runtime assets and use them directly.
-- `data/gutenberg/` exists to support corpus rebuilds and metadata regeneration, not because the render loop itself needs raw texts at runtime.
-- If you are only deploying or updating the clock, you should not need to rerun the enrichment pipeline on-device.
+### Other important paths
 
-For mining/backfill work and corpus expansion notes, see:
+- `tests/` - automated tests
+- `output/` - generated output and analysis artifacts, not canonical runtime source
+- `fonts/` - bundled Playfair Display fonts used by the renderer
+- `litclock.service.example` - example systemd service for Pi deployment
+- `pi_setup_inky_impression.md` - Pi setup notes
+- `bootstrap_pi_inky.sh` - helper bootstrap script for Pi setup
 
-- `run_batch2.sh`
+## Runtime data contract
 
-## Notes
+For normal runtime use, the clock expects prebuilt assets and does **not** need raw Gutenberg texts to render quotes.
 
-- The clock refreshes when the fuzzy bucket changes, not every minute.
-- The default picker uses the attributed dataset: `assets/candidates-attributed.jsonl`.
-- Treat `assets/candidates-attributed.jsonl` as the deployable runtime artifact.
-- Production mode hides debug metadata for a cleaner display.
-- The render pipeline now snaps output to the exact Spectra 6 palette, which materially improves color fidelity on hardware.
-- The current renderer is tuned specifically for the Pimoroni Inky Impression 7.3 / Spectra 6 800×480 panel.
-- If a bucket has no usable quote above the quality threshold, `pick_quote` walks outward through the neighboring minute-states of the same hour and reports the fallback via `resolved_bucket` / `used_fallback` so the display never goes blank.
+- Use `assets/candidates-attributed.jsonl` as the deployable runtime dataset.
+- Use `assets/selection_overrides.json` for runtime selection overrides.
+- Treat `data/` and the mining/enrichment scripts as build-time tooling, not service startup dependencies.
+
+If you are only updating the clock on a Pi, you should not need to rebuild the corpus on-device.
+
+## Quick start
+
+### Local setup
+
+Create a virtual environment and install dependencies:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -e '.[dev]'
+```
+
+### Render once locally
+
+```bash
+python3 run_clock.py --once
+```
+
+### Render once and push to the Inky display
+
+```bash
+python3 run_clock.py --once --display-script display_inky.py --mode production
+```
+
+### Run the full clock loop locally
+
+```bash
+python3 run_clock.py --display-script display_inky.py --mode production
+```
+
+## Testing
+
+Run the full test suite:
+
+```bash
+pytest
+```
+
+Run a targeted subset:
+
+```bash
+pytest tests/test_render_quote.py tests/test_run_clock.py
+```
+
+## Raspberry Pi deployment
+
+The Pi should track `main` and use the prebuilt runtime assets already committed to the repo.
+
+### Example update flow
+
+```bash
+git pull --ff-only origin main
+sudo systemctl restart litclock.service
+systemctl status --no-pager litclock.service
+```
+
+### Example service
+
+See `litclock.service.example`.
+
+Current service model:
+
+- runs `run_clock.py`
+- optionally calls `display_inky.py` after each render
+- uses the prebuilt dataset in `assets/candidates-attributed.jsonl`
+- does not rebuild corpus artifacts at startup
+
+## Build pipeline notes
+
+The build side of the repo exists to improve quote coverage and quality over time.
+
+At a high level, the process is:
+
+1. mine public-domain texts for time phrases
+2. clean candidate quotes into displayable form
+3. enrich and score them
+4. merge and analyze coverage
+5. ship the resulting attributed dataset as a runtime asset
+
+That work is intentionally separate from the steady-state render loop.
+
+## Operational notes
+
+- The clock refreshes when the fuzzy time bucket changes, not every minute.
+- If the exact bucket is weak or empty, the picker walks nearby buckets and records fallback metadata.
+- `production` mode hides debug metadata for cleaner display output.
+- The renderer is tuned for the Pimoroni Inky Impression 7.3 / Spectra 6 800×480 display.
+- Final renders are snapped to the exact Spectra 6 palette for better hardware fidelity.
+- Renderer changes can be surprisingly fragile around text normalization, wrapping, and emphasis/highlight matching, so keep render tests healthy.
+
+## Useful files when something breaks
+
+If the clock is behaving oddly, these are the first files to inspect:
+
+- quote selection problems -> `pick_quote.py`
+- highlight/layout/render issues -> `render_quote.py`
+- loop/update/dedup/service behavior -> `run_clock.py`
+- display handoff issues -> `display_inky.py`
+- runtime dataset questions -> `assets/candidates-attributed.jsonl`

--- a/README.md
+++ b/README.md
@@ -13,6 +13,19 @@ This repo contains both:
 
 If you are deploying or operating the clock, you mostly care about the runtime and the prebuilt assets in `assets/`.
 
+## How LitClock was built
+
+At a high level, the project came together in stages:
+
+1. mine public-domain books for phrases like "quarter past seven" or "ten minutes to midnight"
+2. clean raw matches into displayable quotes
+3. enrich, attribute, and score the candidates
+4. organize them into fuzzy time buckets
+5. pick the best quote for the current bucket at runtime, with nearby fallback when needed
+6. render the result into an image tuned for the target eInk display
+
+That build pipeline is how the runtime quote set came to exist. The clock itself then uses the prebuilt dataset and render loop to turn that corpus work into a live display.
+
 ## Repo map
 
 ### Runtime


### PR DESCRIPTION
## Summary
- rewrite the README around the current runtime and deployment model
- separate runtime concerns from corpus/build tooling
- document local setup, testing, Pi updates, and repo directory contracts

## Testing
- documentation-only change