### PR TITLE
Add top-right debug mode banner

### DIFF
--- a/render_quote.py
+++ b/render_quote.py
@@ -552,6 +552,21 @@ def render(time_str: str, quote_row: dict, width: int, height: int, mode: str = 
         y += source_size + layout["title_gap"]
 
     if show_debug:
+        debug_label = "DEBUG MODE"
+        label_bbox = draw.textbbox((0, 0), debug_label, font=debug_font)
+        label_w = label_bbox[2] - label_bbox[0]
+        label_h = label_bbox[3] - label_bbox[1]
+        label_x = width - SIDE_MARGIN - label_w
+        label_y = 14
+
+        top_rule_y = label_y + label_h + 6
+        top_rule_left = max(SIDE_MARGIN, label_x - 24)
+        top_rule_right = width - SIDE_MARGIN
+        for x in range(top_rule_left, top_rule_right, 5):
+            draw.point((x, top_rule_y), fill=colors["faint"])
+
+        draw_text(draw, (label_x, label_y), debug_label, font=debug_font, fill=colors["faint"])
+
         bucket_value = quote_row.get("bucket") or ""
         resolved = quote_row.get("resolved_bucket") or bucket_value
         if quote_row.get("used_fallback") and resolved and bucket_value and resolved != bucket_value:


### PR DESCRIPTION
## Summary
- add a top-right DEBUG MODE label in debug renders
- use a matching dotted rule so it visually aligns with the bottom debug strip
- keep the banner debug-only

## Testing
- not run (small render-only UI change)