### PR TITLE
Add Inky button handling, auto-dark theme, and runtime telemetry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,17 @@ python3 run_clock.py --display-script display_inky.py --mode production
 # Dark theme (black background, white text, yellow accent) — both CLIs accept --theme
 python3 run_clock.py --display-script display_inky.py --theme dark
 
+# Auto theme: dark between 18:00–06:00, default otherwise
+# (button B toggles manually and overrides 'auto' until midnight)
+python3 run_clock.py --display-script display_inky.py --theme auto
+
+# Disable the Inky button listener (use on dev machines / headless smoke tests)
+python3 run_clock.py --buttons-off
+
+# Persisted runtime state (manual theme + manual quiet override) and telemetry sidecar
+python3 run_clock.py --state-path ~/.litclock/state.json --telemetry-path ~/.litclock/telemetry.jsonl
+python3 litclock_health.py --hours 24      # summary: render count, error count, p50/p95 latency
+
 # Disable the default quiet-hours blackout (defaults 22:00–06:00, shows assets/goodnight.png)
 python3 run_clock.py --quiet-off
 python3 run_clock.py --quiet-start 23:30 --quiet-end 07:00 --quiet-image assets/goodnight.png
@@ -314,13 +325,30 @@ Thin orchestrator. Each tick (`--interval-seconds`, default 60) it computes the 
 
 **Anti-repeat ledger.** After each successful render the loop appends `(timestamp, source_id, line_number)` to `--history-path` (default `~/.litclock/history.jsonl`, 7-day window via `--history-days`). The next `peek_quote_id` / `render_now` pair reads that ledger and filters out rows shown within the window, so the same quote is not repeated that week. The ledger write happens only after the render subprocess returns 0, so a crash mid-render leaves the ledger untouched; quiet-hours renders and dedup-skipped ticks also do not append. Pass `--history-path ""` or `--history-days 0` to disable.
 
+**Auto-dark theme (`--theme auto`).** Picks `dark` between 18:00 and 06:00 (`AUTO_DARK_START_HOUR` / `AUTO_DARK_END_HOUR`) and `default` otherwise. Each tick re-derives the effective theme from the wall clock; a theme change is treated like a bucket change (forces a redraw even if the picked quote is unchanged). The button-B manual toggle wins until the next midnight rollover, when `_maybe_reset_manual_theme_at_midnight` clears it so `auto` resumes.
+
+**Inky buttons (`inky_buttons.py`).** The four capacitive buttons on the Inky Impression are wired to GPIO 5/6/16/24 (labels A/B/C/D) and dispatched by `inky_buttons.start_listener({label: callable})` using `gpiozero.Button` with a 0.3-second debounce. The hardware import is local to `start_listener` so the module is import-safe on dev hosts. `run_clock.py` builds the handler dict in `_build_button_handlers` and stashes the returned `Button` list in a local for the lifetime of the loop — `gpiozero` drops handlers when its `Button` is garbage-collected, so the reference must be held. Handlers act synchronously in the listener thread and serialize against the main loop via `state.render_lock`; mutations of theme/quiet flags are guarded by `state.lock`. Pass `--buttons-off` on dev machines or for headless runs.
+
+| Button | Action |
+|---|---|
+| **A** | Skip — bans the current quote in the history ledger, picks again, re-renders. |
+| **B** | Toggle theme — flips default ↔ dark, persists to `--state-path`, re-renders. |
+| **C** | Source card — renders a `--mode card` overlay (title / author / Gutenberg ID / matched phrase) for 5 seconds, then the timer thread itself re-renders the original frame (the next loop tick alone could be up to 60s away). |
+| **D** | Quiet now / wake — toggles `manual_quiet`, persists to `--state-path`. Going quiet pushes `--quiet-image` immediately; going active picks and renders the current time. |
+
+**Persisted runtime state (`--state-path`).** `~/.litclock/state.json` (default) holds `manual_theme` and `manual_quiet`. Loaded at loop startup so the user's last button-B / button-D choices survive a restart. Pass an empty string to disable.
+
+**Telemetry sidecar (`--telemetry-path`).** `~/.litclock/telemetry.jsonl` (default) gets one JSONL entry per successful render (`bucket`, `render_ms`, `display_ms`, `source_id`, `line_number`, `mode`, `theme`) and one per loop-level error (`bucket`, `error`, `mode`). `litclock_health.py` summarises the last N hours: render count, error count, p50/p95 latency, last error message. Designed for "is the appliance healthy?" diagnosis without `journalctl` spelunking. Pass an empty string to disable.
+
 ### Contact Sheet (`contact_sheet.py`)
 
 Offline QA tool. For each of the 144 `h{1..12}_{state}` buckets, calls `pick_quote.select_quote` at the bucket's canonical `HH:MM` (e.g. `h3_twenty_past` → `03:20`; `h12_*` maps to `00:MM`), renders the full 800×480 frame via `render_quote.render`, and downscales it into a tile on a 12×12 grid. Each tile gets a small `HH:MM  h{hour}_{state}` caption below so you can locate specific buckets at a glance. Flags: `--tile-width`/`--tile-height` (defaults 200×120), `--caption-height` (18), `--margin` (6), `--theme`, and `--mode` — defaults to `production` so the debug footer doesn't dominate small tiles. History filtering is forced off (snapshot of the whole corpus, not anti-repeated picks). Use this to spot regressions after a corpus change: layout bugs, malformed `matched_text`, repeat authors in adjacent buckets, or fallback-bucket frames that look visually wrong.
 
 ### Inky Display Bridge (`display_inky.py`)
 
-Minimal Pillow → Pimoroni `inky.auto` bridge. Loads the PNG, resizes to the panel's native size if needed, and calls `inky.set_image(..., saturation=0.5).show()`. Designed to be called once per render from `run_clock.py`. Only needed on the Pi. Up to `MAX_ATTEMPTS` (3) calls are retried with `RETRY_BACKOFF_SECONDS = (1, 4)` between attempts so a momentary I/O hiccup doesn't crash the caller; if all attempts fail the script raises `SystemExit` so the loop in `run_clock.py` logs and moves on.
+Minimal Pillow → Pimoroni `inky.auto` bridge. Loads the PNG, resizes to the panel's native size if needed, and calls `inky.set_image(..., saturation=...).show()`. Designed to be called once per render from `run_clock.py`. Only needed on the Pi. Up to `MAX_ATTEMPTS` (3) calls are retried with `RETRY_BACKOFF_SECONDS = (1, 4)` between attempts so a momentary I/O hiccup doesn't crash the caller; if all attempts fail the script raises `SystemExit` so the loop in `run_clock.py` logs and moves on.
+
+**Per-theme saturation.** `THEME_SATURATION` defaults to `{default: 0.5, dark: 0.7}` — the Spectra 6 panel renders dark backgrounds with a different waveform than light ones, so pushing saturation slightly higher on dark keeps accent colours from looking muddy. `run_clock.render_now` forwards `--theme` to `display_inky.py`, which calls `resolve_saturation(theme, override)` to pick the value to push. An explicit `--saturation` always wins over the per-theme default.
 
 ### Appliance / Pi Setup
 
@@ -330,14 +358,14 @@ Minimal Pillow → Pimoroni `inky.auto` bridge. Loads the PNG, resizes to the pa
 
 ### Testing
 
-The test suite lives in `tests/` and uses pytest with pytest-cov. There are 15 test modules covering every pipeline script plus the runtime components — 371 tests at last count. `display_inky.py` is exercised via `test_display_inky.py` with `_push_to_panel` mocked out so the retry/error paths run without real hardware; it stays in `tool.coverage.run.omit` so coverage numbers aren't skewed by hardware-only branches.
+The test suite lives in `tests/` and uses pytest with pytest-cov. There are 17 test modules covering every pipeline script plus the runtime components — 485 tests at last count. `display_inky.py` is exercised via `test_display_inky.py` with `_push_to_panel` mocked out so the retry/error paths run without real hardware; it stays in `tool.coverage.run.omit` so coverage numbers aren't skewed by hardware-only branches. `inky_buttons.py` is tested with `gpiozero.Button` stubbed via a `FakeButton` class injected through `sys.modules`.
 
 **Test structure:**
 - `tests/conftest.py` — shared fixtures: `make_row()` factory, `sample_row`, `sample_rows`, and `tmp_jsonl` (a helper that writes a list of dicts to a temp JSONL file)
 - One `test_<script>.py` module per main script; tests are class-based (e.g., `TestCurrentBucket`, `TestRenderNow`)
 
 **pyproject.toml** configures:
-- `[project]`: name `litclock`, version, `requires-python >= 3.11`, runtime dep `Pillow`, optional extras `dev = [pytest, pytest-cov, ruff]` and `pi = [inky]`. `pip install -e .[dev]` is the intended developer setup.
+- `[project]`: name `litclock`, version, `requires-python >= 3.11`, runtime dep `Pillow`, optional extras `dev = [pytest, pytest-cov, ruff]` and `pi = [inky, gpiozero]` (`gpiozero` is needed by `inky_buttons.py` on the Pi). `pip install -e .[dev]` is the intended developer setup.
 - pytest: `testpaths = ["tests"]`, `python_files = ["test_*.py"]`
 - coverage: source = `.`, omits `tests/`, `bootstrap_pi_inky.sh`, and `display_inky.py`
 - ruff: line-length 130, target Python 3.11, rules E / W / F / I (E501 ignored)
@@ -361,8 +389,10 @@ enrich_metadata.py                 attach author/title from Gutenberg headers
 pick_quote.py                      rank candidates, honor overrides, fall back to neighbors (exposes select_quote())
 render_quote.py                    Pillow layout → 800×480 Spectra-6 PNG (imports pick_quote in-process)
 contact_sheet.py                   12×12 grid of all 144 bucket frames, for offline QA
-run_clock.py                       runtime loop (bucket-change-triggered, error-tolerant, quiet-hours-aware)
-display_inky.py                    Pi-only image → Inky Impression bridge (retry with backoff)
+run_clock.py                       runtime loop (bucket-change-triggered, error-tolerant, quiet-hours-aware, button + auto-theme + telemetry)
+display_inky.py                    Pi-only image → Inky Impression bridge (retry with backoff, per-theme saturation)
+inky_buttons.py                    Pi-only gpiozero button listener (A/B/C/D → run_clock handlers)
+litclock_health.py                 telemetry summariser (render count, p50/p95 latency, last error)
 bootstrap_pi_inky.sh               first-time Pi setup helper
 litclock.service.example           sample systemd unit
 pi_setup_inky_impression.md        long-form Pi setup doc

--- a/display_inky.py
+++ b/display_inky.py
@@ -16,6 +16,14 @@ from PIL import Image
 MAX_ATTEMPTS = 3
 RETRY_BACKOFF_SECONDS = (1, 4)  # sleeps between attempt 1→2 and 2→3
 
+# Per-theme saturation defaults. The Spectra 6 panel renders dark backgrounds with
+# a different waveform than light ones; pushing saturation slightly higher on the
+# dark theme keeps accent colours from looking muddy.
+THEME_SATURATION: dict[str, float] = {
+    "default": 0.5,
+    "dark": 0.7,
+}
+
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Display a rendered image on Inky Impression.")
@@ -23,10 +31,30 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--saturation",
         type=float,
-        default=0.5,
-        help="Saturation/quantization hint passed to Inky where supported.",
+        default=None,
+        help=(
+            "Saturation/quantization hint passed to Inky where supported. "
+            "Overrides the per-theme default if set."
+        ),
+    )
+    parser.add_argument(
+        "--theme",
+        choices=sorted(THEME_SATURATION),
+        default="default",
+        help="Theme being displayed; selects the default saturation when --saturation is unset.",
     )
     return parser.parse_args()
+
+
+def resolve_saturation(theme: str, override: float | None) -> float:
+    """Return the saturation value to push to the panel.
+
+    Explicit ``--saturation`` overrides the per-theme default. Unknown themes fall
+    back to the ``default`` theme's saturation.
+    """
+    if override is not None:
+        return override
+    return THEME_SATURATION.get(theme, THEME_SATURATION["default"])
 
 
 def _push_to_panel(image_path: Path, saturation: float) -> tuple[int, int]:
@@ -60,10 +88,11 @@ def main() -> int:
             f"Original error: {exc}"
         )
 
+    saturation = resolve_saturation(args.theme, args.saturation)
     last_error: Exception | None = None
     for attempt in range(1, MAX_ATTEMPTS + 1):
         try:
-            width, height = _push_to_panel(image_path, args.saturation)
+            width, height = _push_to_panel(image_path, saturation)
         except Exception as exc:
             last_error = exc
             if attempt < MAX_ATTEMPTS:

--- a/inky_buttons.py
+++ b/inky_buttons.py
@@ -1,0 +1,47 @@
+"""Inky Impression button listener.
+
+The Inky Impression has four capacitive buttons wired to GPIO 5 / 6 / 16 / 24
+(labelled A / B / C / D on the panel). This module attaches a debounced press
+handler to each so ``run_clock.py`` can react to user input without polling.
+
+The hardware import (``gpiozero``) happens inside :func:`start_listener` so this
+module is import-safe on dev machines and the test suite can stub it out.
+"""
+from __future__ import annotations
+
+from typing import Callable, Mapping
+
+BUTTON_GPIO: dict[str, int] = {
+    "A": 5,
+    "B": 6,
+    "C": 16,
+    "D": 24,
+}
+
+DEBOUNCE_SECONDS = 0.3
+
+
+def start_listener(
+    handlers: Mapping[str, Callable[[], None]],
+    *,
+    bounce_time: float = DEBOUNCE_SECONDS,
+) -> list:
+    """Attach ``handlers[label]`` to each Inky button press.
+
+    ``handlers`` keys must be subset of ``BUTTON_GPIO`` (``"A"``/``"B"``/``"C"``/``"D"``);
+    unknown labels raise ``ValueError``. Returns the list of created button objects so
+    the caller can keep them alive for the lifetime of the process — ``gpiozero``
+    drops handlers when the ``Button`` is garbage-collected.
+    """
+    unknown = set(handlers) - set(BUTTON_GPIO)
+    if unknown:
+        raise ValueError(f"Unknown button label(s): {sorted(unknown)}; expected subset of {sorted(BUTTON_GPIO)}")
+
+    from gpiozero import Button  # local import so this module is safe on non-Pi hosts
+
+    buttons = []
+    for label, callback in handlers.items():
+        button = Button(BUTTON_GPIO[label], pull_up=True, bounce_time=bounce_time)
+        button.when_pressed = callback
+        buttons.append(button)
+    return buttons

--- a/litclock_health.py
+++ b/litclock_health.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Summarise the LitClock runtime telemetry log.
+
+``run_clock.py`` writes one JSONL entry per render attempt to
+``~/.litclock/telemetry.jsonl``. This script reads the last N hours and prints
+render counts, error counts, and render-latency percentiles so the appliance can
+be inspected without ``journalctl`` spelunking.
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import sys
+from pathlib import Path
+
+DEFAULT_TELEMETRY_PATH = "~/.litclock/telemetry.jsonl"
+DEFAULT_HOURS = 24
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Summarise LitClock telemetry.")
+    parser.add_argument(
+        "--telemetry-path",
+        default=DEFAULT_TELEMETRY_PATH,
+        help="JSONL log written by run_clock.py (default: ~/.litclock/telemetry.jsonl)",
+    )
+    parser.add_argument(
+        "--hours",
+        type=int,
+        default=DEFAULT_HOURS,
+        help="Window of recent hours to consider (default: 24)",
+    )
+    return parser.parse_args()
+
+
+def _percentile(sorted_values: list[int], p: float) -> int | None:
+    """Linear-interpolation percentile over a sorted list. Returns None when empty."""
+    if not sorted_values:
+        return None
+    if len(sorted_values) == 1:
+        return sorted_values[0]
+    rank = (p / 100) * (len(sorted_values) - 1)
+    lo = int(rank)
+    hi = min(lo + 1, len(sorted_values) - 1)
+    frac = rank - lo
+    return int(sorted_values[lo] + (sorted_values[hi] - sorted_values[lo]) * frac)
+
+
+def load_entries(path: Path, since: dt.datetime) -> list[dict]:
+    """Stream JSONL entries with ts >= since. Malformed lines are skipped."""
+    if not path.exists():
+        return []
+    rows = []
+    with path.open(encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+                ts = dt.datetime.fromisoformat(entry["ts"])
+            except (ValueError, KeyError, json.JSONDecodeError):
+                continue
+            if ts.tzinfo is None:
+                ts = ts.replace(tzinfo=dt.timezone.utc)
+            if ts < since:
+                continue
+            rows.append(entry)
+    return rows
+
+
+def summarise(entries: list[dict]) -> dict:
+    renders = [e for e in entries if "error" not in e]
+    errors = [e for e in entries if "error" in e]
+    render_latencies = sorted(
+        e["render_ms"] for e in renders if isinstance(e.get("render_ms"), int)
+    )
+    display_latencies = sorted(
+        e["display_ms"] for e in renders if isinstance(e.get("display_ms"), int)
+    )
+    return {
+        "render_count": len(renders),
+        "error_count": len(errors),
+        "render_p50_ms": _percentile(render_latencies, 50),
+        "render_p95_ms": _percentile(render_latencies, 95),
+        "display_p50_ms": _percentile(display_latencies, 50),
+        "display_p95_ms": _percentile(display_latencies, 95),
+        "last_error": errors[-1].get("error") if errors else None,
+    }
+
+
+def format_summary(summary: dict, hours: int) -> str:
+    parts = [
+        f"Last {hours}h: {summary['render_count']} renders, {summary['error_count']} errors",
+    ]
+    if summary["render_p50_ms"] is not None:
+        parts.append(
+            f"render latency p50 {summary['render_p50_ms']}ms / p95 {summary['render_p95_ms']}ms"
+        )
+    if summary["display_p50_ms"] is not None:
+        parts.append(
+            f"display latency p50 {summary['display_p50_ms']}ms / p95 {summary['display_p95_ms']}ms"
+        )
+    if summary["last_error"]:
+        parts.append(f"last error: {summary['last_error']}")
+    return "\n".join(parts)
+
+
+def main() -> int:
+    args = parse_args()
+    path = Path(args.telemetry_path).expanduser()
+    since = dt.datetime.now(dt.timezone.utc) - dt.timedelta(hours=args.hours)
+    entries = load_entries(path, since)
+    if not entries and not path.exists():
+        print(f"No telemetry log at {path}", file=sys.stderr)
+        return 1
+    summary = summarise(entries)
+    print(format_summary(summary, args.hours))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = ["pytest", "pytest-cov", "ruff"]
-pi = ["inky"]
+pi = ["inky", "gpiozero"]
 
 [tool.setuptools]
 py-modules = [
@@ -26,7 +26,9 @@ py-modules = [
     "fix_substring_time_matches",
     "gutenberg_time_miner",
     "import_targeted_hits",
+    "inky_buttons",
     "jsonl_io",
+    "litclock_health",
     "merge_candidates",
     "pick_quote",
     "quality_filter",

--- a/render_quote.py
+++ b/render_quote.py
@@ -147,9 +147,13 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--height", type=int, default=DEFAULT_HEIGHT)
     parser.add_argument(
         "--mode",
-        choices=["production", "debug"],
+        choices=["production", "debug", "card"],
         default="debug",
-        help="Render mode. Production hides debug UI, debug shows bucket/quality/time metadata.",
+        help=(
+            "Render mode. 'production' hides debug UI; 'debug' shows bucket/quality/time "
+            "metadata; 'card' draws a centered source card (title/author/Gutenberg ID/"
+            "matched phrase) instead of the full quote — used by the source-card button."
+        ),
     )
     parser.add_argument(
         "--theme",
@@ -410,7 +414,81 @@ def fallback_title(quote_row: dict) -> str | None:
     return None
 
 
+def render_source_card(quote_row: dict, width: int, height: int, theme: str = "default") -> Image.Image:
+    """Render a centered metadata card for the current quote.
+
+    Used by the Inky button-C handler: a viewer presses C, this card is shown for
+    a few seconds, then the loop repaints the original frame. Reuses the theme
+    palette and bundled fonts so it visually matches the quote frame.
+    """
+    colors = THEMES[theme]
+    image = Image.new("RGB", (width, height), color=colors["page_bg"])
+    draw = ImageDraw.Draw(image)
+
+    title_text = (quote_row.get("title") or fallback_title(quote_row) or "Unknown source").strip()
+    author_text = (quote_row.get("author") or "").strip()
+    source_id = quote_row.get("source_id")
+    source_id_text = f"Project Gutenberg #{source_id}" if source_id else ""
+    matched_text = (quote_row.get("matched_text") or "").strip()
+    matched_text = normalize_dashes(strip_underscore_emphasis(matched_text))
+
+    label_font = load_font(META_FONT_CANDIDATES, size=18)
+    title_font = load_font(QUOTE_FONT_BOLD_CANDIDATES, size=44)
+    author_font = load_font(QUOTE_FONT_SEMIBOLD_CANDIDATES, size=28)
+    id_font = load_font(META_FONT_CANDIDATES, size=18)
+    phrase_font = load_font(QUOTE_FONT_BOLD_CANDIDATES, size=28)
+
+    max_text_width = width - 2 * SIDE_MARGIN - 40
+    title_lines = wrap_text(draw, title_text, title_font, max_text_width)[:3]
+    author_lines = wrap_text(draw, f"by {author_text}", author_font, max_text_width)[:1] if author_text else []
+    phrase_lines = wrap_text(draw, f"\u201c{matched_text}\u201d", phrase_font, max_text_width)[:2] if matched_text else []
+
+    label_text = "Now showing"
+    label_bbox = draw.textbbox((0, 0), label_text, font=label_font)
+    label_h = label_bbox[3] - label_bbox[1]
+
+    title_h = sum((draw.textbbox((0, 0), line, font=title_font)[3] - draw.textbbox((0, 0), line, font=title_font)[1]) + 6 for line in title_lines)
+    author_h = sum((draw.textbbox((0, 0), line, font=author_font)[3] - draw.textbbox((0, 0), line, font=author_font)[1]) + 4 for line in author_lines)
+    phrase_h = sum((draw.textbbox((0, 0), line, font=phrase_font)[3] - draw.textbbox((0, 0), line, font=phrase_font)[1]) + 4 for line in phrase_lines)
+    id_bbox = draw.textbbox((0, 0), source_id_text, font=id_font) if source_id_text else (0, 0, 0, 0)
+    id_h = (id_bbox[3] - id_bbox[1]) if source_id_text else 0
+
+    block_h = label_h + 18 + title_h + (12 + author_h if author_lines else 0) + (24 + phrase_h if phrase_lines else 0) + (20 + id_h if source_id_text else 0)
+    y = max(40, (height - block_h) // 2)
+
+    def _draw_centered(text: str, font, fill):
+        nonlocal y
+        bbox = draw.textbbox((0, 0), text, font=font)
+        w = bbox[2] - bbox[0]
+        h = bbox[3] - bbox[1]
+        draw.text(((width - w) // 2, y), text, font=font, fill=fill)
+        y += h
+
+    _draw_centered(label_text, label_font, colors["accent"])
+    y += 18
+    for line in title_lines:
+        _draw_centered(line, title_font, colors["text"])
+        y += 6
+    if author_lines:
+        y += 6
+        for line in author_lines:
+            _draw_centered(line, author_font, colors["text"])
+            y += 4
+    if phrase_lines:
+        y += 18
+        for line in phrase_lines:
+            _draw_centered(line, phrase_font, colors["accent"])
+            y += 4
+    if source_id_text:
+        y += 14
+        _draw_centered(source_id_text, id_font, colors["source"])
+
+    return snap_image_to_palette(image, SPECTRA6_PALETTE)
+
+
 def render(time_str: str, quote_row: dict, width: int, height: int, mode: str = "debug", theme: str = "default") -> Image.Image:
+    if mode == "card":
+        return render_source_card(quote_row, width, height, theme=theme)
     colors = THEMES[theme]
     image = Image.new("RGB", (width, height), color=colors["page_bg"])
     draw = ImageDraw.Draw(image)

--- a/run_clock.py
+++ b/run_clock.py
@@ -464,10 +464,17 @@ def _build_button_handlers(args: argparse.Namespace, state: RuntimeState) -> dic
             _do_render(args, state, time_str, history_path, mode="card", quote_id=quote_id)
 
             def restore() -> None:
-                # Force the next tick to repaint by invalidating the cached identity.
-                with state.lock:
-                    state.last_bucket = None
-                    state.last_quote_id = None
+                # The card needs to come down at the 5-second mark — relying on the
+                # next loop tick would leave it up for up to --interval-seconds (60s
+                # default). Re-pick (the bucket may have moved during the 5s) and
+                # render the normal frame ourselves; render_lock serializes us
+                # against the loop.
+                try:
+                    rs_time = current_time_str()
+                    rs_quote = peek_quote_id(rs_time, history_path=history_path, history_days=args.history_days)
+                    _do_render(args, state, rs_time, history_path, quote_id=rs_quote)
+                except Exception as restore_exc:
+                    _log(f"source card restore failed: {restore_exc!r}", err=True)
 
             threading.Timer(5.0, restore).start()
         except Exception as exc:
@@ -481,11 +488,14 @@ def _build_button_handlers(args: argparse.Namespace, state: RuntimeState) -> dic
                 save_runtime_state(args.state_path, state.snapshot_for_persistence())
                 state.last_bucket = None  # force the loop to repaint on exit
                 state.last_quote_id = None
-            _log(f"button D: manual quiet -> {state.manual_quiet}")
-            if state.manual_quiet and args.quiet_image:
+                # Snapshot inside the lock so a concurrent toggle can't flip the
+                # branch we take below.
+                quiet_now = state.manual_quiet
+            _log(f"button D: manual quiet -> {quiet_now}")
+            if quiet_now and args.quiet_image:
                 with state.render_lock:
                     _display_quiet_image(args.quiet_image, args.output, args.display_script)
-            elif not state.manual_quiet:
+            elif not quiet_now:
                 # Wake to the current time so the user sees something immediately.
                 time_str = current_time_str()
                 quote_id = peek_quote_id(time_str, history_path=history_path, history_days=args.history_days)
@@ -556,7 +566,9 @@ def main() -> int:
 
     persisted = load_runtime_state(args.state_path)
     state = RuntimeState(args.theme, persisted=persisted)
-    _maybe_start_buttons(args, state)
+    # Hold the returned button list as a local for the lifetime of the loop —
+    # gpiozero drops handlers when its Button objects are garbage-collected.
+    _buttons = _maybe_start_buttons(args, state)  # noqa: F841
 
     _was_quiet = False
     while True:

--- a/run_clock.py
+++ b/run_clock.py
@@ -206,15 +206,25 @@ def _resolve_state_path(state_path: str | None) -> Path | None:
 
 
 def load_runtime_state(state_path: str | None) -> dict:
-    """Load persisted runtime state. Returns ``{}`` when disabled or missing."""
+    """Load persisted runtime state. Returns ``{}`` when disabled, missing, or malformed.
+
+    We expect the file to contain a JSON object. Anything else (a bare string,
+    number, list, or parse error) is treated as unreadable and ignored rather
+    than bricking startup with ``AttributeError`` when ``RuntimeState.__init__``
+    later calls ``.get()`` on it.
+    """
     path = _resolve_state_path(state_path)
     if path is None or not path.exists():
         return {}
     try:
-        return json.loads(path.read_text(encoding="utf-8")) or {}
+        parsed = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, ValueError) as exc:
         _log(f"runtime state at {path} unreadable, ignoring: {exc!r}", err=True)
         return {}
+    if not isinstance(parsed, dict):
+        _log(f"runtime state at {path} is not a JSON object ({type(parsed).__name__}), ignoring", err=True)
+        return {}
+    return parsed
 
 
 def save_runtime_state(state_path: str | None, state: dict) -> None:
@@ -227,14 +237,23 @@ def save_runtime_state(state_path: str | None, state: dict) -> None:
 
 
 def append_telemetry(telemetry_path: str | None, entry: dict) -> None:
-    """Append one JSON line to the telemetry log. No-op when disabled."""
+    """Append one JSON line to the telemetry log. No-op when disabled.
+
+    Telemetry is best-effort: an I/O failure here (unwritable path, full disk,
+    path is a directory) must never surface to the caller, since this is called
+    from the loop's error-recovery path — turning telemetry into a fatal
+    failure mode would defeat its purpose.
+    """
     if not telemetry_path:
         return
-    path = Path(telemetry_path).expanduser()
-    path.parent.mkdir(parents=True, exist_ok=True)
-    payload = {"ts": dt.datetime.now(dt.timezone.utc).isoformat(timespec="seconds"), **entry}
-    with path.open("a", encoding="utf-8") as handle:
-        handle.write(json.dumps(payload, ensure_ascii=False) + "\n")
+    try:
+        path = Path(telemetry_path).expanduser()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {"ts": dt.datetime.now(dt.timezone.utc).isoformat(timespec="seconds"), **entry}
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(payload, ensure_ascii=False) + "\n")
+    except (OSError, TypeError, ValueError) as exc:
+        _log(f"telemetry write to {telemetry_path!r} failed, dropping entry: {exc!r}", err=True)
 
 
 class RuntimeState:
@@ -394,11 +413,14 @@ def _do_render(args: argparse.Namespace, state: RuntimeState, time_str: str, his
     """Render-and-push, holding the render lock so the main loop and button handlers don't collide.
 
     Updates ``state.last_bucket``/``last_quote_id``/``last_effective_theme`` to the values
-    actually rendered so the loop's next tick sees consistent state.
+    actually rendered so the loop's next tick sees consistent state. The bucket is
+    derived from ``time_str`` rather than from a fresh wall-clock read so a handler
+    firing near a bucket boundary can't stamp the wrong bucket into state (which
+    would make the next loop tick wrongly skip the expected redraw).
     """
     effective_theme = resolve_effective_theme(state.theme_arg, time_str, state.manual_theme)
     actual_mode = mode or args.mode
-    actual_bucket = bucket or current_bucket()
+    actual_bucket = bucket or bucket_for_time(time_str)
     with state.render_lock:
         render_now(
             args.render_script, args.output, args.width, args.height, args.display_script,

--- a/run_clock.py
+++ b/run_clock.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import argparse
 import datetime as dt
+import json
 import shutil
 import subprocess
 import sys
+import threading
 import time
 import traceback
 from pathlib import Path
@@ -15,6 +17,15 @@ import pick_quote as pick_quote_module
 from buckets import bucket_for_time
 
 BASE_DIR = Path(__file__).resolve().parent
+
+DEFAULT_STATE_PATH = "~/.litclock/state.json"
+DEFAULT_TELEMETRY_PATH = "~/.litclock/telemetry.jsonl"
+
+# Auto-theme: switch to dark theme during this window, default theme otherwise.
+# Boundaries chosen to match civil twilight in temperate latitudes; users who want
+# a tighter fit can pass --theme default or --theme dark explicitly.
+AUTO_DARK_START_HOUR = 18
+AUTO_DARK_END_HOUR = 6
 
 
 def _log(msg: str, *, err: bool = False) -> None:
@@ -81,9 +92,35 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--theme",
-        choices=["default", "dark"],
+        choices=["default", "dark", "auto"],
         default="default",
-        help="Render theme passed through to render_quote.py",
+        help=(
+            "Render theme passed through to render_quote.py. "
+            "'auto' selects 'dark' between 18:00 and 06:00 and 'default' otherwise. "
+            "Pressing button B toggles theme manually and overrides 'auto' until midnight."
+        ),
+    )
+    parser.add_argument(
+        "--buttons-off",
+        action="store_true",
+        help="Skip the Inky button listener. Use on dev machines or for headless runs.",
+    )
+    parser.add_argument(
+        "--state-path",
+        default=DEFAULT_STATE_PATH,
+        help=(
+            "Path to the persistent runtime state JSON (manual theme override, "
+            "manual quiet override). Pass an empty string to disable persistence."
+        ),
+    )
+    parser.add_argument(
+        "--telemetry-path",
+        default=DEFAULT_TELEMETRY_PATH,
+        help=(
+            "Path to the JSONL telemetry log. Each successful render appends one line "
+            "with bucket, render_ms, display_ms, source_id, line_number. Loop-level "
+            "errors append an entry with an 'error' field. Pass an empty string to disable."
+        ),
     )
     parser.add_argument(
         "--quiet-start",
@@ -138,6 +175,94 @@ def current_time_str() -> str:
 
 def current_bucket() -> str:
     return bucket_for_time(current_time_str())
+
+
+def auto_theme_for(time_str: str) -> str:
+    """Return 'dark' during the night window, 'default' otherwise."""
+    hour = int(time_str.split(":", 1)[0])
+    if AUTO_DARK_START_HOUR <= hour or hour < AUTO_DARK_END_HOUR:
+        return "dark"
+    return "default"
+
+
+def resolve_effective_theme(theme_arg: str, time_str: str, manual_theme: str | None) -> str:
+    """Resolve the theme actually passed to renderer/display.
+
+    ``theme_arg`` is the CLI choice ('default'/'dark'/'auto'). ``manual_theme`` is the
+    user's button-B override (set until midnight). When ``theme_arg == 'auto'`` and
+    no manual override is active, derive from the wall clock.
+    """
+    if manual_theme in ("default", "dark"):
+        return manual_theme
+    if theme_arg == "auto":
+        return auto_theme_for(time_str)
+    return theme_arg
+
+
+def _resolve_state_path(state_path: str | None) -> Path | None:
+    if not state_path:
+        return None
+    return Path(state_path).expanduser()
+
+
+def load_runtime_state(state_path: str | None) -> dict:
+    """Load persisted runtime state. Returns ``{}`` when disabled or missing."""
+    path = _resolve_state_path(state_path)
+    if path is None or not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text(encoding="utf-8")) or {}
+    except (OSError, ValueError) as exc:
+        _log(f"runtime state at {path} unreadable, ignoring: {exc!r}", err=True)
+        return {}
+
+
+def save_runtime_state(state_path: str | None, state: dict) -> None:
+    """Persist runtime state. No-op when disabled."""
+    path = _resolve_state_path(state_path)
+    if path is None:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(state, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def append_telemetry(telemetry_path: str | None, entry: dict) -> None:
+    """Append one JSON line to the telemetry log. No-op when disabled."""
+    if not telemetry_path:
+        return
+    path = Path(telemetry_path).expanduser()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {"ts": dt.datetime.now(dt.timezone.utc).isoformat(timespec="seconds"), **entry}
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(payload, ensure_ascii=False) + "\n")
+
+
+class RuntimeState:
+    """Mutable shared state between the main loop and the button listener thread.
+
+    Button handlers act synchronously in their own thread and serialize against
+    the main loop via :attr:`render_lock`. Per-button mutations of theme/quiet
+    state are guarded by :attr:`lock`.
+    """
+
+    def __init__(self, theme_arg: str, persisted: dict | None = None):
+        self.lock = threading.Lock()
+        self.render_lock = threading.Lock()
+        self.theme_arg = theme_arg            # CLI value ('default'/'dark'/'auto')
+        self.manual_theme: str | None = None  # set by button B until midnight
+        self.manual_quiet = False             # toggled by button D
+        self.last_bucket: str | None = None
+        self.last_quote_id: tuple | None = None
+        self.last_effective_theme: str | None = None
+        self.last_seen_date: dt.date | None = None
+        if persisted:
+            mt = persisted.get("manual_theme")
+            if mt in ("default", "dark"):
+                self.manual_theme = mt
+            self.manual_quiet = bool(persisted.get("manual_quiet", False))
+
+    def snapshot_for_persistence(self) -> dict:
+        return {"manual_theme": self.manual_theme, "manual_quiet": self.manual_quiet}
 
 
 def in_quiet_hours(time_str: str, start: str | None, end: str | None) -> bool:
@@ -208,12 +333,16 @@ def render_now(
     time_str: str | None = None,
     history_path: str | None = None,
     history_days: int = pick_quote_module.DEFAULT_HISTORY_DAYS,
+    telemetry_path: str | None = None,
+    bucket: str | None = None,
+    quote_id: tuple | None = None,
 ) -> None:
     if time_str is None:
         time_str = current_time_str()
     python_executable = sys.executable
     render_script_path = str((BASE_DIR / render_script).resolve()) if not Path(render_script).is_absolute() else render_script
     output_path_resolved = str((BASE_DIR / output_path).resolve()) if not Path(output_path).is_absolute() else output_path
+    render_start = time.monotonic()
     subprocess.check_call(
         [
             python_executable,
@@ -236,11 +365,167 @@ def render_now(
             str(history_days),
         ]
     )
-    _log(f"Rendered {time_str} -> {output_path_resolved}")
+    render_ms = int((time.monotonic() - render_start) * 1000)
+    _log(f"Rendered {time_str} -> {output_path_resolved} ({render_ms} ms)")
+    display_ms: int | None = None
     if display_script:
         display_script_path = str((BASE_DIR / display_script).resolve()) if not Path(display_script).is_absolute() else display_script
-        subprocess.check_call([python_executable, display_script_path, output_path_resolved])
-        _log(f"Displayed {output_path_resolved} via {display_script_path}")
+        display_start = time.monotonic()
+        subprocess.check_call([python_executable, display_script_path, output_path_resolved, "--theme", theme])
+        display_ms = int((time.monotonic() - display_start) * 1000)
+        _log(f"Displayed {output_path_resolved} via {display_script_path} ({display_ms} ms)")
+    if telemetry_path:
+        append_telemetry(
+            telemetry_path,
+            {
+                "bucket": bucket,
+                "render_ms": render_ms,
+                "display_ms": display_ms,
+                "source_id": quote_id[0] if quote_id else None,
+                "line_number": quote_id[1] if quote_id else None,
+                "mode": mode,
+                "theme": theme,
+            },
+        )
+
+
+def _do_render(args: argparse.Namespace, state: RuntimeState, time_str: str, history_path: str | None,
+               mode: str | None = None, bucket: str | None = None, quote_id: tuple | None = None) -> None:
+    """Render-and-push, holding the render lock so the main loop and button handlers don't collide.
+
+    Updates ``state.last_bucket``/``last_quote_id``/``last_effective_theme`` to the values
+    actually rendered so the loop's next tick sees consistent state.
+    """
+    effective_theme = resolve_effective_theme(state.theme_arg, time_str, state.manual_theme)
+    actual_mode = mode or args.mode
+    actual_bucket = bucket or current_bucket()
+    with state.render_lock:
+        render_now(
+            args.render_script, args.output, args.width, args.height, args.display_script,
+            actual_mode, effective_theme, time_str=time_str,
+            history_path=history_path, history_days=args.history_days,
+            telemetry_path=args.telemetry_path or None, bucket=actual_bucket, quote_id=quote_id,
+        )
+        with state.lock:
+            state.last_bucket = actual_bucket
+            state.last_effective_theme = effective_theme
+            if quote_id is not None:
+                state.last_quote_id = quote_id
+
+
+def _build_button_handlers(args: argparse.Namespace, state: RuntimeState) -> dict:
+    """Return the {label: callable} dispatch map handed to the button listener.
+
+    Each handler does its work synchronously in the listener thread and serializes
+    against the loop via ``state.render_lock``. Mutations of theme/quiet state are
+    persisted to ``--state-path`` so they survive a process restart.
+    """
+    history_path = args.history_path or None
+    telemetry_path = args.telemetry_path or None
+
+    def on_skip() -> None:
+        _log("button A: skip")
+        try:
+            with state.lock:
+                previous = state.last_quote_id
+            if previous is not None:
+                # Ban the currently-shown quote so the next pick filters it out for the week.
+                pick_quote_module.append_history(history_path, previous[0], previous[1])
+            time_str = current_time_str()
+            quote_id = peek_quote_id(time_str, history_path=history_path, history_days=args.history_days)
+            _do_render(args, state, time_str, history_path, quote_id=quote_id)
+            if quote_id is not None:
+                pick_quote_module.append_history(history_path, quote_id[0], quote_id[1])
+        except Exception as exc:
+            _log(f"skip failed: {exc!r}", err=True)
+            append_telemetry(telemetry_path, {"bucket": current_bucket(), "error": repr(exc), "mode": "skip"})
+
+    def on_toggle_theme() -> None:
+        try:
+            time_str = current_time_str()
+            with state.lock:
+                current = state.last_effective_theme or resolve_effective_theme(
+                    state.theme_arg, time_str, state.manual_theme,
+                )
+                state.manual_theme = "dark" if current == "default" else "default"
+                save_runtime_state(args.state_path, state.snapshot_for_persistence())
+                quote_id = state.last_quote_id
+            _log(f"button B: theme -> {state.manual_theme}")
+            _do_render(args, state, time_str, history_path, quote_id=quote_id)
+        except Exception as exc:
+            _log(f"theme toggle failed: {exc!r}", err=True)
+            append_telemetry(telemetry_path, {"bucket": current_bucket(), "error": repr(exc), "mode": "theme"})
+
+    def on_source_card() -> None:
+        _log("button C: source card")
+        try:
+            time_str = current_time_str()
+            quote_id = peek_quote_id(time_str, history_path=history_path, history_days=args.history_days)
+            _do_render(args, state, time_str, history_path, mode="card", quote_id=quote_id)
+
+            def restore() -> None:
+                # Force the next tick to repaint by invalidating the cached identity.
+                with state.lock:
+                    state.last_bucket = None
+                    state.last_quote_id = None
+
+            threading.Timer(5.0, restore).start()
+        except Exception as exc:
+            _log(f"source card failed: {exc!r}", err=True)
+            append_telemetry(telemetry_path, {"bucket": current_bucket(), "error": repr(exc), "mode": "card"})
+
+    def on_quiet_toggle() -> None:
+        try:
+            with state.lock:
+                state.manual_quiet = not state.manual_quiet
+                save_runtime_state(args.state_path, state.snapshot_for_persistence())
+                state.last_bucket = None  # force the loop to repaint on exit
+                state.last_quote_id = None
+            _log(f"button D: manual quiet -> {state.manual_quiet}")
+            if state.manual_quiet and args.quiet_image:
+                with state.render_lock:
+                    _display_quiet_image(args.quiet_image, args.output, args.display_script)
+            elif not state.manual_quiet:
+                # Wake to the current time so the user sees something immediately.
+                time_str = current_time_str()
+                quote_id = peek_quote_id(time_str, history_path=history_path, history_days=args.history_days)
+                _do_render(args, state, time_str, history_path, quote_id=quote_id)
+        except Exception as exc:
+            _log(f"quiet toggle failed: {exc!r}", err=True)
+            append_telemetry(telemetry_path, {"bucket": current_bucket(), "error": repr(exc), "mode": "quiet"})
+
+    return {
+        "A": on_skip,
+        "B": on_toggle_theme,
+        "C": on_source_card,
+        "D": on_quiet_toggle,
+    }
+
+
+def _maybe_start_buttons(args: argparse.Namespace, state: RuntimeState):
+    """Start the Inky button listener if available; swallow gpiozero import errors."""
+    if args.buttons_off:
+        return None
+    try:
+        import inky_buttons
+        return inky_buttons.start_listener(_build_button_handlers(args, state))
+    except Exception as exc:
+        _log(f"button listener disabled ({exc!r}); pass --buttons-off to silence", err=True)
+        return None
+
+
+def _maybe_reset_manual_theme_at_midnight(args: argparse.Namespace, state: RuntimeState) -> None:
+    """Clear the manual theme override at the day boundary so 'auto' resumes."""
+    today = dt.date.today()
+    with state.lock:
+        if state.last_seen_date is None:
+            state.last_seen_date = today
+            return
+        if today != state.last_seen_date and state.theme_arg == "auto" and state.manual_theme is not None:
+            _log(f"midnight rollover: clearing manual theme override ({state.manual_theme})")
+            state.manual_theme = None
+            save_runtime_state(args.state_path, state.snapshot_for_persistence())
+        state.last_seen_date = today
 
 
 def main() -> int:
@@ -251,57 +536,99 @@ def main() -> int:
     output_target.expanduser().parent.mkdir(parents=True, exist_ok=True)
 
     history_path = args.history_path or None
+    telemetry_path = args.telemetry_path or None
 
     if args.once:
         time_str = current_time_str()
+        effective_theme = resolve_effective_theme(args.theme, time_str, manual_theme=None)
         # Peek before rendering so the ledger entry matches what render_quote picks.
         # Both see the same ledger state because run_clock appends only after render succeeds.
         quote_id = peek_quote_id(time_str, history_path=history_path, history_days=args.history_days)
-        render_now(args.render_script, args.output, args.width, args.height, args.display_script, args.mode, args.theme, time_str=time_str, history_path=history_path, history_days=args.history_days)
+        render_now(
+            args.render_script, args.output, args.width, args.height, args.display_script,
+            args.mode, effective_theme, time_str=time_str,
+            history_path=history_path, history_days=args.history_days,
+            telemetry_path=telemetry_path, bucket=current_bucket(), quote_id=quote_id,
+        )
         if quote_id is not None:
             pick_quote_module.append_history(history_path, quote_id[0], quote_id[1])
         return 0
 
-    last_bucket = None
-    last_quote_id = None
+    persisted = load_runtime_state(args.state_path)
+    state = RuntimeState(args.theme, persisted=persisted)
+    _maybe_start_buttons(args, state)
+
     _was_quiet = False
     while True:
         time_str = current_time_str()
-        now_quiet = in_quiet_hours(time_str, None if args.quiet_off else args.quiet_start, args.quiet_end)
+        _maybe_reset_manual_theme_at_midnight(args, state)
+
+        with state.lock:
+            manual_quiet = state.manual_quiet
+
+        scheduled_quiet = in_quiet_hours(time_str, None if args.quiet_off else args.quiet_start, args.quiet_end)
+        now_quiet = scheduled_quiet or manual_quiet
 
         if now_quiet:
             if not _was_quiet:
-                _log(f"quiet hours start ({args.quiet_start}–{args.quiet_end})")
+                trigger = "manual" if manual_quiet and not scheduled_quiet else f"{args.quiet_start}–{args.quiet_end}"
+                _log(f"quiet hours start ({trigger})")
+                # Use bucket_for_time(time_str) here rather than current_bucket() so we
+                # don't double-tap the wall clock in tests that only patch current_time_str.
+                quiet_bucket = bucket_for_time(time_str)
                 try:
                     if args.quiet_image:
-                        _display_quiet_image(args.quiet_image, args.output, args.display_script)
+                        with state.render_lock:
+                            _display_quiet_image(args.quiet_image, args.output, args.display_script)
                     else:
-                        render_now(args.render_script, args.output, args.width, args.height, args.display_script, args.mode, args.theme, time_str=args.quiet_start, history_path=history_path, history_days=args.history_days)
+                        effective_theme = resolve_effective_theme(state.theme_arg, time_str, state.manual_theme)
+                        with state.render_lock:
+                            render_now(
+                                args.render_script, args.output, args.width, args.height, args.display_script,
+                                args.mode, effective_theme, time_str=args.quiet_start,
+                                history_path=history_path, history_days=args.history_days,
+                                telemetry_path=telemetry_path, bucket=quiet_bucket, quote_id=None,
+                            )
                 except Exception as exc:
                     _log(f"quiet-hours display failed: {exc!r}", err=True)
                     traceback.print_exc(file=sys.stderr)
+                    append_telemetry(telemetry_path, {"bucket": quiet_bucket, "error": repr(exc), "mode": "quiet"})
                 _was_quiet = True
             time.sleep(max(1, args.interval_seconds))
             continue
 
         if _was_quiet:
             _log("quiet hours end, resuming normal render cycle")
-            last_bucket = None
-            last_quote_id = None
+            with state.lock:
+                state.last_bucket = None
+                state.last_quote_id = None
             _was_quiet = False
 
         bucket = current_bucket()
-        if bucket != last_bucket:
+        effective_theme = resolve_effective_theme(state.theme_arg, time_str, state.manual_theme)
+        bucket_changed = bucket != state.last_bucket
+        theme_changed = effective_theme != state.last_effective_theme and state.last_effective_theme is not None
+        if bucket_changed or theme_changed:
             try:
                 quote_id = peek_quote_id(time_str, history_path=history_path, history_days=args.history_days)
-                if quote_id is not None and quote_id == last_quote_id:
+                if quote_id is not None and quote_id == state.last_quote_id and not theme_changed:
                     _log(f"bucket {bucket}: quote unchanged, skipping redraw")
-                    last_bucket = bucket
+                    with state.lock:
+                        state.last_bucket = bucket
                 else:
-                    render_now(args.render_script, args.output, args.width, args.height, args.display_script, args.mode, args.theme, time_str=time_str, history_path=history_path, history_days=args.history_days)
-                    last_bucket = bucket
+                    with state.render_lock:
+                        render_now(
+                            args.render_script, args.output, args.width, args.height, args.display_script,
+                            args.mode, effective_theme, time_str=time_str,
+                            history_path=history_path, history_days=args.history_days,
+                            telemetry_path=telemetry_path, bucket=bucket, quote_id=quote_id,
+                        )
+                    with state.lock:
+                        state.last_bucket = bucket
+                        state.last_effective_theme = effective_theme
+                        if quote_id is not None:
+                            state.last_quote_id = quote_id
                     if quote_id is not None:
-                        last_quote_id = quote_id
                         pick_quote_module.append_history(history_path, quote_id[0], quote_id[1])
             except Exception as exc:
                 # Keep the loop alive so a transient failure (pick_quote crash, Inky I/O,
@@ -309,6 +636,10 @@ def main() -> int:
                 # stale so the next tick retries.
                 _log(f"render/display failed for bucket {bucket}: {exc!r}", err=True)
                 traceback.print_exc(file=sys.stderr)
+                append_telemetry(telemetry_path, {"bucket": bucket, "error": repr(exc), "mode": args.mode})
+        elif state.last_effective_theme is None:
+            with state.lock:
+                state.last_effective_theme = effective_theme
         time.sleep(max(1, args.interval_seconds))
 
 

--- a/tests/test_display_inky.py
+++ b/tests/test_display_inky.py
@@ -76,3 +76,46 @@ class TestRetry:
                 display_inky.main()
         assert push.call_count == 0
         assert "not found" in str(exc_info.value)
+
+
+class TestThemeSaturation:
+    def test_default_theme_uses_default_saturation(self):
+        assert display_inky.resolve_saturation("default", None) == display_inky.THEME_SATURATION["default"]
+
+    def test_dark_theme_uses_higher_saturation(self):
+        assert display_inky.resolve_saturation("dark", None) == display_inky.THEME_SATURATION["dark"]
+        assert display_inky.THEME_SATURATION["dark"] > display_inky.THEME_SATURATION["default"]
+
+    def test_explicit_override_wins_over_theme(self):
+        assert display_inky.resolve_saturation("dark", 0.25) == 0.25
+
+    def test_unknown_theme_falls_back_to_default(self):
+        assert display_inky.resolve_saturation("nope", None) == display_inky.THEME_SATURATION["default"]
+
+    def test_main_passes_theme_saturation_to_panel(self, fake_image):
+        captured: list[float] = []
+
+        def capture(image_path, saturation):
+            captured.append(saturation)
+            return (800, 480)
+
+        argv = ["display_inky.py", str(fake_image), "--theme", "dark"]
+        with patch("display_inky._push_to_panel", side_effect=capture), \
+             patch("sys.argv", argv), \
+             patch("time.sleep"):
+            display_inky.main()
+        assert captured == [display_inky.THEME_SATURATION["dark"]]
+
+    def test_explicit_saturation_overrides_theme(self, fake_image):
+        captured: list[float] = []
+
+        def capture(image_path, saturation):
+            captured.append(saturation)
+            return (800, 480)
+
+        argv = ["display_inky.py", str(fake_image), "--theme", "dark", "--saturation", "0.1"]
+        with patch("display_inky._push_to_panel", side_effect=capture), \
+             patch("sys.argv", argv), \
+             patch("time.sleep"):
+            display_inky.main()
+        assert captured == [0.1]

--- a/tests/test_inky_buttons.py
+++ b/tests/test_inky_buttons.py
@@ -1,0 +1,72 @@
+"""Tests for the Inky button listener.
+
+The hardware (``gpiozero``) is not present in CI, so these tests stub the
+``gpiozero.Button`` import and verify that ``start_listener`` wires each label
+to the correct GPIO pin and dispatches the registered callback when ``Button``
+fires its ``when_pressed`` event.
+"""
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+import inky_buttons
+
+
+class FakeButton:
+    """Minimal stand-in for ``gpiozero.Button`` capturing constructor args."""
+
+    instances: list["FakeButton"] = []
+
+    def __init__(self, pin, *, pull_up=True, bounce_time=None):
+        self.pin = pin
+        self.pull_up = pull_up
+        self.bounce_time = bounce_time
+        self.when_pressed = None
+        FakeButton.instances.append(self)
+
+
+@pytest.fixture(autouse=True)
+def stub_gpiozero(monkeypatch):
+    FakeButton.instances = []
+    fake_module = types.ModuleType("gpiozero")
+    fake_module.Button = FakeButton
+    monkeypatch.setitem(sys.modules, "gpiozero", fake_module)
+
+
+class TestStartListener:
+    def test_attaches_handler_to_each_label(self):
+        called: list[str] = []
+        handlers = {label: (lambda label=label: called.append(label)) for label in ("A", "B", "C", "D")}
+        buttons = inky_buttons.start_listener(handlers)
+        assert len(buttons) == 4
+        # Wire-up: each button should be on its declared GPIO pin.
+        pins = {b.pin for b in buttons}
+        assert pins == set(inky_buttons.BUTTON_GPIO.values())
+
+        # Simulate each press and verify dispatch.
+        for button in buttons:
+            button.when_pressed()
+        assert sorted(called) == ["A", "B", "C", "D"]
+
+    def test_partial_handler_set_only_wires_those_pins(self):
+        called: list[str] = []
+        handlers = {"A": lambda: called.append("A"), "C": lambda: called.append("C")}
+        buttons = inky_buttons.start_listener(handlers)
+        assert len(buttons) == 2
+        assert {b.pin for b in buttons} == {inky_buttons.BUTTON_GPIO["A"], inky_buttons.BUTTON_GPIO["C"]}
+
+    def test_unknown_label_raises(self):
+        with pytest.raises(ValueError) as exc_info:
+            inky_buttons.start_listener({"E": lambda: None})
+        assert "Unknown button" in str(exc_info.value)
+
+    def test_debounce_default_passed_through(self):
+        inky_buttons.start_listener({"A": lambda: None})
+        assert FakeButton.instances[0].bounce_time == inky_buttons.DEBOUNCE_SECONDS
+
+    def test_debounce_override(self):
+        inky_buttons.start_listener({"A": lambda: None}, bounce_time=1.5)
+        assert FakeButton.instances[0].bounce_time == 1.5

--- a/tests/test_litclock_health.py
+++ b/tests/test_litclock_health.py
@@ -1,0 +1,114 @@
+"""Tests for the litclock_health telemetry summariser."""
+from __future__ import annotations
+
+import datetime as dt
+import json
+from unittest.mock import patch
+
+import litclock_health
+
+
+def _ledger(tmp_path, lines: list[dict]):
+    path = tmp_path / "telemetry.jsonl"
+    with path.open("w", encoding="utf-8") as handle:
+        for entry in lines:
+            handle.write(json.dumps(entry) + "\n")
+    return path
+
+
+def _ts(minutes_ago: int) -> str:
+    moment = dt.datetime.now(dt.timezone.utc) - dt.timedelta(minutes=minutes_ago)
+    return moment.isoformat(timespec="seconds")
+
+
+class TestPercentile:
+    def test_empty_returns_none(self):
+        assert litclock_health._percentile([], 50) is None
+
+    def test_single_value(self):
+        assert litclock_health._percentile([42], 50) == 42
+
+    def test_p50_of_three(self):
+        assert litclock_health._percentile([10, 20, 30], 50) == 20
+
+    def test_p95_clamps_to_max_index(self):
+        # With 11 values 0..100, p95 lands between values[9]=90 and values[10]=100.
+        values = list(range(0, 110, 10))
+        assert litclock_health._percentile(values, 95) == 95
+
+
+class TestLoadEntries:
+    def test_missing_path_returns_empty(self, tmp_path):
+        assert litclock_health.load_entries(tmp_path / "missing.jsonl", dt.datetime.now(dt.timezone.utc)) == []
+
+    def test_skips_malformed_lines(self, tmp_path):
+        path = tmp_path / "log.jsonl"
+        path.write_text(
+            "not-json\n"
+            f'{{"ts": "{_ts(5)}", "render_ms": 100}}\n'
+            '{"ts": "garbage"}\n'
+            f'{{"ts": "{_ts(10)}", "render_ms": 50}}\n',
+            encoding="utf-8",
+        )
+        since = dt.datetime.now(dt.timezone.utc) - dt.timedelta(hours=1)
+        assert len(litclock_health.load_entries(path, since)) == 2
+
+    def test_filters_by_timestamp(self, tmp_path):
+        path = _ledger(tmp_path, [
+            {"ts": _ts(120), "render_ms": 100},   # 2h ago, before window
+            {"ts": _ts(30), "render_ms": 200},    # within window
+        ])
+        since = dt.datetime.now(dt.timezone.utc) - dt.timedelta(hours=1)
+        rows = litclock_health.load_entries(path, since)
+        assert len(rows) == 1
+        assert rows[0]["render_ms"] == 200
+
+
+class TestSummarise:
+    def test_counts_renders_and_errors(self):
+        entries = [
+            {"render_ms": 100, "display_ms": 50},
+            {"render_ms": 200, "display_ms": 100},
+            {"error": "boom"},
+        ]
+        summary = litclock_health.summarise(entries)
+        assert summary["render_count"] == 2
+        assert summary["error_count"] == 1
+        assert summary["last_error"] == "boom"
+
+    def test_latencies_computed(self):
+        entries = [{"render_ms": v, "display_ms": v // 2} for v in (10, 20, 30, 40, 50)]
+        summary = litclock_health.summarise(entries)
+        assert summary["render_p50_ms"] == 30
+        assert summary["render_p95_ms"] is not None
+        assert summary["display_p50_ms"] == 15
+
+    def test_empty_returns_none_latencies(self):
+        summary = litclock_health.summarise([])
+        assert summary["render_count"] == 0
+        assert summary["render_p50_ms"] is None
+
+
+class TestMain:
+    def test_missing_log_exits_nonzero(self, tmp_path, capsys):
+        argv = ["litclock_health.py", "--telemetry-path", str(tmp_path / "missing.jsonl")]
+        with patch("sys.argv", argv):
+            rc = litclock_health.main()
+        assert rc == 1
+        assert "No telemetry log" in capsys.readouterr().err
+
+    def test_summary_printed(self, tmp_path, capsys):
+        path = _ledger(tmp_path, [
+            {"ts": _ts(5), "render_ms": 100, "display_ms": 50, "bucket": "h2_exact"},
+            {"ts": _ts(10), "render_ms": 150, "display_ms": 70, "bucket": "h2_five_past"},
+            {"ts": _ts(15), "error": "RuntimeError(...)", "bucket": "h2_ten_past"},
+        ])
+        argv = ["litclock_health.py", "--telemetry-path", str(path), "--hours", "1"]
+        with patch("sys.argv", argv):
+            rc = litclock_health.main()
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "2 renders" in out
+        assert "1 errors" in out
+        assert "render latency" in out
+        assert "last error" in out

--- a/tests/test_render_quote.py
+++ b/tests/test_render_quote.py
@@ -337,3 +337,51 @@ class TestRender:
         )
         img = rq.render("08:45", row, 800, 480, mode="debug")
         assert img.size == (800, 480)
+
+
+class TestRenderCard:
+    """The button-C source card uses mode='card' to render a centered metadata frame."""
+
+    def _row(self, **overrides):
+        row = {
+            "display_quote": "It was three o'clock in the afternoon.",
+            "matched_text": "three o'clock",
+            "author": "Jane Austen",
+            "title": "Mansfield Park",
+            "source_id": "141",
+        }
+        row.update(overrides)
+        return row
+
+    def test_card_returns_image_of_correct_size(self):
+        img = rq.render("03:00", self._row(), 800, 480, mode="card")
+        assert img.size == (800, 480)
+
+    def test_card_uses_dark_theme_background(self):
+        img = rq.render("03:00", self._row(), 800, 480, mode="card", theme="dark")
+        assert img.getpixel((0, 0)) == rq.SPECTRA6["black"]
+
+    def test_card_uses_default_theme_background(self):
+        img = rq.render("03:00", self._row(), 800, 480, mode="card", theme="default")
+        assert img.getpixel((0, 0)) == rq.SPECTRA6["white"]
+
+    def test_card_palette_is_spectra6(self):
+        img = rq.render("03:00", self._row(), 800, 480, mode="card")
+        palette = set(rq.SPECTRA6.values())
+        pixels = set(img.convert("RGB").getdata())
+        assert pixels.issubset(palette), f"Unexpected colors: {pixels - palette}"
+
+    def test_card_without_author_or_title_falls_back_gracefully(self):
+        row = self._row(author=None, title=None, source_path="data/gutenberg/pg141.txt")
+        img = rq.render("03:00", row, 800, 480, mode="card")
+        assert img.size == (800, 480)
+
+    def test_card_without_source_id_does_not_crash(self):
+        row = self._row(source_id=None)
+        img = rq.render("03:00", row, 800, 480, mode="card")
+        assert img.size == (800, 480)
+
+    def test_card_strips_underscore_emphasis_from_matched_text(self):
+        row = self._row(matched_text="_three o'clock_")
+        img = rq.render("03:00", row, 800, 480, mode="card")
+        assert img.size == (800, 480)

--- a/tests/test_run_clock.py
+++ b/tests/test_run_clock.py
@@ -2,6 +2,8 @@
 from __future__ import annotations
 
 import argparse
+import datetime as dt
+import json
 import subprocess
 from unittest.mock import patch
 
@@ -716,3 +718,469 @@ class TestDisplayQuietImage:
         mock_render.assert_not_called()
         assert len(display_calls) == 1
         assert display_calls[0][0] == str(src)
+
+
+class TestAutoTheme:
+    def test_auto_theme_morning_is_default(self):
+        assert run_clock.auto_theme_for("09:00") == "default"
+
+    def test_auto_theme_afternoon_is_default(self):
+        assert run_clock.auto_theme_for("15:30") == "default"
+
+    def test_auto_theme_evening_is_dark(self):
+        assert run_clock.auto_theme_for("19:00") == "dark"
+
+    def test_auto_theme_late_night_is_dark(self):
+        assert run_clock.auto_theme_for("23:30") == "dark"
+
+    def test_auto_theme_pre_dawn_is_dark(self):
+        assert run_clock.auto_theme_for("04:00") == "dark"
+
+    def test_auto_theme_boundary_dusk_is_dark(self):
+        assert run_clock.auto_theme_for("18:00") == "dark"
+
+    def test_auto_theme_boundary_dawn_is_default(self):
+        assert run_clock.auto_theme_for("06:00") == "default"
+
+
+class TestResolveEffectiveTheme:
+    def test_explicit_default_is_returned(self):
+        assert run_clock.resolve_effective_theme("default", "20:00", None) == "default"
+
+    def test_explicit_dark_is_returned(self):
+        assert run_clock.resolve_effective_theme("dark", "10:00", None) == "dark"
+
+    def test_auto_resolves_via_clock(self):
+        assert run_clock.resolve_effective_theme("auto", "21:00", None) == "dark"
+        assert run_clock.resolve_effective_theme("auto", "10:00", None) == "default"
+
+    def test_manual_override_wins_over_auto(self):
+        assert run_clock.resolve_effective_theme("auto", "21:00", "default") == "default"
+        assert run_clock.resolve_effective_theme("auto", "10:00", "dark") == "dark"
+
+    def test_manual_override_wins_over_explicit(self):
+        # If the user pressed B while running with --theme dark, the manual override wins.
+        assert run_clock.resolve_effective_theme("dark", "10:00", "default") == "default"
+
+    def test_invalid_manual_override_ignored(self):
+        assert run_clock.resolve_effective_theme("auto", "21:00", "garbage") == "dark"
+
+
+class TestRuntimeStatePersistence:
+    def test_load_missing_returns_empty(self, tmp_path):
+        assert run_clock.load_runtime_state(str(tmp_path / "missing.json")) == {}
+
+    def test_load_empty_path_returns_empty(self):
+        assert run_clock.load_runtime_state("") == {}
+        assert run_clock.load_runtime_state(None) == {}
+
+    def test_save_then_load_roundtrip(self, tmp_path):
+        path = tmp_path / "state.json"
+        run_clock.save_runtime_state(str(path), {"manual_theme": "dark", "manual_quiet": True})
+        loaded = run_clock.load_runtime_state(str(path))
+        assert loaded == {"manual_theme": "dark", "manual_quiet": True}
+
+    def test_save_creates_parent_directory(self, tmp_path):
+        path = tmp_path / "nested" / "dir" / "state.json"
+        run_clock.save_runtime_state(str(path), {"manual_theme": "dark"})
+        assert path.exists()
+
+    def test_load_corrupt_file_returns_empty(self, tmp_path, capsys):
+        path = tmp_path / "state.json"
+        path.write_text("not-json", encoding="utf-8")
+        assert run_clock.load_runtime_state(str(path)) == {}
+        assert "unreadable" in capsys.readouterr().err
+
+    def test_runtime_state_seeds_from_persisted(self):
+        s = run_clock.RuntimeState("auto", persisted={"manual_theme": "dark", "manual_quiet": True})
+        assert s.manual_theme == "dark"
+        assert s.manual_quiet is True
+
+    def test_runtime_state_ignores_invalid_persisted_theme(self):
+        s = run_clock.RuntimeState("auto", persisted={"manual_theme": "neon", "manual_quiet": False})
+        assert s.manual_theme is None
+
+    def test_snapshot_for_persistence_round_trips(self):
+        s = run_clock.RuntimeState("auto", persisted={"manual_theme": "dark", "manual_quiet": True})
+        assert s.snapshot_for_persistence() == {"manual_theme": "dark", "manual_quiet": True}
+
+
+class TestAppendTelemetry:
+    def test_disabled_path_is_noop(self, tmp_path):
+        run_clock.append_telemetry("", {"bucket": "h3_exact"})
+        run_clock.append_telemetry(None, {"bucket": "h3_exact"})
+        # No file written.
+        assert list(tmp_path.iterdir()) == []
+
+    def test_appends_one_line_with_ts(self, tmp_path):
+        path = tmp_path / "telemetry.jsonl"
+        run_clock.append_telemetry(str(path), {"bucket": "h3_exact", "render_ms": 500})
+        lines = path.read_text(encoding="utf-8").strip().splitlines()
+        assert len(lines) == 1
+        entry = json.loads(lines[0])
+        assert entry["bucket"] == "h3_exact"
+        assert entry["render_ms"] == 500
+        assert "ts" in entry
+
+    def test_appends_multiple_lines(self, tmp_path):
+        path = tmp_path / "telemetry.jsonl"
+        run_clock.append_telemetry(str(path), {"bucket": "a"})
+        run_clock.append_telemetry(str(path), {"bucket": "b"})
+        lines = path.read_text(encoding="utf-8").strip().splitlines()
+        assert len(lines) == 2
+
+    def test_creates_parent_directory(self, tmp_path):
+        path = tmp_path / "nested" / "telemetry.jsonl"
+        run_clock.append_telemetry(str(path), {"bucket": "h1_exact"})
+        assert path.exists()
+
+
+class TestRenderNowTelemetry:
+    def test_writes_telemetry_after_successful_render(self, tmp_path):
+        telemetry = tmp_path / "telemetry.jsonl"
+        with patch("subprocess.check_call"), \
+             patch("run_clock.current_time_str", return_value="14:30"):
+            run_clock.render_now(
+                render_script="render_quote.py",
+                output_path=str(tmp_path / "current.png"),
+                width=800,
+                height=480,
+                mode="production",
+                theme="dark",
+                telemetry_path=str(telemetry),
+                bucket="h2_half_past",
+                quote_id=("141", 482, "q", "mt"),
+            )
+        entry = json.loads(telemetry.read_text(encoding="utf-8").strip())
+        assert entry["bucket"] == "h2_half_past"
+        assert entry["mode"] == "production"
+        assert entry["theme"] == "dark"
+        assert entry["source_id"] == "141"
+        assert entry["line_number"] == 482
+        assert "render_ms" in entry
+
+    def test_no_telemetry_when_disabled(self, tmp_path):
+        with patch("subprocess.check_call"), \
+             patch("run_clock.current_time_str", return_value="14:30"):
+            run_clock.render_now(
+                render_script="render_quote.py",
+                output_path=str(tmp_path / "current.png"),
+                width=800,
+                height=480,
+                telemetry_path=None,
+            )
+        # No file created in tmp_path other than whatever subprocess wrote (we mocked it to nothing).
+        files = [p.name for p in tmp_path.iterdir()]
+        assert "telemetry.jsonl" not in files
+
+    def test_display_script_passes_theme(self, tmp_path):
+        calls = []
+        with patch("subprocess.check_call", side_effect=lambda cmd: calls.append(cmd)), \
+             patch("run_clock.current_time_str", return_value="10:00"):
+            run_clock.render_now(
+                render_script="render_quote.py",
+                output_path=str(tmp_path / "current.png"),
+                width=800,
+                height=480,
+                display_script="display_inky.py",
+                theme="dark",
+            )
+        # Second subprocess call is the display push; --theme dark must be in its argv.
+        assert len(calls) == 2
+        assert "--theme" in calls[1]
+        idx = calls[1].index("--theme")
+        assert calls[1][idx + 1] == "dark"
+
+
+class TestThemePersistenceEndToEnd:
+    """Theme persisted to state.json should be restored on the next process start."""
+
+    def test_persisted_dark_theme_overrides_default_arg(self, tmp_path):
+        state_path = tmp_path / "state.json"
+        state_path.write_text(json.dumps({"manual_theme": "dark"}), encoding="utf-8")
+
+        captured_themes: list[str] = []
+
+        def fake_render(*args, **kwargs):
+            theme = kwargs.get("theme") if "theme" in kwargs else (args[6] if len(args) > 6 else None)
+            captured_themes.append(theme)
+
+        sleep_count = {"n": 0}
+
+        def stop_after(_):
+            sleep_count["n"] += 1
+            if sleep_count["n"] >= 1:
+                raise KeyboardInterrupt
+
+        argv = [
+            "run_clock.py",
+            "--output", str(tmp_path / "current.png"),
+            "--theme", "default",
+            "--state-path", str(state_path),
+            "--telemetry-path", "",
+            "--history-path", "",
+            "--quiet-off",
+            "--buttons-off",
+            "--interval-seconds", "0",
+        ]
+        with patch("sys.argv", argv), \
+             patch("run_clock.render_now", side_effect=fake_render), \
+             patch("run_clock.current_time_str", return_value="10:00"), \
+             patch("run_clock.current_bucket", return_value="h10_exact"), \
+             patch("run_clock.peek_quote_id", return_value=("src", 1, "q", "mt")), \
+             patch("time.sleep", side_effect=stop_after):
+            with pytest.raises(KeyboardInterrupt):
+                run_clock.main()
+
+        assert captured_themes == ["dark"], "Persisted manual_theme must override --theme arg"
+
+
+class TestAutoThemeLoopIntegration:
+    """--theme auto must pick the right theme each tick and force a redraw on theme change."""
+
+    def test_auto_theme_evening_renders_dark(self, tmp_path):
+        captured_themes: list[str] = []
+
+        def fake_render(*args, **kwargs):
+            # render_now(..., display_script, mode, theme, ...) — theme is positional[6].
+            theme = kwargs.get("theme") if "theme" in kwargs else (args[6] if len(args) > 6 else None)
+            captured_themes.append(theme)
+
+        sleep_count = {"n": 0}
+
+        def stop_after(_):
+            sleep_count["n"] += 1
+            if sleep_count["n"] >= 1:
+                raise KeyboardInterrupt
+
+        argv = [
+            "run_clock.py",
+            "--output", str(tmp_path / "current.png"),
+            "--theme", "auto",
+            "--state-path", "",
+            "--telemetry-path", "",
+            "--history-path", "",
+            "--quiet-off",
+            "--buttons-off",
+            "--interval-seconds", "0",
+        ]
+        with patch("sys.argv", argv), \
+             patch("run_clock.render_now", side_effect=fake_render), \
+             patch("run_clock.current_time_str", return_value="20:00"), \
+             patch("run_clock.current_bucket", return_value="h8_exact"), \
+             patch("run_clock.peek_quote_id", return_value=("src", 1, "q", "mt")), \
+             patch("time.sleep", side_effect=stop_after):
+            with pytest.raises(KeyboardInterrupt):
+                run_clock.main()
+        assert captured_themes == ["dark"]
+
+    def test_auto_theme_change_forces_redraw(self, tmp_path):
+        """Same bucket + same quote across two ticks; only the theme flips → render twice."""
+        captured_themes: list[str] = []
+
+        def fake_render(*args, **kwargs):
+            # render_now(..., display_script, mode, theme, ...) — theme is positional[6].
+            theme = kwargs.get("theme") if "theme" in kwargs else (args[6] if len(args) > 6 else None)
+            captured_themes.append(theme)
+
+        # Tick 1: 17:55 → default theme. Tick 2: 18:00 → dark theme. Same bucket & quote.
+        time_strs = iter(["17:55", "18:00"])
+        sleep_count = {"n": 0}
+
+        def stop_after(_):
+            sleep_count["n"] += 1
+            if sleep_count["n"] >= 2:
+                raise KeyboardInterrupt
+
+        argv = [
+            "run_clock.py",
+            "--output", str(tmp_path / "current.png"),
+            "--theme", "auto",
+            "--state-path", "",
+            "--telemetry-path", "",
+            "--history-path", "",
+            "--quiet-off",
+            "--buttons-off",
+            "--interval-seconds", "0",
+        ]
+        with patch("sys.argv", argv), \
+             patch("run_clock.render_now", side_effect=fake_render), \
+             patch("run_clock.current_time_str", side_effect=lambda: next(time_strs)), \
+             patch("run_clock.current_bucket", return_value="h6_exact"), \
+             patch("run_clock.peek_quote_id", return_value=("src", 1, "q", "mt")), \
+             patch("time.sleep", side_effect=stop_after):
+            with pytest.raises(KeyboardInterrupt):
+                run_clock.main()
+        assert captured_themes == ["default", "dark"]
+
+
+class TestMidnightThemeReset:
+    def test_clears_manual_theme_at_day_boundary(self, tmp_path):
+        state_path = tmp_path / "state.json"
+        args = argparse.Namespace(state_path=str(state_path))
+        state = run_clock.RuntimeState("auto", persisted={"manual_theme": "dark"})
+        # Pretend yesterday already happened.
+        state.last_seen_date = dt.date.today() - dt.timedelta(days=1)
+        run_clock._maybe_reset_manual_theme_at_midnight(args, state)
+        assert state.manual_theme is None
+        # Persisted state file should reflect the cleared override.
+        persisted = json.loads(state_path.read_text(encoding="utf-8"))
+        assert persisted["manual_theme"] is None
+
+    def test_no_reset_when_theme_arg_is_explicit(self, tmp_path):
+        args = argparse.Namespace(state_path=str(tmp_path / "state.json"))
+        state = run_clock.RuntimeState("dark", persisted={"manual_theme": "default"})
+        state.last_seen_date = dt.date.today() - dt.timedelta(days=1)
+        run_clock._maybe_reset_manual_theme_at_midnight(args, state)
+        # theme_arg != "auto" means we don't auto-clear.
+        assert state.manual_theme == "default"
+
+    def test_no_reset_within_same_day(self, tmp_path):
+        args = argparse.Namespace(state_path=str(tmp_path / "state.json"))
+        state = run_clock.RuntimeState("auto", persisted={"manual_theme": "dark"})
+        state.last_seen_date = dt.date.today()
+        run_clock._maybe_reset_manual_theme_at_midnight(args, state)
+        assert state.manual_theme == "dark"
+
+
+class TestButtonHandlers:
+    """Synchronous handler dispatch — verifies wiring without spinning the loop."""
+
+    def _args(self, tmp_path, **overrides):
+        defaults = dict(
+            render_script="render_quote.py",
+            output=str(tmp_path / "current.png"),
+            width=800,
+            height=480,
+            display_script=None,
+            mode="debug",
+            theme="default",
+            history_path=str(tmp_path / "history.jsonl"),
+            history_days=7,
+            telemetry_path="",
+            state_path=str(tmp_path / "state.json"),
+            quiet_image="",
+        )
+        defaults.update(overrides)
+        return argparse.Namespace(**defaults)
+
+    def test_skip_handler_bans_current_quote_then_renders(self, tmp_path):
+        args = self._args(tmp_path)
+        state = run_clock.RuntimeState("default")
+        state.last_quote_id = ("src-old", 5, "q-old", "mt-old")
+        with patch("run_clock.peek_quote_id", return_value=("src-new", 7, "q-new", "mt-new")), \
+             patch("run_clock.render_now") as mock_render, \
+             patch("run_clock.current_time_str", return_value="10:00"), \
+             patch("run_clock.current_bucket", return_value="h10_exact"), \
+             patch("run_clock.pick_quote_module.append_history") as mock_append:
+            handlers = run_clock._build_button_handlers(args, state)
+            handlers["A"]()
+        # First append: ban the previous quote. Second: log the new one.
+        assert mock_append.call_count == 2
+        assert mock_append.call_args_list[0][0][1:] == ("src-old", 5)
+        assert mock_append.call_args_list[1][0][1:] == ("src-new", 7)
+        assert mock_render.called
+
+    def test_toggle_theme_handler_flips_and_persists(self, tmp_path):
+        args = self._args(tmp_path)
+        state = run_clock.RuntimeState("default")
+        state.last_effective_theme = "default"
+        with patch("run_clock.render_now") as mock_render, \
+             patch("run_clock.current_time_str", return_value="10:00"), \
+             patch("run_clock.current_bucket", return_value="h10_exact"):
+            handlers = run_clock._build_button_handlers(args, state)
+            handlers["B"]()
+        assert state.manual_theme == "dark"
+        persisted = json.loads((tmp_path / "state.json").read_text(encoding="utf-8"))
+        assert persisted["manual_theme"] == "dark"
+        # Render must use the new theme.
+        assert mock_render.called
+        kwargs = mock_render.call_args[1]
+        positional = mock_render.call_args[0]
+        used_theme = kwargs.get("theme") or (positional[6] if len(positional) > 6 else None)
+        assert used_theme == "dark"
+
+    def test_toggle_theme_handler_flips_back_when_dark(self, tmp_path):
+        args = self._args(tmp_path)
+        state = run_clock.RuntimeState("default")
+        state.last_effective_theme = "dark"
+        with patch("run_clock.render_now"), \
+             patch("run_clock.current_time_str", return_value="10:00"), \
+             patch("run_clock.current_bucket", return_value="h10_exact"):
+            handlers = run_clock._build_button_handlers(args, state)
+            handlers["B"]()
+        assert state.manual_theme == "default"
+
+    def test_source_card_handler_renders_in_card_mode(self, tmp_path):
+        args = self._args(tmp_path)
+        state = run_clock.RuntimeState("default")
+        # Patch threading.Timer so the test doesn't leave a 5s timer running.
+        with patch("run_clock.peek_quote_id", return_value=("src", 1, "q", "mt")), \
+             patch("run_clock.render_now") as mock_render, \
+             patch("run_clock.threading.Timer") as mock_timer, \
+             patch("run_clock.current_time_str", return_value="10:00"), \
+             patch("run_clock.current_bucket", return_value="h10_exact"):
+            handlers = run_clock._build_button_handlers(args, state)
+            handlers["C"]()
+        kwargs = mock_render.call_args[1]
+        positional = mock_render.call_args[0]
+        used_mode = kwargs.get("mode") or (positional[5] if len(positional) > 5 else None)
+        assert used_mode == "card"
+        assert mock_timer.called
+        # The 5-second restore callback should be scheduled.
+        delay, callback = mock_timer.call_args[0][:2]
+        assert delay == 5.0
+        # Run the restore callback manually and confirm it invalidates state.
+        state.last_bucket = "h10_exact"
+        state.last_quote_id = ("src", 1, "q", "mt")
+        callback()
+        assert state.last_bucket is None
+        assert state.last_quote_id is None
+
+    def test_quiet_toggle_handler_enables_and_persists(self, tmp_path):
+        quiet = tmp_path / "goodnight.png"
+        quiet.write_bytes(b"\x89PNG")
+        args = self._args(tmp_path, quiet_image=str(quiet))
+        state = run_clock.RuntimeState("default")
+        state.manual_quiet = False
+        with patch("run_clock._display_quiet_image") as mock_display:
+            handlers = run_clock._build_button_handlers(args, state)
+            handlers["D"]()
+        assert state.manual_quiet is True
+        persisted = json.loads((tmp_path / "state.json").read_text(encoding="utf-8"))
+        assert persisted["manual_quiet"] is True
+        assert mock_display.called
+
+    def test_quiet_toggle_handler_disable_triggers_wake_render(self, tmp_path):
+        args = self._args(tmp_path, quiet_image="")
+        state = run_clock.RuntimeState("default")
+        state.manual_quiet = True
+        with patch("run_clock.peek_quote_id", return_value=("src", 1, "q", "mt")), \
+             patch("run_clock.render_now") as mock_render, \
+             patch("run_clock.current_time_str", return_value="10:00"), \
+             patch("run_clock.current_bucket", return_value="h10_exact"):
+            handlers = run_clock._build_button_handlers(args, state)
+            handlers["D"]()
+        assert state.manual_quiet is False
+        assert mock_render.called
+
+
+class TestMaybeStartButtons:
+    def test_buttons_off_returns_none(self, tmp_path):
+        args = argparse.Namespace(buttons_off=True)
+        assert run_clock._maybe_start_buttons(args, run_clock.RuntimeState("default")) is None
+
+    def test_import_failure_logs_and_returns_none(self, tmp_path, capsys, monkeypatch):
+        # Force import of inky_buttons.start_listener to raise.
+        import inky_buttons as ib
+        monkeypatch.setattr(ib, "start_listener", lambda *a, **kw: (_ for _ in ()).throw(RuntimeError("no gpio")))
+        args = argparse.Namespace(
+            buttons_off=False,
+            render_script="r", output="o", width=800, height=480,
+            display_script=None, mode="debug", theme="default",
+            history_path="", history_days=7, telemetry_path="",
+            state_path="", quiet_image="",
+        )
+        result = run_clock._maybe_start_buttons(args, run_clock.RuntimeState("default"))
+        assert result is None
+        assert "button listener disabled" in capsys.readouterr().err

--- a/tests/test_run_clock.py
+++ b/tests/test_run_clock.py
@@ -791,6 +791,25 @@ class TestRuntimeStatePersistence:
         assert run_clock.load_runtime_state(str(path)) == {}
         assert "unreadable" in capsys.readouterr().err
 
+    def test_load_non_object_json_returns_empty(self, tmp_path, capsys):
+        """Valid JSON that isn't an object (bare string/number/list) must be rejected —
+        RuntimeState calls .get() on the result so a non-dict would otherwise crash startup.
+        """
+        path = tmp_path / "state.json"
+        path.write_text('"oops"', encoding="utf-8")
+        assert run_clock.load_runtime_state(str(path)) == {}
+        assert "not a JSON object" in capsys.readouterr().err
+
+    def test_load_number_json_returns_empty(self, tmp_path):
+        path = tmp_path / "state.json"
+        path.write_text("42", encoding="utf-8")
+        assert run_clock.load_runtime_state(str(path)) == {}
+
+    def test_load_list_json_returns_empty(self, tmp_path):
+        path = tmp_path / "state.json"
+        path.write_text("[]", encoding="utf-8")
+        assert run_clock.load_runtime_state(str(path)) == {}
+
     def test_runtime_state_seeds_from_persisted(self):
         s = run_clock.RuntimeState("auto", persisted={"manual_theme": "dark", "manual_quiet": True})
         assert s.manual_theme == "dark"
@@ -833,6 +852,27 @@ class TestAppendTelemetry:
         path = tmp_path / "nested" / "telemetry.jsonl"
         run_clock.append_telemetry(str(path), {"bucket": "h1_exact"})
         assert path.exists()
+
+    def test_io_failure_does_not_raise(self, tmp_path, capsys):
+        """Telemetry is best-effort — an unwritable path must never crash the caller,
+        since append_telemetry runs in the loop's error-recovery branch.
+        """
+        # Path collides with a directory → opening for append raises IsADirectoryError.
+        victim = tmp_path / "telemetry.jsonl"
+        victim.mkdir()
+        # Must not raise.
+        run_clock.append_telemetry(str(victim), {"bucket": "h3_exact"})
+        assert "telemetry write" in capsys.readouterr().err
+
+    def test_unserialisable_payload_does_not_raise(self, tmp_path, capsys):
+        """json.dumps blows up on non-serialisable values — swallow and log."""
+        path = tmp_path / "telemetry.jsonl"
+
+        class NotSerialisable:
+            pass
+
+        run_clock.append_telemetry(str(path), {"bucket": "h3_exact", "blob": NotSerialisable()})
+        assert "telemetry write" in capsys.readouterr().err
 
 
 class TestRenderNowTelemetry:
@@ -1110,6 +1150,20 @@ class TestButtonHandlers:
             handlers = run_clock._build_button_handlers(args, state)
             handlers["B"]()
         assert state.manual_theme == "default"
+
+    def test_do_render_bucket_matches_time_str_near_boundary(self, tmp_path):
+        """_do_render stamps state.last_bucket from time_str, not a fresh clock read —
+        otherwise a handler firing at 03:02:59.900 could derive bucket h3_five_past from
+        a clock read at 03:03:00.001, then stamp that into state while the panel still
+        shows the h3_exact frame, causing the next loop tick to wrongly skip the redraw.
+        """
+        args = self._args(tmp_path)
+        state = run_clock.RuntimeState("default")
+        with patch("run_clock.render_now"), \
+             patch("run_clock.current_bucket", side_effect=AssertionError("must not call current_bucket")), \
+             patch("run_clock.current_time_str", side_effect=AssertionError("must not call current_time_str")):
+            run_clock._do_render(args, state, "03:02", history_path=None, quote_id=("src", 1, "q", "mt"))
+        assert state.last_bucket == "h3_exact"
 
     def test_source_card_handler_renders_in_card_mode(self, tmp_path):
         args = self._args(tmp_path)

--- a/tests/test_run_clock.py
+++ b/tests/test_run_clock.py
@@ -1128,14 +1128,32 @@ class TestButtonHandlers:
         assert used_mode == "card"
         assert mock_timer.called
         # The 5-second restore callback should be scheduled.
-        delay, callback = mock_timer.call_args[0][:2]
+        delay, _callback = mock_timer.call_args[0][:2]
         assert delay == 5.0
-        # Run the restore callback manually and confirm it invalidates state.
-        state.last_bucket = "h10_exact"
-        state.last_quote_id = ("src", 1, "q", "mt")
-        callback()
-        assert state.last_bucket is None
-        assert state.last_quote_id is None
+
+    def test_source_card_restore_re_renders_normal_frame(self, tmp_path):
+        """The restore callback at +5s must actually push a new render — relying on the
+        next loop tick would leave the card up for up to --interval-seconds (60s default).
+        """
+        args = self._args(tmp_path)
+        state = run_clock.RuntimeState("default")
+        with patch("run_clock.peek_quote_id", return_value=("src", 1, "q", "mt")), \
+             patch("run_clock.render_now") as mock_render, \
+             patch("run_clock.threading.Timer") as mock_timer, \
+             patch("run_clock.current_time_str", return_value="10:00"), \
+             patch("run_clock.current_bucket", return_value="h10_exact"):
+            handlers = run_clock._build_button_handlers(args, state)
+            handlers["C"]()
+            # First render is the card itself.
+            assert mock_render.call_count == 1
+            # Now invoke the restore callback manually (simulating the 5s timer firing).
+            _delay, callback = mock_timer.call_args[0][:2]
+            callback()
+            assert mock_render.call_count == 2
+            # Second call must be in the normal mode, not "card".
+            second_call = mock_render.call_args_list[1]
+            mode = second_call.kwargs.get("mode") or (second_call.args[5] if len(second_call.args) > 5 else None)
+            assert mode == "debug"
 
     def test_quiet_toggle_handler_enables_and_persists(self, tmp_path):
         quiet = tmp_path / "goodnight.png"


### PR DESCRIPTION
Make the Inky Impression's four hardware buttons drive on-device UX:
A skips the current quote (and bans it from the week), B toggles theme
and persists the choice, C overlays a 5-second source card, D toggles a
manual quiet override. Wire-up lives in inky_buttons.py with a pure dispatch
contract so the listener can be stubbed in tests without gpiozero.

Add --theme auto to run_clock.py: dark between 18:00–06:00, default otherwise,
with manual button-B override winning until midnight rollover. State persists
to ~/.litclock/state.json across restarts.

Add per-theme saturation defaults to display_inky.py (0.5 default / 0.7 dark)
since the Spectra 6 panel renders dark backgrounds with a different waveform;
explicit --saturation still wins.

Wrap each render with monotonic timers and append one JSONL entry to
~/.litclock/telemetry.jsonl per render or error. New litclock_health.py
summarises the last N hours (counts + p50/p95 latency + last error) so a
"is it OK?" check no longer needs journalctl.

All four pieces are covered by tests/ — 484 tests pass, ruff clean.