### PR TITLE
Add button long-press, litclock_health --json, and startup frame

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,15 @@ python3 run_clock.py --buttons-off
 
 # Persisted runtime state (manual theme + manual quiet override) and telemetry sidecar
 python3 run_clock.py --state-path ~/.litclock/state.json --telemetry-path ~/.litclock/telemetry.jsonl
-python3 litclock_health.py --hours 24      # summary: render count, error count, p50/p95 latency
+python3 litclock_health.py --hours 24                  # human-readable summary
+python3 litclock_health.py --hours 24 --json           # JSON for cron / systemd health checks
+python3 litclock_health.py --hours 1 --fail-if-no-renders   # exit 2 if the window was silent
+
+# Push a static "starting" frame at boot so the panel doesn't ghost yesterday's render
+python3 run_clock.py --startup-image assets/goodnight.png
+
+# Override the button-D long-press shutdown command (default: sudo -n shutdown -h now)
+python3 run_clock.py --shutdown-command ""             # disable shutdown-on-hold entirely
 
 # Disable the default quiet-hours blackout (defaults 22:00–06:00, shows assets/goodnight.png)
 python3 run_clock.py --quiet-off
@@ -327,18 +335,22 @@ Thin orchestrator. Each tick (`--interval-seconds`, default 60) it computes the 
 
 **Auto-dark theme (`--theme auto`).** Picks `dark` between 18:00 and 06:00 (`AUTO_DARK_START_HOUR` / `AUTO_DARK_END_HOUR`) and `default` otherwise. Each tick re-derives the effective theme from the wall clock; a theme change is treated like a bucket change (forces a redraw even if the picked quote is unchanged). The button-B manual toggle wins until the next midnight rollover, when `_maybe_reset_manual_theme_at_midnight` clears it so `auto` resumes.
 
-**Inky buttons (`inky_buttons.py`).** The four capacitive buttons on the Inky Impression are wired to GPIO 5/6/16/24 (labels A/B/C/D) and dispatched by `inky_buttons.start_listener({label: callable})` using `gpiozero.Button` with a 0.3-second debounce. The hardware import is local to `start_listener` so the module is import-safe on dev hosts. `run_clock.py` builds the handler dict in `_build_button_handlers` and stashes the returned `Button` list in a local for the lifetime of the loop — `gpiozero` drops handlers when its `Button` is garbage-collected, so the reference must be held. Handlers act synchronously in the listener thread and serialize against the main loop via `state.render_lock`; mutations of theme/quiet flags are guarded by `state.lock`. Pass `--buttons-off` on dev machines or for headless runs.
+**Inky buttons (`inky_buttons.py`).** The four capacitive buttons on the Inky Impression are wired to GPIO 5/6/16/24 (labels A/B/C/D) and dispatched by `inky_buttons.start_listener(short_handlers, hold_handlers=...)` using `gpiozero.Button` with a 0.3-second debounce and a 2-second hold threshold. The hardware import is local to `start_listener` so the module is import-safe on dev hosts. `run_clock.py` builds the short/hold handler dicts in `_build_button_handlers` and stashes the returned keepalive list for the lifetime of the loop — `gpiozero` drops handlers when its `Button` is garbage-collected, so the reference must be held. Handlers act synchronously in the listener thread and serialize against the main loop via `state.render_lock`; mutations of theme/quiet flags are guarded by `state.lock`. Pass `--buttons-off` on dev machines or for headless runs.
 
-| Button | Action |
-|---|---|
-| **A** | Skip — bans the current quote in the history ledger, picks again, re-renders. |
-| **B** | Toggle theme — flips default ↔ dark, persists to `--state-path`, re-renders. |
-| **C** | Source card — renders a `--mode card` overlay (title / author / Gutenberg ID / matched phrase) for 5 seconds, then the timer thread itself re-renders the original frame (the next loop tick alone could be up to 60s away). |
-| **D** | Quiet now / wake — toggles `manual_quiet`, persists to `--state-path`. Going quiet pushes `--quiet-image` immediately; going active picks and renders the current time. |
+Short-press vs long-press dispatch is routed through a tiny `_HoldDispatcher` so the short callback fires on *release* only when the button was not held long enough to trigger the hold callback — a long press therefore fires only the hold action, never both.
+
+| Button | Short press | Long press (2s) |
+|---|---|---|
+| **A** | Skip — bans the current quote in the history ledger, picks again, re-renders. Records the just-banned quote as `state.last_skipped`. | Un-skip — removes the last-skipped quote's entry from the history ledger and re-renders. Reverses a fat-fingered tap. |
+| **B** | Toggle theme — flips default ↔ dark, persists to `--state-path`, re-renders. | — |
+| **C** | Source card — renders a `--mode card` overlay (title / author / Gutenberg ID / matched phrase) for 5 seconds, then the timer thread itself re-renders the original frame (the next loop tick alone could be up to 60s away). | — |
+| **D** | Quiet now / wake — toggles `manual_quiet`, persists to `--state-path`. Going quiet pushes `--quiet-image` immediately; going active picks and renders the current time. | Shutdown — shows `--quiet-image`, then runs `--shutdown-command` (default `sudo -n shutdown -h now`). Requires passwordless sudo for shutdown; override or empty the flag if you don't want this behaviour. |
 
 **Persisted runtime state (`--state-path`).** `~/.litclock/state.json` (default) holds `manual_theme` and `manual_quiet`. Loaded at loop startup so the user's last button-B / button-D choices survive a restart. Pass an empty string to disable.
 
-**Telemetry sidecar (`--telemetry-path`).** `~/.litclock/telemetry.jsonl` (default) gets one JSONL entry per successful render (`bucket`, `render_ms`, `display_ms`, `source_id`, `line_number`, `mode`, `theme`) and one per loop-level error (`bucket`, `error`, `mode`). `litclock_health.py` summarises the last N hours: render count, error count, p50/p95 latency, last error message. Designed for "is the appliance healthy?" diagnosis without `journalctl` spelunking. Pass an empty string to disable.
+**Telemetry sidecar (`--telemetry-path`).** `~/.litclock/telemetry.jsonl` (default) gets one JSONL entry per successful render (`bucket`, `render_ms`, `display_ms`, `source_id`, `line_number`, `mode`, `theme`) and one per loop-level error (`bucket`, `error`, `mode`). `litclock_health.py` summarises the last N hours: render count, error count, p50/p95 latency, last error message. `--json` emits the summary as JSON for cron/systemd integration; exit codes are `0` healthy, `1` no telemetry log, `2` unhealthy (errors but zero renders in the window, or `--fail-if-no-renders` was set and the window was silent). Pass an empty string to disable.
+
+**Startup frame (`--startup-image`).** Optional PNG pushed to the display once at loop startup, before the first quote render, so the panel doesn't ghost yesterday's frame during cold boot. Off by default (a Spectra 6 refresh takes 10–20s, so the extra round-trip isn't always worth it). Point at any PNG that encodes to the panel's 6-colour palette cleanly.
 
 ### Contact Sheet (`contact_sheet.py`)
 
@@ -358,7 +370,7 @@ Minimal Pillow → Pimoroni `inky.auto` bridge. Loads the PNG, resizes to the pa
 
 ### Testing
 
-The test suite lives in `tests/` and uses pytest with pytest-cov. There are 17 test modules covering every pipeline script plus the runtime components — 485 tests at last count. `display_inky.py` is exercised via `test_display_inky.py` with `_push_to_panel` mocked out so the retry/error paths run without real hardware; it stays in `tool.coverage.run.omit` so coverage numbers aren't skewed by hardware-only branches. `inky_buttons.py` is tested with `gpiozero.Button` stubbed via a `FakeButton` class injected through `sys.modules`.
+The test suite lives in `tests/` and uses pytest with pytest-cov. There are 17 test modules covering every pipeline script plus the runtime components — 522 tests at last count. `display_inky.py` is exercised via `test_display_inky.py` with `_push_to_panel` mocked out so the retry/error paths run without real hardware; it stays in `tool.coverage.run.omit` so coverage numbers aren't skewed by hardware-only branches. `inky_buttons.py` is tested with `gpiozero.Button` stubbed via a `FakeButton` class injected through `sys.modules`.
 
 **Test structure:**
 - `tests/conftest.py` — shared fixtures: `make_row()` factory, `sample_row`, `sample_rows`, and `tmp_jsonl` (a helper that writes a list of dicts to a temp JSONL file)

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ That build pipeline is how the runtime quote set came to exist. The clock itself
 - `render_quote.py` - quote renderer, typography, highlighting, theme handling, Spectra 6 palette snapping
 - `pick_quote.py` - runtime quote selection from the attributed dataset
 - `display_inky.py` - thin bridge that sends a rendered image to the Inky display
+- `inky_buttons.py` - listener for the four Inky Impression capacitive buttons (A/B/C/D), short + long press
+- `litclock_health.py` - summarises the telemetry sidecar (render count, p50/p95 latency, last error); supports `--json`
 - `buckets.py` - fuzzy time bucket mapping
 
 ### Runtime assets
@@ -107,6 +109,54 @@ python3 run_clock.py --display-script display_inky.py --mode production
 ### Themes
 
 Pass `--theme dark` to either `run_clock.py` or `render_quote.py` for a black-background / yellow-accent variant. `--theme default` is the white-background / red-accent original.
+
+Pass `--theme auto` to let the clock pick for you: dark between 18:00 and 06:00, default otherwise. A manual button-B press overrides `auto` until the next midnight rollover.
+
+### Inky buttons (short and long press)
+
+The four capacitive buttons on an Inky Impression 7.3 are active whenever `run_clock.py` runs on a Pi with the `gpiozero` package installed. Pass `--buttons-off` on dev hosts or for headless smoke tests.
+
+| Button | Short press | Long press (2s) |
+|---|---|---|
+| **A** | Skip — bans the current quote in the history ledger and picks a new one. | Un-skip — removes the last-skipped ban from the ledger and re-renders. Reverses a fat-fingered tap. |
+| **B** | Toggle theme — flips default ↔ dark, persists to `--state-path`. | — |
+| **C** | Source card — shows a 5-second overlay with the title / author / Gutenberg ID / matched phrase. | — |
+| **D** | Quiet now / wake — toggles the manual quiet override, persists to `--state-path`. | Shutdown — shows the goodnight frame, then runs `--shutdown-command` (default `sudo -n shutdown -h now`; empty to disable). |
+
+Short and long actions are mutually exclusive per press: a long press fires only the hold callback, a quick tap fires only the short one.
+
+### Persisted runtime state and telemetry
+
+The loop can persist the manual theme and quiet overrides so they survive a restart, and it can log one JSONL entry per render/error for after-the-fact "is the appliance OK?" checks.
+
+```bash
+# Default paths (pass an empty string to disable either)
+python3 run_clock.py \
+  --state-path ~/.litclock/state.json \
+  --telemetry-path ~/.litclock/telemetry.jsonl
+
+# Human-readable telemetry summary for the last 24h
+python3 litclock_health.py --hours 24
+
+# JSON summary for cron / systemd health checks (exits 2 when unhealthy)
+python3 litclock_health.py --hours 1 --json --fail-if-no-renders
+```
+
+`litclock_health.py` exit codes:
+
+- `0` — healthy (renders happened in the window, or no errors with nothing scheduled)
+- `1` — telemetry log missing
+- `2` — unhealthy: errors but zero renders, or `--fail-if-no-renders` with a silent window
+
+### Startup frame
+
+```bash
+# Optional: push a static frame to the panel before the first quote renders
+# so a cold boot doesn't ghost yesterday's image.
+python3 run_clock.py --startup-image assets/goodnight.png
+```
+
+The extra refresh costs a Spectra 6 cycle (~10–20s) so this is off by default; enable when you care more about clean boot visuals than time-to-first-quote.
 
 ### Quiet hours
 
@@ -279,7 +329,11 @@ That work is intentionally separate from the steady-state render loop.
 - The clock refreshes when the fuzzy time bucket changes, not every minute, and additionally skips a redraw when the picked quote is identical to the previous frame.
 - If the exact bucket is weak or empty, the picker walks nearby buckets and records fallback metadata.
 - `production` mode hides debug metadata for cleaner display output; `debug` mode draws a top-right `DEBUG MODE` banner and a centered bottom strip with bucket/layout/quality/id.
-- Quiet hours are on by default (22:00–06:00) and show `assets/goodnight.png`; override with `--quiet-start` / `--quiet-end` / `--quiet-image`, or disable with `--quiet-off`.
+- Quiet hours are on by default (22:00–06:00) and show `assets/goodnight.png`; override with `--quiet-start` / `--quiet-end` / `--quiet-image`, or disable with `--quiet-off`. Button D toggles a manual quiet override at any time.
+- Button B flips the theme at any time and persists the choice to `--state-path`. Button A's long press reverses the most recent skip.
+- `--theme auto` switches dark/default by wall-clock time (dark 18:00–06:00); a manual button-B override wins until the next midnight rollover.
+- Per-theme saturation: `display_inky.py` uses `0.5` for `default` and `0.7` for `dark` on the Spectra 6 panel so accents don't go muddy on dark backgrounds.
+- Telemetry at `--telemetry-path` (default `~/.litclock/telemetry.jsonl`) gets one line per render and one per loop-level error; `litclock_health.py --json` feeds systemd / cron health checks.
 - The renderer is tuned for the Pimoroni Inky Impression 7.3 / Spectra 6 800×480 display.
 - Final renders are snapped to the exact Spectra 6 palette for better hardware fidelity.
 - Renderer changes can be surprisingly fragile around text normalization, wrapping, and emphasis/highlight matching, so keep render tests healthy.
@@ -292,4 +346,9 @@ If the clock is behaving oddly, these are the first files to inspect:
 - highlight/layout/render issues -> `render_quote.py`
 - loop/update/dedup/service behavior -> `run_clock.py`
 - display handoff issues -> `display_inky.py`
+- button/long-press wiring -> `inky_buttons.py`
+- "is the appliance alive?" -> `python3 litclock_health.py --hours 24` (use `--json` from cron)
+- telemetry log (one JSONL entry per render/error) -> `~/.litclock/telemetry.jsonl`
+- persisted manual theme / quiet override -> `~/.litclock/state.json`
+- anti-repeat ledger of recently-shown quotes -> `~/.litclock/history.jsonl`
 - runtime dataset questions -> `assets/candidates-attributed.jsonl`

--- a/inky_buttons.py
+++ b/inky_buttons.py
@@ -6,6 +6,10 @@ handler to each so ``run_clock.py`` can react to user input without polling.
 
 The hardware import (``gpiozero``) happens inside :func:`start_listener` so this
 module is import-safe on dev machines and the test suite can stub it out.
+
+Short-press vs long-press: when a button has both a short and a hold handler,
+the short callback fires on *release* only if the button was not held long
+enough to trigger the hold callback. This avoids firing both on a long press.
 """
 from __future__ import annotations
 
@@ -19,29 +23,88 @@ BUTTON_GPIO: dict[str, int] = {
 }
 
 DEBOUNCE_SECONDS = 0.3
+DEFAULT_HOLD_SECONDS = 2.0
+
+
+class _HoldDispatcher:
+    """Route a button's press/hold/release events to short- and long-press callbacks.
+
+    gpiozero fires ``when_pressed`` on every press. ``when_held`` fires after
+    ``hold_time`` seconds while the button is still held; it also sets the
+    ``Button.is_held`` attribute. We route through this dispatcher so the short
+    callback only fires on release when the button was NOT held, preventing a
+    long press from triggering both the short and long actions.
+    """
+
+    def __init__(
+        self,
+        short: Callable[[], None] | None,
+        long_: Callable[[], None] | None,
+    ) -> None:
+        self._short = short
+        self._long = long_
+        self._held = False
+
+    def on_press(self) -> None:
+        self._held = False
+
+    def on_hold(self) -> None:
+        self._held = True
+        if self._long is not None:
+            self._long()
+
+    def on_release(self) -> None:
+        if not self._held and self._short is not None:
+            self._short()
 
 
 def start_listener(
     handlers: Mapping[str, Callable[[], None]],
     *,
+    hold_handlers: Mapping[str, Callable[[], None]] | None = None,
+    hold_time: float = DEFAULT_HOLD_SECONDS,
     bounce_time: float = DEBOUNCE_SECONDS,
 ) -> list:
-    """Attach ``handlers[label]`` to each Inky button press.
+    """Attach ``handlers[label]`` (short press) and optional ``hold_handlers[label]``
+    (long press, ``hold_time`` seconds) to each Inky button.
 
-    ``handlers`` keys must be subset of ``BUTTON_GPIO`` (``"A"``/``"B"``/``"C"``/``"D"``);
-    unknown labels raise ``ValueError``. Returns the list of created button objects so
-    the caller can keep them alive for the lifetime of the process — ``gpiozero``
-    drops handlers when the ``Button`` is garbage-collected.
+    Keys in either mapping must be a subset of ``BUTTON_GPIO``
+    (``"A"``/``"B"``/``"C"``/``"D"``); unknown labels raise ``ValueError``. A label
+    may appear in ``hold_handlers`` without appearing in ``handlers`` if you only
+    want a long-press action. Returns the list of created button objects (plus
+    dispatcher refs) so the caller can keep them alive for the lifetime of the
+    process — ``gpiozero`` drops handlers when the ``Button`` is
+    garbage-collected.
     """
-    unknown = set(handlers) - set(BUTTON_GPIO)
+    hold_handlers = dict(hold_handlers or {})
+    labels = set(handlers) | set(hold_handlers)
+    unknown = labels - set(BUTTON_GPIO)
     if unknown:
-        raise ValueError(f"Unknown button label(s): {sorted(unknown)}; expected subset of {sorted(BUTTON_GPIO)}")
+        raise ValueError(
+            f"Unknown button label(s): {sorted(unknown)}; expected subset of {sorted(BUTTON_GPIO)}"
+        )
 
     from gpiozero import Button  # local import so this module is safe on non-Pi hosts
 
-    buttons = []
-    for label, callback in handlers.items():
-        button = Button(BUTTON_GPIO[label], pull_up=True, bounce_time=bounce_time)
-        button.when_pressed = callback
-        buttons.append(button)
-    return buttons
+    keepalive: list = []
+    for label in sorted(labels):
+        short = handlers.get(label)
+        long_ = hold_handlers.get(label)
+        button = Button(
+            BUTTON_GPIO[label],
+            pull_up=True,
+            bounce_time=bounce_time,
+            hold_time=hold_time,
+        )
+        if long_ is None:
+            # No hold handler: keep the simple press-fires-immediately path so
+            # single-action buttons stay snappy.
+            button.when_pressed = short
+        else:
+            dispatcher = _HoldDispatcher(short, long_)
+            button.when_pressed = dispatcher.on_press
+            button.when_held = dispatcher.on_hold
+            button.when_released = dispatcher.on_release
+            keepalive.append(dispatcher)
+        keepalive.append(button)
+    return keepalive

--- a/litclock.service.example
+++ b/litclock.service.example
@@ -7,9 +7,16 @@ Wants=network-online.target
 Type=simple
 User=pi
 WorkingDirectory=/home/pi/LitClock
-ExecStart=/home/pi/.virtualenvs/pimoroni/bin/python /home/pi/LitClock/run_clock.py --display-script display_inky.py --mode production
+ExecStart=/home/pi/.virtualenvs/pimoroni/bin/python /home/pi/LitClock/run_clock.py --display-script display_inky.py --mode production --theme auto
 # Uses the prebuilt runtime dataset in assets/candidates-attributed.jsonl.
 # Rebuilding corpus artifacts is a separate maintenance task, not part of service startup.
+#
+# Useful additions depending on your setup:
+#   --buttons-off                           if gpiozero isn't installed or you don't want buttons
+#   --shutdown-command ""                   disable button-D long-press shutdown
+#   --startup-image /home/pi/LitClock/assets/goodnight.png   push a frame at boot
+#   --state-path /home/pi/.litclock/state.json              persisted theme/quiet overrides
+#   --telemetry-path /home/pi/.litclock/telemetry.jsonl     telemetry sidecar (litclock_health.py)
 Restart=always
 RestartSec=10
 

--- a/litclock_health.py
+++ b/litclock_health.py
@@ -31,6 +31,20 @@ def parse_args() -> argparse.Namespace:
         default=DEFAULT_HOURS,
         help="Window of recent hours to consider (default: 24)",
     )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit a JSON summary instead of the human-readable text. Handy for cron/systemd checks.",
+    )
+    parser.add_argument(
+        "--fail-if-no-renders",
+        action="store_true",
+        help=(
+            "Exit 2 if the window contains zero successful renders (default: only fail when "
+            "there are errors AND no renders). Use on active appliances where silence itself "
+            "indicates a problem."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -107,17 +121,37 @@ def format_summary(summary: dict, hours: int) -> str:
     return "\n".join(parts)
 
 
+def evaluate_health(summary: dict, *, fail_if_no_renders: bool) -> int:
+    """Map a summary dict to a process exit code.
+
+    - ``0``: healthy (there are renders, or nothing unhealthy happened)
+    - ``2``: unhealthy — errors but no successful renders, or
+      ``--fail-if-no-renders`` was set and the window was silent.
+    """
+    if summary["error_count"] > 0 and summary["render_count"] == 0:
+        return 2
+    if fail_if_no_renders and summary["render_count"] == 0:
+        return 2
+    return 0
+
+
 def main() -> int:
     args = parse_args()
     path = Path(args.telemetry_path).expanduser()
     since = dt.datetime.now(dt.timezone.utc) - dt.timedelta(hours=args.hours)
     entries = load_entries(path, since)
     if not entries and not path.exists():
-        print(f"No telemetry log at {path}", file=sys.stderr)
+        if args.json:
+            print(json.dumps({"error": f"No telemetry log at {path}", "hours": args.hours}))
+        else:
+            print(f"No telemetry log at {path}", file=sys.stderr)
         return 1
     summary = summarise(entries)
-    print(format_summary(summary, args.hours))
-    return 0
+    if args.json:
+        print(json.dumps({"hours": args.hours, **summary}))
+    else:
+        print(format_summary(summary, args.hours))
+    return evaluate_health(summary, fail_if_no_renders=args.fail_if_no_renders)
 
 
 if __name__ == "__main__":

--- a/pi_setup_inky_impression.md
+++ b/pi_setup_inky_impression.md
@@ -54,6 +54,34 @@ Notes:
 - the sample runs `run_clock.py` in `--mode production`
 - edit `User=`, `WorkingDirectory=`, and `ExecStart=` if your Pi paths differ
 - if `inky-photo-frame.service` is still enabled, stop/disable it first so LitClock can own the display
+- install the `gpiozero` package into the same virtualenv if you want Inky button support (short press + 2s long press); otherwise add `--buttons-off` to `ExecStart=`
+
+### Optional: allow button D long-press shutdown
+
+The default `--shutdown-command` is `sudo -n shutdown -h now`, so a 2-second hold of button D can power the appliance down cleanly. That requires passwordless sudo for shutdown. A minimal sudoers drop-in:
+
+```bash
+sudo tee /etc/sudoers.d/litclock-shutdown <<'EOF'
+pi ALL=(root) NOPASSWD: /sbin/shutdown
+EOF
+sudo chmod 440 /etc/sudoers.d/litclock-shutdown
+```
+
+If you prefer not to grant that, set `--shutdown-command ""` in the service `ExecStart=` to turn the hold-to-shutdown off.
+
+### Optional: health checks + telemetry
+
+The loop writes a JSONL telemetry sidecar to `~/.litclock/telemetry.jsonl` (one line per successful render, one per loop-level error) and `litclock_health.py` summarises the last N hours. Useful scripts for a quick Pi check:
+
+```bash
+# Human-readable summary
+python3 litclock_health.py --hours 24
+
+# Machine-readable; exit 2 when no renders landed in the window
+python3 litclock_health.py --hours 1 --json --fail-if-no-renders
+```
+
+Wire the JSON form into a once-a-day cron / systemd timer if you want passive alerting without SSH journalctl spelunking.
 
 ## Path B: Fresh Inky setup
 

--- a/pick_quote.py
+++ b/pick_quote.py
@@ -325,6 +325,36 @@ def append_history(history_path: str | None, source_id, line_number) -> None:
         handle.write(json.dumps(entry, ensure_ascii=False) + "\n")
 
 
+def remove_last_history_entry(history_path: str | None, source_id, line_number) -> bool:
+    """Remove the most recent ledger entry matching ``(source_id, line_number)``.
+
+    Powers the "un-skip" button long-press: a skip appended the banned quote to
+    the ledger, holding the button reverses that entry so the quote can appear
+    again. Returns True if an entry was removed, False otherwise (no path,
+    missing file, nothing matched).
+    """
+    if not history_path or source_id is None or line_number is None:
+        return False
+    path = Path(history_path).expanduser()
+    if not path.exists():
+        return False
+    lines = path.read_text(encoding="utf-8").splitlines()
+    target = (str(source_id), line_number)
+    for i in range(len(lines) - 1, -1, -1):
+        try:
+            entry = json.loads(lines[i])
+        except (ValueError, json.JSONDecodeError):
+            continue
+        if (str(entry.get("source_id")), entry.get("line_number")) == target:
+            del lines[i]
+            if lines:
+                path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+            else:
+                path.write_text("", encoding="utf-8")
+            return True
+    return False
+
+
 def _row_history_key(row: dict) -> tuple | None:
     source_id = row.get("source_id")
     line_number = row.get("line_number")

--- a/run_clock.py
+++ b/run_clock.py
@@ -106,6 +106,24 @@ def parse_args() -> argparse.Namespace:
         help="Skip the Inky button listener. Use on dev machines or for headless runs.",
     )
     parser.add_argument(
+        "--shutdown-command",
+        default="sudo -n shutdown -h now",
+        help=(
+            "Shell command invoked when button D is held for 2 seconds. "
+            "Default assumes passwordless sudo for shutdown is configured; set to "
+            "an empty string to disable the long-press-to-shutdown feature."
+        ),
+    )
+    parser.add_argument(
+        "--startup-image",
+        default=None,
+        help=(
+            "Optional PNG pushed to the display once at loop startup before the "
+            "first quote render, so the panel doesn't ghost yesterday's frame "
+            "during cold boot. Omit (default) to skip the startup frame."
+        ),
+    )
+    parser.add_argument(
         "--state-path",
         default=DEFAULT_STATE_PATH,
         help=(
@@ -274,6 +292,9 @@ class RuntimeState:
         self.last_quote_id: tuple | None = None
         self.last_effective_theme: str | None = None
         self.last_seen_date: dt.date | None = None
+        # Populated when button A (skip) bans a quote; button A long-press
+        # rolls that ban back and re-renders.
+        self.last_skipped: tuple | None = None
         if persisted:
             mt = persisted.get("manual_theme")
             if mt in ("default", "dark"):
@@ -453,6 +474,9 @@ def _build_button_handlers(args: argparse.Namespace, state: RuntimeState) -> dic
             if previous is not None:
                 # Ban the currently-shown quote so the next pick filters it out for the week.
                 pick_quote_module.append_history(history_path, previous[0], previous[1])
+                with state.lock:
+                    # Remember what we just banned so A long-press can reverse it.
+                    state.last_skipped = previous
             time_str = current_time_str()
             quote_id = peek_quote_id(time_str, history_path=history_path, history_days=args.history_days)
             _do_render(args, state, time_str, history_path, quote_id=quote_id)
@@ -461,6 +485,34 @@ def _build_button_handlers(args: argparse.Namespace, state: RuntimeState) -> dic
         except Exception as exc:
             _log(f"skip failed: {exc!r}", err=True)
             append_telemetry(telemetry_path, {"bucket": current_bucket(), "error": repr(exc), "mode": "skip"})
+
+    def on_unskip() -> None:
+        """Button A held 2s: reverse the most recent skip.
+
+        Removes the last-skipped quote's ban from the history ledger and
+        re-renders the current time. If the bucket hasn't moved since the skip,
+        the un-banned quote is likely to be picked again. If the bucket has
+        moved on, the user just sees a fresh render for the new time — the
+        ledger is still cleaned up either way.
+        """
+        _log("button A held: un-skip")
+        try:
+            with state.lock:
+                target = state.last_skipped
+                state.last_skipped = None
+            if target is None:
+                _log("un-skip: no recently-skipped quote recorded")
+                return
+            removed = pick_quote_module.remove_last_history_entry(history_path, target[0], target[1])
+            _log(f"un-skip: removed ledger entry for source={target[0]} line={target[1]} ok={removed}")
+            time_str = current_time_str()
+            quote_id = peek_quote_id(time_str, history_path=history_path, history_days=args.history_days)
+            _do_render(args, state, time_str, history_path, quote_id=quote_id)
+            if quote_id is not None:
+                pick_quote_module.append_history(history_path, quote_id[0], quote_id[1])
+        except Exception as exc:
+            _log(f"un-skip failed: {exc!r}", err=True)
+            append_telemetry(telemetry_path, {"bucket": current_bucket(), "error": repr(exc), "mode": "unskip"})
 
     def on_toggle_theme() -> None:
         try:
@@ -503,6 +555,32 @@ def _build_button_handlers(args: argparse.Namespace, state: RuntimeState) -> dic
             _log(f"source card failed: {exc!r}", err=True)
             append_telemetry(telemetry_path, {"bucket": current_bucket(), "error": repr(exc), "mode": "card"})
 
+    def on_shutdown() -> None:
+        """Button D held 2s: display the goodnight frame and invoke the shutdown command.
+
+        Best-effort. If ``--shutdown-command`` is empty or returns non-zero,
+        the failure is logged and the loop continues. A clean shutdown on the
+        Pi requires passwordless sudo for the default ``sudo -n shutdown -h now``;
+        users running without sudo can override via ``--shutdown-command``.
+        """
+        _log("button D held: shutdown")
+        try:
+            if args.quiet_image:
+                with state.render_lock:
+                    _display_quiet_image(args.quiet_image, args.output, args.display_script)
+        except Exception as exc:
+            _log(f"shutdown pre-frame failed: {exc!r}", err=True)
+        cmd = (args.shutdown_command or "").strip()
+        if not cmd:
+            _log("shutdown: --shutdown-command is empty, skipping system shutdown")
+            return
+        try:
+            import shlex
+            subprocess.check_call(shlex.split(cmd))
+        except Exception as exc:
+            _log(f"shutdown command {cmd!r} failed: {exc!r}", err=True)
+            append_telemetry(telemetry_path, {"bucket": current_bucket(), "error": repr(exc), "mode": "shutdown"})
+
     def on_quiet_toggle() -> None:
         try:
             with state.lock:
@@ -526,12 +604,17 @@ def _build_button_handlers(args: argparse.Namespace, state: RuntimeState) -> dic
             _log(f"quiet toggle failed: {exc!r}", err=True)
             append_telemetry(telemetry_path, {"bucket": current_bucket(), "error": repr(exc), "mode": "quiet"})
 
-    return {
+    short_handlers = {
         "A": on_skip,
         "B": on_toggle_theme,
         "C": on_source_card,
         "D": on_quiet_toggle,
     }
+    hold_handlers = {
+        "A": on_unskip,
+        "D": on_shutdown,
+    }
+    return short_handlers, hold_handlers
 
 
 def _maybe_start_buttons(args: argparse.Namespace, state: RuntimeState):
@@ -540,7 +623,8 @@ def _maybe_start_buttons(args: argparse.Namespace, state: RuntimeState):
         return None
     try:
         import inky_buttons
-        return inky_buttons.start_listener(_build_button_handlers(args, state))
+        short_handlers, hold_handlers = _build_button_handlers(args, state)
+        return inky_buttons.start_listener(short_handlers, hold_handlers=hold_handlers)
     except Exception as exc:
         _log(f"button listener disabled ({exc!r}); pass --buttons-off to silence", err=True)
         return None
@@ -591,6 +675,16 @@ def main() -> int:
     # Hold the returned button list as a local for the lifetime of the loop —
     # gpiozero drops handlers when its Button objects are garbage-collected.
     _buttons = _maybe_start_buttons(args, state)  # noqa: F841
+
+    # Startup frame: push a static image to the panel before the first quote
+    # renders so viewers see something intentional instead of yesterday's
+    # ghosted frame during cold boot. Best-effort; a missing file is logged
+    # and the loop continues to the first real render.
+    if args.startup_image:
+        try:
+            _display_quiet_image(args.startup_image, args.output, args.display_script)
+        except Exception as exc:
+            _log(f"startup image display failed: {exc!r}", err=True)
 
     _was_quiet = False
     while True:

--- a/run_clock.py
+++ b/run_clock.py
@@ -589,17 +589,26 @@ def _build_button_handlers(
     def on_shutdown() -> None:
         """Button D held 2s: display the goodnight frame and invoke the shutdown command.
 
-        Best-effort. If ``--shutdown-command`` is empty or returns non-zero,
-        the failure is logged and the loop continues. A clean shutdown on the
-        Pi requires passwordless sudo for the default ``sudo -n shutdown -h now``;
-        users running without sudo can override via ``--shutdown-command``.
+        Best-effort. If ``--shutdown-command`` returns non-zero the failure
+        is logged and the loop continues. A clean shutdown on the Pi requires
+        passwordless sudo for the default ``sudo -n shutdown -h now``; users
+        running without sudo can override via ``--shutdown-command``.
 
-        Order-of-operations: we flip ``state.manual_quiet`` BEFORE pushing the
-        goodnight frame so that even if the main loop wakes between our
-        ``_display_quiet_image`` call and the shutdown invocation, it takes the
-        quiet branch and (worst case) re-pushes goodnight — it can't slip a
-        normal quote onto the panel in the final seconds before poweroff.
+        If ``--shutdown-command`` is empty the feature is fully disabled:
+        we return early without flipping quiet state, so an accidental long
+        press can't leave the clock stuck in manual quiet across restarts.
+
+        Order-of-operations: when shutdown IS enabled we flip
+        ``state.manual_quiet`` BEFORE pushing the goodnight frame so that
+        even if the main loop wakes between our ``_display_quiet_image``
+        call and the shutdown invocation, it takes the quiet branch and
+        (worst case) re-pushes goodnight — it can't slip a normal quote
+        onto the panel in the final seconds before poweroff.
         """
+        cmd = (args.shutdown_command or "").strip()
+        if not cmd:
+            _log("button D held: --shutdown-command is empty, skipping system shutdown")
+            return
         _log("button D held: shutdown")
         with state.lock:
             state.manual_quiet = True
@@ -612,10 +621,6 @@ def _build_button_handlers(
                     )
         except Exception as exc:
             _log(f"shutdown pre-frame failed: {exc!r}", err=True)
-        cmd = (args.shutdown_command or "").strip()
-        if not cmd:
-            _log("shutdown: --shutdown-command is empty, skipping system shutdown")
-            return
         try:
             subprocess.check_call(shlex.split(cmd))
         except Exception as exc:

--- a/run_clock.py
+++ b/run_clock.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import datetime as dt
 import json
+import shlex
 import shutil
 import subprocess
 import sys
@@ -285,6 +286,10 @@ class RuntimeState:
     def __init__(self, theme_arg: str, persisted: dict | None = None):
         self.lock = threading.Lock()
         self.render_lock = threading.Lock()
+        # Serialises read-modify-write of ~/.litclock/history.jsonl. Button A's
+        # long-press does a remove-last-entry that would otherwise race the main
+        # loop's post-render append and silently drop it.
+        self.ledger_lock = threading.Lock()
         self.theme_arg = theme_arg            # CLI value ('default'/'dark'/'auto')
         self.manual_theme: str | None = None  # set by button B until midnight
         self.manual_quiet = False             # toggled by button D
@@ -322,12 +327,23 @@ def in_quiet_hours(time_str: str, start: str | None, end: str | None) -> bool:
     return (cur >= s or cur < e) if s > e else (s <= cur < e)
 
 
-def _display_quiet_image(quiet_image: str, output: str, display_script: str | None) -> None:
-    """Copy quiet_image to the output path and optionally push it to the display script."""
+def _display_quiet_image(
+    quiet_image: str,
+    output: str,
+    display_script: str | None,
+    *,
+    reason: str = "quiet hours",
+) -> None:
+    """Copy ``quiet_image`` to ``output`` and optionally push it to the display script.
+
+    ``reason`` is the label prefixed to the log message so the same helper can serve
+    the quiet-hours entry, the startup frame, and the button-D long-press
+    shutdown preamble without lying about why it ran.
+    """
     quiet_path = Path(quiet_image) if Path(quiet_image).is_absolute() else (BASE_DIR / quiet_image).resolve()
     output_resolved = str((BASE_DIR / output).resolve()) if not Path(output).is_absolute() else output
     shutil.copy2(str(quiet_path), output_resolved)
-    _log(f"quiet hours: {quiet_path.name} -> {output_resolved}")
+    _log(f"{reason}: {quiet_path.name} -> {output_resolved}")
     if display_script:
         display_path = str((BASE_DIR / display_script).resolve()) if not Path(display_script).is_absolute() else display_script
         subprocess.check_call([sys.executable, display_path, output_resolved])
@@ -456,12 +472,18 @@ def _do_render(args: argparse.Namespace, state: RuntimeState, time_str: str, his
                 state.last_quote_id = quote_id
 
 
-def _build_button_handlers(args: argparse.Namespace, state: RuntimeState) -> dict:
-    """Return the {label: callable} dispatch map handed to the button listener.
+def _build_button_handlers(
+    args: argparse.Namespace, state: RuntimeState,
+) -> tuple[dict[str, "callable"], dict[str, "callable"]]:
+    """Return ``(short_handlers, hold_handlers)`` for ``inky_buttons.start_listener``.
 
-    Each handler does its work synchronously in the listener thread and serializes
-    against the loop via ``state.render_lock``. Mutations of theme/quiet state are
-    persisted to ``--state-path`` so they survive a process restart.
+    ``short_handlers`` covers quick taps on A/B/C/D; ``hold_handlers`` adds the
+    2-second long-press actions on A (un-skip) and D (shutdown). Each handler
+    does its work synchronously in the listener thread and serialises against
+    the loop via ``state.render_lock``. Mutations of theme/quiet state are
+    persisted to ``--state-path`` so they survive a process restart; ledger
+    appends/removes go through ``state.ledger_lock`` to prevent the main loop's
+    post-render append from racing the un-skip's read-modify-write.
     """
     history_path = args.history_path or None
     telemetry_path = args.telemetry_path or None
@@ -473,7 +495,8 @@ def _build_button_handlers(args: argparse.Namespace, state: RuntimeState) -> dic
                 previous = state.last_quote_id
             if previous is not None:
                 # Ban the currently-shown quote so the next pick filters it out for the week.
-                pick_quote_module.append_history(history_path, previous[0], previous[1])
+                with state.ledger_lock:
+                    pick_quote_module.append_history(history_path, previous[0], previous[1])
                 with state.lock:
                     # Remember what we just banned so A long-press can reverse it.
                     state.last_skipped = previous
@@ -481,7 +504,8 @@ def _build_button_handlers(args: argparse.Namespace, state: RuntimeState) -> dic
             quote_id = peek_quote_id(time_str, history_path=history_path, history_days=args.history_days)
             _do_render(args, state, time_str, history_path, quote_id=quote_id)
             if quote_id is not None:
-                pick_quote_module.append_history(history_path, quote_id[0], quote_id[1])
+                with state.ledger_lock:
+                    pick_quote_module.append_history(history_path, quote_id[0], quote_id[1])
         except Exception as exc:
             _log(f"skip failed: {exc!r}", err=True)
             append_telemetry(telemetry_path, {"bucket": current_bucket(), "error": repr(exc), "mode": "skip"})
@@ -493,7 +517,9 @@ def _build_button_handlers(args: argparse.Namespace, state: RuntimeState) -> dic
         re-renders the current time. If the bucket hasn't moved since the skip,
         the un-banned quote is likely to be picked again. If the bucket has
         moved on, the user just sees a fresh render for the new time — the
-        ledger is still cleaned up either way.
+        ledger is still cleaned up either way. The ledger read-modify-write is
+        serialised against the main loop's ``append_history`` via
+        ``state.ledger_lock`` so a concurrent append is not silently lost.
         """
         _log("button A held: un-skip")
         try:
@@ -503,13 +529,15 @@ def _build_button_handlers(args: argparse.Namespace, state: RuntimeState) -> dic
             if target is None:
                 _log("un-skip: no recently-skipped quote recorded")
                 return
-            removed = pick_quote_module.remove_last_history_entry(history_path, target[0], target[1])
+            with state.ledger_lock:
+                removed = pick_quote_module.remove_last_history_entry(history_path, target[0], target[1])
             _log(f"un-skip: removed ledger entry for source={target[0]} line={target[1]} ok={removed}")
             time_str = current_time_str()
             quote_id = peek_quote_id(time_str, history_path=history_path, history_days=args.history_days)
             _do_render(args, state, time_str, history_path, quote_id=quote_id)
             if quote_id is not None:
-                pick_quote_module.append_history(history_path, quote_id[0], quote_id[1])
+                with state.ledger_lock:
+                    pick_quote_module.append_history(history_path, quote_id[0], quote_id[1])
         except Exception as exc:
             _log(f"un-skip failed: {exc!r}", err=True)
             append_telemetry(telemetry_path, {"bucket": current_bucket(), "error": repr(exc), "mode": "unskip"})
@@ -550,7 +578,10 @@ def _build_button_handlers(args: argparse.Namespace, state: RuntimeState) -> dic
                 except Exception as restore_exc:
                     _log(f"source card restore failed: {restore_exc!r}", err=True)
 
-            threading.Timer(5.0, restore).start()
+            timer = threading.Timer(5.0, restore)
+            # Daemon so a pending restore doesn't block process exit on SIGTERM / KeyboardInterrupt.
+            timer.daemon = True
+            timer.start()
         except Exception as exc:
             _log(f"source card failed: {exc!r}", err=True)
             append_telemetry(telemetry_path, {"bucket": current_bucket(), "error": repr(exc), "mode": "card"})
@@ -562,12 +593,23 @@ def _build_button_handlers(args: argparse.Namespace, state: RuntimeState) -> dic
         the failure is logged and the loop continues. A clean shutdown on the
         Pi requires passwordless sudo for the default ``sudo -n shutdown -h now``;
         users running without sudo can override via ``--shutdown-command``.
+
+        Order-of-operations: we flip ``state.manual_quiet`` BEFORE pushing the
+        goodnight frame so that even if the main loop wakes between our
+        ``_display_quiet_image`` call and the shutdown invocation, it takes the
+        quiet branch and (worst case) re-pushes goodnight — it can't slip a
+        normal quote onto the panel in the final seconds before poweroff.
         """
         _log("button D held: shutdown")
+        with state.lock:
+            state.manual_quiet = True
+            save_runtime_state(args.state_path, state.snapshot_for_persistence())
         try:
             if args.quiet_image:
                 with state.render_lock:
-                    _display_quiet_image(args.quiet_image, args.output, args.display_script)
+                    _display_quiet_image(
+                        args.quiet_image, args.output, args.display_script, reason="shutdown",
+                    )
         except Exception as exc:
             _log(f"shutdown pre-frame failed: {exc!r}", err=True)
         cmd = (args.shutdown_command or "").strip()
@@ -575,7 +617,6 @@ def _build_button_handlers(args: argparse.Namespace, state: RuntimeState) -> dic
             _log("shutdown: --shutdown-command is empty, skipping system shutdown")
             return
         try:
-            import shlex
             subprocess.check_call(shlex.split(cmd))
         except Exception as exc:
             _log(f"shutdown command {cmd!r} failed: {exc!r}", err=True)
@@ -672,19 +713,24 @@ def main() -> int:
 
     persisted = load_runtime_state(args.state_path)
     state = RuntimeState(args.theme, persisted=persisted)
-    # Hold the returned button list as a local for the lifetime of the loop —
-    # gpiozero drops handlers when its Button objects are garbage-collected.
-    _buttons = _maybe_start_buttons(args, state)  # noqa: F841
 
     # Startup frame: push a static image to the panel before the first quote
     # renders so viewers see something intentional instead of yesterday's
     # ghosted frame during cold boot. Best-effort; a missing file is logged
-    # and the loop continues to the first real render.
+    # and the loop continues to the first real render. Runs BEFORE the button
+    # listener starts so a press during the (potentially slow) Inky push can't
+    # collide with the unlocked display call.
     if args.startup_image:
         try:
-            _display_quiet_image(args.startup_image, args.output, args.display_script)
+            _display_quiet_image(
+                args.startup_image, args.output, args.display_script, reason="startup",
+            )
         except Exception as exc:
             _log(f"startup image display failed: {exc!r}", err=True)
+
+    # Hold the returned button list as a local for the lifetime of the loop —
+    # gpiozero drops handlers when its Button objects are garbage-collected.
+    _buttons = _maybe_start_buttons(args, state)  # noqa: F841
 
     _was_quiet = False
     while True:
@@ -757,7 +803,8 @@ def main() -> int:
                         if quote_id is not None:
                             state.last_quote_id = quote_id
                     if quote_id is not None:
-                        pick_quote_module.append_history(history_path, quote_id[0], quote_id[1])
+                        with state.ledger_lock:
+                            pick_quote_module.append_history(history_path, quote_id[0], quote_id[1])
             except Exception as exc:
                 # Keep the loop alive so a transient failure (pick_quote crash, Inky I/O,
                 # missing corpus row, etc.) does not kill the appliance. last_bucket stays

--- a/tests/test_inky_buttons.py
+++ b/tests/test_inky_buttons.py
@@ -3,7 +3,7 @@
 The hardware (``gpiozero``) is not present in CI, so these tests stub the
 ``gpiozero.Button`` import and verify that ``start_listener`` wires each label
 to the correct GPIO pin and dispatches the registered callback when ``Button``
-fires its ``when_pressed`` event.
+fires its ``when_pressed`` / ``when_held`` / ``when_released`` events.
 """
 from __future__ import annotations
 
@@ -20,11 +20,14 @@ class FakeButton:
 
     instances: list["FakeButton"] = []
 
-    def __init__(self, pin, *, pull_up=True, bounce_time=None):
+    def __init__(self, pin, *, pull_up=True, bounce_time=None, hold_time=None):
         self.pin = pin
         self.pull_up = pull_up
         self.bounce_time = bounce_time
+        self.hold_time = hold_time
         self.when_pressed = None
+        self.when_held = None
+        self.when_released = None
         FakeButton.instances.append(self)
 
 
@@ -36,18 +39,26 @@ def stub_gpiozero(monkeypatch):
     monkeypatch.setitem(sys.modules, "gpiozero", fake_module)
 
 
+def _button_for_label(buttons, label):
+    pin = inky_buttons.BUTTON_GPIO[label]
+    for obj in buttons:
+        if isinstance(obj, FakeButton) and obj.pin == pin:
+            return obj
+    raise AssertionError(f"no FakeButton for label {label}")
+
+
 class TestStartListener:
     def test_attaches_handler_to_each_label(self):
         called: list[str] = []
         handlers = {label: (lambda label=label: called.append(label)) for label in ("A", "B", "C", "D")}
         buttons = inky_buttons.start_listener(handlers)
-        assert len(buttons) == 4
-        # Wire-up: each button should be on its declared GPIO pin.
-        pins = {b.pin for b in buttons}
+        # Only FakeButton objects are expected when there are no hold handlers.
+        fake_buttons = [b for b in buttons if isinstance(b, FakeButton)]
+        assert len(fake_buttons) == 4
+        pins = {b.pin for b in fake_buttons}
         assert pins == set(inky_buttons.BUTTON_GPIO.values())
 
-        # Simulate each press and verify dispatch.
-        for button in buttons:
+        for button in fake_buttons:
             button.when_pressed()
         assert sorted(called) == ["A", "B", "C", "D"]
 
@@ -55,12 +66,18 @@ class TestStartListener:
         called: list[str] = []
         handlers = {"A": lambda: called.append("A"), "C": lambda: called.append("C")}
         buttons = inky_buttons.start_listener(handlers)
-        assert len(buttons) == 2
-        assert {b.pin for b in buttons} == {inky_buttons.BUTTON_GPIO["A"], inky_buttons.BUTTON_GPIO["C"]}
+        fake_buttons = [b for b in buttons if isinstance(b, FakeButton)]
+        assert len(fake_buttons) == 2
+        assert {b.pin for b in fake_buttons} == {inky_buttons.BUTTON_GPIO["A"], inky_buttons.BUTTON_GPIO["C"]}
 
     def test_unknown_label_raises(self):
         with pytest.raises(ValueError) as exc_info:
             inky_buttons.start_listener({"E": lambda: None})
+        assert "Unknown button" in str(exc_info.value)
+
+    def test_unknown_label_in_hold_handlers_raises(self):
+        with pytest.raises(ValueError) as exc_info:
+            inky_buttons.start_listener({}, hold_handlers={"Z": lambda: None})
         assert "Unknown button" in str(exc_info.value)
 
     def test_debounce_default_passed_through(self):
@@ -70,3 +87,71 @@ class TestStartListener:
     def test_debounce_override(self):
         inky_buttons.start_listener({"A": lambda: None}, bounce_time=1.5)
         assert FakeButton.instances[0].bounce_time == 1.5
+
+    def test_hold_time_default_passed_through(self):
+        inky_buttons.start_listener({"A": lambda: None}, hold_handlers={"A": lambda: None})
+        assert FakeButton.instances[0].hold_time == inky_buttons.DEFAULT_HOLD_SECONDS
+
+    def test_hold_time_override(self):
+        inky_buttons.start_listener(
+            {"A": lambda: None}, hold_handlers={"A": lambda: None}, hold_time=5.0,
+        )
+        assert FakeButton.instances[0].hold_time == 5.0
+
+
+class TestHoldDispatch:
+    def test_short_press_fires_short_only(self):
+        short_calls: list[str] = []
+        long_calls: list[str] = []
+        buttons = inky_buttons.start_listener(
+            {"A": lambda: short_calls.append("A")},
+            hold_handlers={"A": lambda: long_calls.append("A")},
+        )
+        button = _button_for_label(buttons, "A")
+        # Simulate a quick tap: press then release without hold firing.
+        button.when_pressed()
+        button.when_released()
+        assert short_calls == ["A"]
+        assert long_calls == []
+
+    def test_long_press_fires_long_only(self):
+        short_calls: list[str] = []
+        long_calls: list[str] = []
+        buttons = inky_buttons.start_listener(
+            {"A": lambda: short_calls.append("A")},
+            hold_handlers={"A": lambda: long_calls.append("A")},
+        )
+        button = _button_for_label(buttons, "A")
+        # Press, hold fires before release; when released the short action
+        # MUST NOT fire because the button was held long enough.
+        button.when_pressed()
+        button.when_held()
+        button.when_released()
+        assert short_calls == []
+        assert long_calls == ["A"]
+
+    def test_hold_handler_without_short_handler(self):
+        long_calls: list[str] = []
+        buttons = inky_buttons.start_listener(
+            {},  # no short actions
+            hold_handlers={"D": lambda: long_calls.append("D")},
+        )
+        button = _button_for_label(buttons, "D")
+        button.when_pressed()
+        button.when_held()
+        button.when_released()  # should not crash with no short handler
+        assert long_calls == ["D"]
+
+    def test_short_handler_without_hold_handler_uses_when_pressed(self):
+        short_calls: list[str] = []
+        buttons = inky_buttons.start_listener(
+            {"B": lambda: short_calls.append("B")},
+        )
+        button = _button_for_label(buttons, "B")
+        # When there's no hold handler, the short action fires on press (not release)
+        # — same snappy behavior we had before long-press support.
+        assert button.when_pressed is not None
+        assert button.when_held is None
+        assert button.when_released is None
+        button.when_pressed()
+        assert short_calls == ["B"]

--- a/tests/test_litclock_health.py
+++ b/tests/test_litclock_health.py
@@ -112,3 +112,74 @@ class TestMain:
         assert "1 errors" in out
         assert "render latency" in out
         assert "last error" in out
+
+
+class TestJsonOutput:
+    def test_json_flag_emits_valid_json(self, tmp_path, capsys):
+        path = _ledger(tmp_path, [
+            {"ts": _ts(5), "render_ms": 100, "display_ms": 50, "bucket": "h2_exact"},
+        ])
+        argv = ["litclock_health.py", "--telemetry-path", str(path), "--hours", "1", "--json"]
+        with patch("sys.argv", argv):
+            rc = litclock_health.main()
+        assert rc == 0
+        out = capsys.readouterr().out.strip()
+        parsed = json.loads(out)
+        assert parsed["render_count"] == 1
+        assert parsed["error_count"] == 0
+        assert parsed["hours"] == 1
+
+    def test_json_flag_on_missing_log_still_emits_json(self, tmp_path, capsys):
+        argv = [
+            "litclock_health.py", "--telemetry-path", str(tmp_path / "missing.jsonl"),
+            "--json",
+        ]
+        with patch("sys.argv", argv):
+            rc = litclock_health.main()
+        assert rc == 1
+        out = capsys.readouterr().out.strip()
+        parsed = json.loads(out)
+        assert "error" in parsed
+
+
+class TestEvaluateHealth:
+    def test_healthy_returns_zero(self):
+        summary = {"render_count": 10, "error_count": 0}
+        assert litclock_health.evaluate_health(summary, fail_if_no_renders=False) == 0
+
+    def test_errors_but_some_renders_still_healthy(self):
+        summary = {"render_count": 10, "error_count": 2}
+        assert litclock_health.evaluate_health(summary, fail_if_no_renders=False) == 0
+
+    def test_errors_and_zero_renders_is_unhealthy(self):
+        summary = {"render_count": 0, "error_count": 3}
+        assert litclock_health.evaluate_health(summary, fail_if_no_renders=False) == 2
+
+    def test_fail_if_no_renders_triggers_exit_two(self):
+        summary = {"render_count": 0, "error_count": 0}
+        assert litclock_health.evaluate_health(summary, fail_if_no_renders=True) == 2
+        assert litclock_health.evaluate_health(summary, fail_if_no_renders=False) == 0
+
+
+class TestMainExitCodes:
+    def test_errors_with_no_renders_exits_two(self, tmp_path):
+        path = _ledger(tmp_path, [
+            {"ts": _ts(5), "error": "boom", "bucket": "h2_exact"},
+        ])
+        argv = ["litclock_health.py", "--telemetry-path", str(path), "--hours", "1"]
+        with patch("sys.argv", argv):
+            rc = litclock_health.main()
+        assert rc == 2
+
+    def test_fail_if_no_renders_with_empty_window(self, tmp_path):
+        # An entry outside the --hours window leaves the window empty but the file exists.
+        path = _ledger(tmp_path, [
+            {"ts": _ts(24 * 60), "render_ms": 100, "bucket": "h2_exact"},
+        ])
+        argv = [
+            "litclock_health.py", "--telemetry-path", str(path),
+            "--hours", "1", "--fail-if-no-renders",
+        ]
+        with patch("sys.argv", argv):
+            rc = litclock_health.main()
+        assert rc == 2

--- a/tests/test_pick_quote.py
+++ b/tests/test_pick_quote.py
@@ -317,6 +317,38 @@ class TestRecentHistory:
         pq.append_history(str(path), "1234", 5678)
         assert path.exists()
 
+    def test_remove_last_history_entry_removes_most_recent_match(self, tmp_path):
+        path = tmp_path / "history.jsonl"
+        pq.append_history(str(path), "1", 1)
+        pq.append_history(str(path), "2", 2)
+        pq.append_history(str(path), "1", 1)  # duplicate — we expect this one to go
+        removed = pq.remove_last_history_entry(str(path), "1", 1)
+        assert removed is True
+        remaining = [json.loads(line) for line in path.read_text().splitlines()]
+        # The first (1, 1) entry must still be there; only the duplicate was removed.
+        assert [(e["source_id"], e["line_number"]) for e in remaining] == [("1", 1), ("2", 2)]
+
+    def test_remove_last_history_entry_returns_false_when_no_match(self, tmp_path):
+        path = tmp_path / "history.jsonl"
+        pq.append_history(str(path), "1", 1)
+        assert pq.remove_last_history_entry(str(path), "42", 99) is False
+        # Unchanged.
+        assert len(path.read_text().splitlines()) == 1
+
+    def test_remove_last_history_entry_noop_for_empty_path(self, tmp_path):
+        assert pq.remove_last_history_entry("", "1", 1) is False
+        assert pq.remove_last_history_entry(None, "1", 1) is False
+
+    def test_remove_last_history_entry_noop_when_file_missing(self, tmp_path):
+        path = tmp_path / "missing.jsonl"
+        assert pq.remove_last_history_entry(str(path), "1", 1) is False
+
+    def test_remove_last_history_entry_leaves_empty_file_when_last_removed(self, tmp_path):
+        path = tmp_path / "history.jsonl"
+        pq.append_history(str(path), "1", 1)
+        assert pq.remove_last_history_entry(str(path), "1", 1) is True
+        assert path.read_text() == ""
+
     def test_pick_best_filters_recently_shown(self):
         overrides = {"preferred_buckets": {}, "boost_source_ids": [], "ban_source_ids": []}
         fresh = make_row(fuzzy_bucket="h3_exact", source_id="1", line_number=100, quality_score=80,

--- a/tests/test_run_clock.py
+++ b/tests/test_run_clock.py
@@ -1100,6 +1100,7 @@ class TestButtonHandlers:
             telemetry_path="",
             state_path=str(tmp_path / "state.json"),
             quiet_image="",
+            shutdown_command="",
         )
         defaults.update(overrides)
         return argparse.Namespace(**defaults)
@@ -1113,8 +1114,8 @@ class TestButtonHandlers:
              patch("run_clock.current_time_str", return_value="10:00"), \
              patch("run_clock.current_bucket", return_value="h10_exact"), \
              patch("run_clock.pick_quote_module.append_history") as mock_append:
-            handlers = run_clock._build_button_handlers(args, state)
-            handlers["A"]()
+            short_handlers, _hold_handlers = run_clock._build_button_handlers(args, state)
+            short_handlers["A"]()
         # First append: ban the previous quote. Second: log the new one.
         assert mock_append.call_count == 2
         assert mock_append.call_args_list[0][0][1:] == ("src-old", 5)
@@ -1128,8 +1129,8 @@ class TestButtonHandlers:
         with patch("run_clock.render_now") as mock_render, \
              patch("run_clock.current_time_str", return_value="10:00"), \
              patch("run_clock.current_bucket", return_value="h10_exact"):
-            handlers = run_clock._build_button_handlers(args, state)
-            handlers["B"]()
+            short_handlers, _hold_handlers = run_clock._build_button_handlers(args, state)
+            short_handlers["B"]()
         assert state.manual_theme == "dark"
         persisted = json.loads((tmp_path / "state.json").read_text(encoding="utf-8"))
         assert persisted["manual_theme"] == "dark"
@@ -1147,8 +1148,8 @@ class TestButtonHandlers:
         with patch("run_clock.render_now"), \
              patch("run_clock.current_time_str", return_value="10:00"), \
              patch("run_clock.current_bucket", return_value="h10_exact"):
-            handlers = run_clock._build_button_handlers(args, state)
-            handlers["B"]()
+            short_handlers, _hold_handlers = run_clock._build_button_handlers(args, state)
+            short_handlers["B"]()
         assert state.manual_theme == "default"
 
     def test_do_render_bucket_matches_time_str_near_boundary(self, tmp_path):
@@ -1174,8 +1175,8 @@ class TestButtonHandlers:
              patch("run_clock.threading.Timer") as mock_timer, \
              patch("run_clock.current_time_str", return_value="10:00"), \
              patch("run_clock.current_bucket", return_value="h10_exact"):
-            handlers = run_clock._build_button_handlers(args, state)
-            handlers["C"]()
+            short_handlers, _hold_handlers = run_clock._build_button_handlers(args, state)
+            short_handlers["C"]()
         kwargs = mock_render.call_args[1]
         positional = mock_render.call_args[0]
         used_mode = kwargs.get("mode") or (positional[5] if len(positional) > 5 else None)
@@ -1196,8 +1197,8 @@ class TestButtonHandlers:
              patch("run_clock.threading.Timer") as mock_timer, \
              patch("run_clock.current_time_str", return_value="10:00"), \
              patch("run_clock.current_bucket", return_value="h10_exact"):
-            handlers = run_clock._build_button_handlers(args, state)
-            handlers["C"]()
+            short_handlers, _hold_handlers = run_clock._build_button_handlers(args, state)
+            short_handlers["C"]()
             # First render is the card itself.
             assert mock_render.call_count == 1
             # Now invoke the restore callback manually (simulating the 5s timer firing).
@@ -1216,8 +1217,8 @@ class TestButtonHandlers:
         state = run_clock.RuntimeState("default")
         state.manual_quiet = False
         with patch("run_clock._display_quiet_image") as mock_display:
-            handlers = run_clock._build_button_handlers(args, state)
-            handlers["D"]()
+            short_handlers, _hold_handlers = run_clock._build_button_handlers(args, state)
+            short_handlers["D"]()
         assert state.manual_quiet is True
         persisted = json.loads((tmp_path / "state.json").read_text(encoding="utf-8"))
         assert persisted["manual_quiet"] is True
@@ -1231,8 +1232,8 @@ class TestButtonHandlers:
              patch("run_clock.render_now") as mock_render, \
              patch("run_clock.current_time_str", return_value="10:00"), \
              patch("run_clock.current_bucket", return_value="h10_exact"):
-            handlers = run_clock._build_button_handlers(args, state)
-            handlers["D"]()
+            short_handlers, _hold_handlers = run_clock._build_button_handlers(args, state)
+            short_handlers["D"]()
         assert state.manual_quiet is False
         assert mock_render.called
 
@@ -1251,8 +1252,235 @@ class TestMaybeStartButtons:
             render_script="r", output="o", width=800, height=480,
             display_script=None, mode="debug", theme="default",
             history_path="", history_days=7, telemetry_path="",
-            state_path="", quiet_image="",
+            state_path="", quiet_image="", shutdown_command="",
         )
         result = run_clock._maybe_start_buttons(args, run_clock.RuntimeState("default"))
         assert result is None
         assert "button listener disabled" in capsys.readouterr().err
+
+    def test_passes_both_short_and_hold_handlers(self, tmp_path, monkeypatch):
+        captured = {}
+
+        def fake_start(handlers, *, hold_handlers=None, **kw):
+            captured["short"] = handlers
+            captured["hold"] = hold_handlers
+            return ["stub"]
+
+        import inky_buttons as ib
+        monkeypatch.setattr(ib, "start_listener", fake_start)
+        args = argparse.Namespace(
+            buttons_off=False,
+            render_script="r", output=str(tmp_path / "out.png"),
+            width=800, height=480, display_script=None, mode="debug",
+            theme="default", history_path="", history_days=7, telemetry_path="",
+            state_path="", quiet_image="", shutdown_command="",
+        )
+        result = run_clock._maybe_start_buttons(args, run_clock.RuntimeState("default"))
+        assert result == ["stub"]
+        assert set(captured["short"]) == {"A", "B", "C", "D"}
+        # Long-press is only wired on A (un-skip) and D (shutdown).
+        assert set(captured["hold"]) == {"A", "D"}
+
+
+class TestUnskipHandler:
+    """Button A held 2s: remove the last-skipped ban from the ledger and re-render."""
+
+    def _args(self, tmp_path, **overrides):
+        defaults = dict(
+            render_script="render_quote.py",
+            output=str(tmp_path / "current.png"),
+            width=800, height=480, display_script=None,
+            mode="debug", theme="default",
+            history_path=str(tmp_path / "history.jsonl"),
+            history_days=7, telemetry_path="",
+            state_path=str(tmp_path / "state.json"),
+            quiet_image="", shutdown_command="",
+        )
+        defaults.update(overrides)
+        return argparse.Namespace(**defaults)
+
+    def test_skip_records_last_skipped_in_state(self, tmp_path):
+        args = self._args(tmp_path)
+        state = run_clock.RuntimeState("default")
+        state.last_quote_id = ("src-old", 5, "q-old", "mt-old")
+        with patch("run_clock.peek_quote_id", return_value=("src-new", 7, "q-new", "mt-new")), \
+             patch("run_clock.render_now"), \
+             patch("run_clock.current_time_str", return_value="10:00"), \
+             patch("run_clock.current_bucket", return_value="h10_exact"), \
+             patch("run_clock.pick_quote_module.append_history"):
+            short, _hold = run_clock._build_button_handlers(args, state)
+            short["A"]()
+        assert state.last_skipped == ("src-old", 5, "q-old", "mt-old")
+
+    def test_unskip_removes_ledger_entry_and_rerenders(self, tmp_path):
+        args = self._args(tmp_path)
+        state = run_clock.RuntimeState("default")
+        state.last_skipped = ("src-old", 5, "q-old", "mt-old")
+        with patch("run_clock.peek_quote_id", return_value=("src-new", 7, "q-new", "mt-new")), \
+             patch("run_clock.render_now") as mock_render, \
+             patch("run_clock.current_time_str", return_value="10:00"), \
+             patch("run_clock.current_bucket", return_value="h10_exact"), \
+             patch("run_clock.pick_quote_module.remove_last_history_entry", return_value=True) as mock_rm, \
+             patch("run_clock.pick_quote_module.append_history") as mock_append:
+            _short, hold = run_clock._build_button_handlers(args, state)
+            hold["A"]()
+        # Removed the ban.
+        assert mock_rm.called
+        assert mock_rm.call_args[0][1:] == ("src-old", 5)
+        # State cleared so double-press doesn't double-remove.
+        assert state.last_skipped is None
+        # Re-rendered the current time.
+        assert mock_render.called
+        # Logged the new pick in history.
+        assert mock_append.called
+
+    def test_unskip_noop_when_no_last_skipped(self, tmp_path, capsys):
+        args = self._args(tmp_path)
+        state = run_clock.RuntimeState("default")
+        state.last_skipped = None
+        with patch("run_clock.render_now") as mock_render, \
+             patch("run_clock.pick_quote_module.remove_last_history_entry") as mock_rm:
+            _short, hold = run_clock._build_button_handlers(args, state)
+            hold["A"]()
+        assert not mock_rm.called
+        assert not mock_render.called
+        assert "no recently-skipped" in capsys.readouterr().out
+
+
+class TestShutdownHandler:
+    """Button D held 2s: goodnight frame, then invoke shutdown command."""
+
+    def _args(self, tmp_path, **overrides):
+        defaults = dict(
+            render_script="render_quote.py",
+            output=str(tmp_path / "current.png"),
+            width=800, height=480, display_script=None,
+            mode="debug", theme="default",
+            history_path="", history_days=7, telemetry_path="",
+            state_path="", quiet_image="",
+            shutdown_command="sudo -n shutdown -h now",
+        )
+        defaults.update(overrides)
+        return argparse.Namespace(**defaults)
+
+    def test_shutdown_invokes_configured_command(self, tmp_path):
+        args = self._args(tmp_path)
+        state = run_clock.RuntimeState("default")
+        with patch("run_clock.subprocess.check_call") as mock_check, \
+             patch("run_clock.current_bucket", return_value="h10_exact"):
+            _short, hold = run_clock._build_button_handlers(args, state)
+            hold["D"]()
+        assert mock_check.called
+        cmd = mock_check.call_args[0][0]
+        assert cmd == ["sudo", "-n", "shutdown", "-h", "now"]
+
+    def test_empty_shutdown_command_skips_invocation(self, tmp_path, capsys):
+        args = self._args(tmp_path, shutdown_command="")
+        state = run_clock.RuntimeState("default")
+        with patch("run_clock.subprocess.check_call") as mock_check, \
+             patch("run_clock.current_bucket", return_value="h10_exact"):
+            _short, hold = run_clock._build_button_handlers(args, state)
+            hold["D"]()
+        assert not mock_check.called
+        assert "skipping system shutdown" in capsys.readouterr().out
+
+    def test_shutdown_displays_goodnight_first(self, tmp_path):
+        quiet = tmp_path / "goodnight.png"
+        quiet.write_bytes(b"\x89PNG")
+        args = self._args(tmp_path, quiet_image=str(quiet))
+        state = run_clock.RuntimeState("default")
+        with patch("run_clock._display_quiet_image") as mock_display, \
+             patch("run_clock.subprocess.check_call"), \
+             patch("run_clock.current_bucket", return_value="h10_exact"):
+            _short, hold = run_clock._build_button_handlers(args, state)
+            hold["D"]()
+        assert mock_display.called
+
+    def test_shutdown_command_failure_is_logged_not_raised(self, tmp_path, capsys):
+        args = self._args(tmp_path)
+        state = run_clock.RuntimeState("default")
+        with patch("run_clock.subprocess.check_call", side_effect=RuntimeError("nope")), \
+             patch("run_clock.current_bucket", return_value="h10_exact"):
+            _short, hold = run_clock._build_button_handlers(args, state)
+            # Must not raise.
+            hold["D"]()
+        assert "shutdown command" in capsys.readouterr().err
+
+
+class TestStartupImage:
+    """--startup-image: push a static PNG before the first real render on boot."""
+
+    def test_startup_image_pushed_when_set(self, tmp_path):
+        startup = tmp_path / "starting.png"
+        startup.write_bytes(b"\x89PNG")
+        argv = [
+            "run_clock.py",
+            "--once",
+            "--startup-image", str(startup),
+            "--output", str(tmp_path / "out.png"),
+            "--history-path", "",
+            "--telemetry-path", "",
+            "--state-path", "",
+        ]
+        # --once skips the startup image (it's for the loop). Verify parse accepts.
+        with patch("sys.argv", argv):
+            args = run_clock.parse_args()
+        assert args.startup_image == str(startup)
+
+    def test_startup_image_used_in_main_loop_path(self, tmp_path, monkeypatch):
+        """When --startup-image is set and --once is not, main() calls _display_quiet_image
+        once before entering the loop, then the loop body can be aborted via a stub.
+        """
+        startup = tmp_path / "starting.png"
+        startup.write_bytes(b"\x89PNG")
+        argv = [
+            "run_clock.py",
+            "--startup-image", str(startup),
+            "--output", str(tmp_path / "out.png"),
+            "--buttons-off",
+            "--history-path", "", "--telemetry-path", "",
+            "--state-path", "",
+            "--quiet-off",
+            "--interval-seconds", "1",
+        ]
+        calls = []
+
+        def fake_display(quiet_image, output, display_script):
+            calls.append(("display", quiet_image))
+
+        def fake_sleep(_):
+            raise KeyboardInterrupt
+
+        monkeypatch.setattr(run_clock, "_display_quiet_image", fake_display)
+        monkeypatch.setattr(run_clock.time, "sleep", fake_sleep)
+        with patch("sys.argv", argv), \
+             patch("run_clock.render_now") as mock_render, \
+             patch("run_clock.peek_quote_id", return_value=("src", 1, "q", "mt")):
+            with pytest.raises(KeyboardInterrupt):
+                run_clock.main()
+        # Startup image was pushed before any render.
+        assert any(c[0] == "display" for c in calls)
+        # And normal render still ran for the first tick.
+        assert mock_render.called
+
+    def test_no_startup_image_when_flag_omitted(self, tmp_path, monkeypatch):
+        argv = [
+            "run_clock.py",
+            "--output", str(tmp_path / "out.png"),
+            "--buttons-off",
+            "--history-path", "", "--telemetry-path", "",
+            "--state-path", "", "--quiet-off",
+            "--interval-seconds", "1",
+        ]
+        displayed = []
+        monkeypatch.setattr(
+            run_clock, "_display_quiet_image",
+            lambda q, o, d: displayed.append(q),
+        )
+        monkeypatch.setattr(run_clock.time, "sleep", lambda _: (_ for _ in ()).throw(KeyboardInterrupt))
+        with patch("sys.argv", argv), \
+             patch("run_clock.render_now"), \
+             patch("run_clock.peek_quote_id", return_value=None):
+            with pytest.raises(KeyboardInterrupt):
+                run_clock.main()
+        assert displayed == []

--- a/tests/test_run_clock.py
+++ b/tests/test_run_clock.py
@@ -1406,6 +1406,41 @@ class TestShutdownHandler:
             hold["D"]()
         assert "shutdown command" in capsys.readouterr().err
 
+    def test_shutdown_flips_manual_quiet_before_goodnight_push(self, tmp_path):
+        """P1 regression: manual_quiet must be set before the goodnight push
+        so a concurrent main-loop tick takes the quiet branch and cannot slip a
+        normal render between the goodnight frame and the shutdown invocation.
+        """
+        quiet = tmp_path / "goodnight.png"
+        quiet.write_bytes(b"\x89PNG")
+        args = self._args(tmp_path, quiet_image=str(quiet))
+        state = run_clock.RuntimeState("default")
+        seen_flag_at_display = []
+
+        def record_display(*a, **kw):
+            seen_flag_at_display.append(state.manual_quiet)
+
+        with patch("run_clock._display_quiet_image", side_effect=record_display), \
+             patch("run_clock.subprocess.check_call"), \
+             patch("run_clock.current_bucket", return_value="h10_exact"):
+            _short, hold = run_clock._build_button_handlers(args, state)
+            hold["D"]()
+        assert seen_flag_at_display == [True]
+
+    def test_shutdown_passes_reason_to_quiet_display(self, tmp_path):
+        """Log label for the goodnight push must distinguish shutdown from quiet hours."""
+        quiet = tmp_path / "goodnight.png"
+        quiet.write_bytes(b"\x89PNG")
+        args = self._args(tmp_path, quiet_image=str(quiet))
+        state = run_clock.RuntimeState("default")
+        with patch("run_clock._display_quiet_image") as mock_display, \
+             patch("run_clock.subprocess.check_call"), \
+             patch("run_clock.current_bucket", return_value="h10_exact"):
+            _short, hold = run_clock._build_button_handlers(args, state)
+            hold["D"]()
+        kwargs = mock_display.call_args.kwargs
+        assert kwargs.get("reason") == "shutdown"
+
 
 class TestStartupImage:
     """--startup-image: push a static PNG before the first real render on boot."""
@@ -1445,8 +1480,8 @@ class TestStartupImage:
         ]
         calls = []
 
-        def fake_display(quiet_image, output, display_script):
-            calls.append(("display", quiet_image))
+        def fake_display(quiet_image, output, display_script, **kwargs):
+            calls.append(("display", quiet_image, kwargs.get("reason")))
 
         def fake_sleep(_):
             raise KeyboardInterrupt
@@ -1463,6 +1498,43 @@ class TestStartupImage:
         # And normal render still ran for the first tick.
         assert mock_render.called
 
+    def test_startup_image_pushed_before_buttons_start(self, tmp_path, monkeypatch):
+        """P1 regression: startup-frame push must happen BEFORE the button
+        listener starts, so a press during the (slow) Inky push cannot race
+        against the unlocked display call.
+        """
+        startup = tmp_path / "starting.png"
+        startup.write_bytes(b"\x89PNG")
+        argv = [
+            "run_clock.py",
+            "--startup-image", str(startup),
+            "--output", str(tmp_path / "out.png"),
+            "--history-path", "", "--telemetry-path", "",
+            "--state-path", "", "--quiet-off",
+            "--interval-seconds", "1",
+        ]
+        order = []
+
+        def fake_display(*a, **kw):
+            order.append(("display", kw.get("reason")))
+
+        def fake_start_buttons(*a, **kw):
+            order.append(("buttons",))
+            return []
+
+        monkeypatch.setattr(run_clock, "_display_quiet_image", fake_display)
+        monkeypatch.setattr(run_clock, "_maybe_start_buttons", fake_start_buttons)
+        monkeypatch.setattr(run_clock.time, "sleep", lambda _: (_ for _ in ()).throw(KeyboardInterrupt))
+        with patch("sys.argv", argv), \
+             patch("run_clock.render_now"), \
+             patch("run_clock.peek_quote_id", return_value=("s", 1, "q", "m")):
+            with pytest.raises(KeyboardInterrupt):
+                run_clock.main()
+        # Startup display must precede button listener.
+        assert order[0] == ("display", "startup")
+        assert ("buttons",) in order
+        assert order.index(("display", "startup")) < order.index(("buttons",))
+
     def test_no_startup_image_when_flag_omitted(self, tmp_path, monkeypatch):
         argv = [
             "run_clock.py",
@@ -1475,7 +1547,7 @@ class TestStartupImage:
         displayed = []
         monkeypatch.setattr(
             run_clock, "_display_quiet_image",
-            lambda q, o, d: displayed.append(q),
+            lambda q, o, d, **kw: displayed.append(q),
         )
         monkeypatch.setattr(run_clock.time, "sleep", lambda _: (_ for _ in ()).throw(KeyboardInterrupt))
         with patch("sys.argv", argv), \

--- a/tests/test_run_clock.py
+++ b/tests/test_run_clock.py
@@ -1384,6 +1384,22 @@ class TestShutdownHandler:
         assert not mock_check.called
         assert "skipping system shutdown" in capsys.readouterr().out
 
+    def test_empty_shutdown_command_does_not_flip_quiet(self, tmp_path):
+        """When shutdown is disabled, an accidental long-press must not leave
+        the clock stuck in manual quiet mode (which would persist across restarts)."""
+        args = self._args(tmp_path, shutdown_command="")
+        state = run_clock.RuntimeState("default")
+        assert state.manual_quiet is False
+        with patch("run_clock._display_quiet_image") as mock_display, \
+             patch("run_clock.subprocess.check_call"), \
+             patch("run_clock.save_runtime_state") as mock_save, \
+             patch("run_clock.current_bucket", return_value="h10_exact"):
+            _short, hold = run_clock._build_button_handlers(args, state)
+            hold["D"]()
+        assert state.manual_quiet is False
+        assert not mock_display.called
+        assert not mock_save.called
+
     def test_shutdown_displays_goodnight_first(self, tmp_path):
         quiet = tmp_path / "goodnight.png"
         quiet.write_bytes(b"\x89PNG")


### PR DESCRIPTION
Three on-device UX polish items on top of the v1 buttons plan:

- **Button long-press** (`inky_buttons.py`): `_HoldDispatcher` routes
  press/hold/release events so a 2s hold fires only the hold callback,
  and a quick tap fires only the short callback. `run_clock.py` wires:
  - A hold → un-skip (removes the last-skipped entry from the history
    ledger via `pick_quote.remove_last_history_entry` and re-renders).
  - D hold → goodnight frame + `--shutdown-command` (default
    `sudo -n shutdown -h now`; pass an empty string to disable).

- **`litclock_health.py`** gains `--json` (machine-readable summary for
  cron / systemd) and exit-code semantics: 0 healthy, 1 missing log,
  2 unhealthy (errors + zero renders, or `--fail-if-no-renders` with a
  silent window).

- **Startup frame** (`--startup-image`): optional PNG pushed once before
  the first quote render so a cold boot doesn't ghost yesterday's frame.
  Off by default since the extra Spectra 6 refresh isn't always worth it.

Docs updated: CLAUDE.md, README.md, pi_setup_inky_impression.md, and
litclock.service.example all reflect the new flags and button behavior.

Test suite grows 522 tests (from 491); ruff clean.

https://claude.ai/code/session_011JgtvJtDD567eEkZYFwXvC