### PR TITLE
Drop-on-busy gate for button presses, per-press GPIO logging, probe_buttons.py

### DIFF
--- a/inky_buttons.py
+++ b/inky_buttons.py
@@ -64,6 +64,7 @@ def start_listener(
     hold_handlers: Mapping[str, Callable[[], None]] | None = None,
     hold_time: float = DEFAULT_HOLD_SECONDS,
     bounce_time: float = DEBOUNCE_SECONDS,
+    press_logger: Callable[[str, int], None] | None = None,
 ) -> list:
     """Attach ``handlers[label]`` (short press) and optional ``hold_handlers[label]``
     (long press, ``hold_time`` seconds) to each Inky button.
@@ -75,6 +76,11 @@ def start_listener(
     dispatcher refs) so the caller can keep them alive for the lifetime of the
     process — ``gpiozero`` drops handlers when the ``Button`` is
     garbage-collected.
+
+    ``press_logger``, if provided, is called as ``press_logger(label, gpio_pin)``
+    on every hardware press — runs before the short/long dispatch and can't be
+    suppressed by handler exceptions. Use it to verify that a physical button
+    is actually wired to the expected GPIO pin before blaming the handler.
     """
     hold_handlers = dict(hold_handlers or {})
     labels = set(handlers) | set(hold_handlers)
@@ -90,19 +96,32 @@ def start_listener(
     for label in sorted(labels):
         short = handlers.get(label)
         long_ = hold_handlers.get(label)
+        pin = BUTTON_GPIO[label]
         button = Button(
-            BUTTON_GPIO[label],
+            pin,
             pull_up=True,
             bounce_time=bounce_time,
             hold_time=hold_time,
         )
+
+        def _make_press_cb(lbl: str, p: int, dispatch: Callable[[], None] | None):
+            def _cb() -> None:
+                if press_logger is not None:
+                    try:
+                        press_logger(lbl, p)
+                    except Exception:
+                        pass
+                if dispatch is not None:
+                    dispatch()
+            return _cb
+
         if long_ is None:
             # No hold handler: keep the simple press-fires-immediately path so
             # single-action buttons stay snappy.
-            button.when_pressed = short
+            button.when_pressed = _make_press_cb(label, pin, short)
         else:
             dispatcher = _HoldDispatcher(short, long_)
-            button.when_pressed = dispatcher.on_press
+            button.when_pressed = _make_press_cb(label, pin, dispatcher.on_press)
             button.when_held = dispatcher.on_hold
             button.when_released = dispatcher.on_release
             keepalive.append(dispatcher)

--- a/probe_buttons.py
+++ b/probe_buttons.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Standalone GPIO press probe for the Inky Impression.
+
+Run on the Pi and press each physical button in turn. Each press prints a
+timestamped line showing which GPIO pin fired, so you can verify the wiring
+before blaming ``inky_buttons.BUTTON_GPIO``.
+
+Usage:
+    python3 probe_buttons.py
+    python3 probe_buttons.py --pins 5 6 16 24 17 13 26  # custom pin set
+
+The default candidate set is the standard Inky Impression pins (5, 6, 16, 24)
+plus a handful of common alternates (13, 17, 26) in case your panel variant
+wires its buttons somewhere else. Pins actively used by the Inky display
+(SPI 8-11, BUSY 17 on some variants, DC/RESET) are deliberately skipped from
+the defaults — override with ``--pins`` if you want to probe them anyway.
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import signal
+import sys
+
+DEFAULT_PINS = [5, 6, 16, 24, 13, 26]
+
+
+def _log(msg: str) -> None:
+    print(f"[{dt.datetime.now().isoformat(timespec='seconds')}] {msg}", flush=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--pins",
+        type=int,
+        nargs="+",
+        default=DEFAULT_PINS,
+        help=f"GPIO BCM pin numbers to probe (default: {DEFAULT_PINS}).",
+    )
+    parser.add_argument(
+        "--pull-down",
+        action="store_true",
+        help="Attach with pull_up=False (active-high buttons). Default is pull_up=True.",
+    )
+    parser.add_argument(
+        "--bounce",
+        type=float,
+        default=0.05,
+        help="Debounce window in seconds (default: 0.05 — low so the probe is responsive).",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        from gpiozero import Button
+    except ImportError as exc:
+        print(f"gpiozero not available: {exc}. Install with `pip install gpiozero` (+ lgpio on Pi 5).", file=sys.stderr)
+        return 1
+
+    buttons = []
+    for pin in args.pins:
+        try:
+            btn = Button(pin, pull_up=not args.pull_down, bounce_time=args.bounce)
+            btn.when_pressed = lambda p=pin: _log(f"GPIO {p}: PRESSED")
+            btn.when_released = lambda p=pin: _log(f"GPIO {p}: released")
+            buttons.append(btn)
+            _log(f"listening on GPIO {pin}")
+        except Exception as exc:
+            _log(f"GPIO {pin}: attach FAILED ({exc!r})")
+
+    if not buttons:
+        print("No pins attached. Aborting.", file=sys.stderr)
+        return 1
+
+    _log("Ready. Press each physical button on the Inky panel. Ctrl-C to quit.")
+    try:
+        signal.pause()
+    except KeyboardInterrupt:
+        _log("Exiting.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/run_clock.py
+++ b/run_clock.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import contextlib
 import datetime as dt
 import json
 import shlex
@@ -445,31 +446,61 @@ def render_now(
         )
 
 
-def _do_render(args: argparse.Namespace, state: RuntimeState, time_str: str, history_path: str | None,
-               mode: str | None = None, bucket: str | None = None, quote_id: tuple | None = None) -> None:
-    """Render-and-push, holding the render lock so the main loop and button handlers don't collide.
+def _render_unlocked(args: argparse.Namespace, state: RuntimeState, time_str: str, history_path: str | None,
+                     mode: str | None = None, bucket: str | None = None, quote_id: tuple | None = None) -> None:
+    """Core render-and-push. The caller MUST already hold ``state.render_lock``.
 
-    Updates ``state.last_bucket``/``last_quote_id``/``last_effective_theme`` to the values
-    actually rendered so the loop's next tick sees consistent state. The bucket is
-    derived from ``time_str`` rather than from a fresh wall-clock read so a handler
-    firing near a bucket boundary can't stamp the wrong bucket into state (which
-    would make the next loop tick wrongly skip the expected redraw).
+    Split out from :func:`_do_render` so a button handler can take the render
+    lock non-blocking via :func:`_button_render_gate`, hold it for the handler's
+    full duration (state mutations + render + display push), and drop follow-up
+    presses that land while a 10–20 s Spectra 6 refresh is still in flight
+    instead of queuing behind it.
     """
     effective_theme = resolve_effective_theme(state.theme_arg, time_str, state.manual_theme)
     actual_mode = mode or args.mode
     actual_bucket = bucket or bucket_for_time(time_str)
+    render_now(
+        args.render_script, args.output, args.width, args.height, args.display_script,
+        actual_mode, effective_theme, time_str=time_str,
+        history_path=history_path, history_days=args.history_days,
+        telemetry_path=args.telemetry_path or None, bucket=actual_bucket, quote_id=quote_id,
+    )
+    with state.lock:
+        state.last_bucket = actual_bucket
+        state.last_effective_theme = effective_theme
+        if quote_id is not None:
+            state.last_quote_id = quote_id
+
+
+def _do_render(args: argparse.Namespace, state: RuntimeState, time_str: str, history_path: str | None,
+               mode: str | None = None, bucket: str | None = None, quote_id: tuple | None = None) -> None:
+    """Blocking render-and-push. Acquires ``state.render_lock`` and delegates to
+    :func:`_render_unlocked`. Used by the source-card restore timer (which must
+    not be dropped, or the card would stay up) and tests.
+    """
     with state.render_lock:
-        render_now(
-            args.render_script, args.output, args.width, args.height, args.display_script,
-            actual_mode, effective_theme, time_str=time_str,
-            history_path=history_path, history_days=args.history_days,
-            telemetry_path=args.telemetry_path or None, bucket=actual_bucket, quote_id=quote_id,
-        )
-        with state.lock:
-            state.last_bucket = actual_bucket
-            state.last_effective_theme = effective_theme
-            if quote_id is not None:
-                state.last_quote_id = quote_id
+        _render_unlocked(args, state, time_str, history_path, mode=mode, bucket=bucket, quote_id=quote_id)
+
+
+@contextlib.contextmanager
+def _button_render_gate(state: RuntimeState, name: str):
+    """Try-acquire ``state.render_lock`` for a button handler.
+
+    Yields ``True`` if the lock was acquired (caller does its work; the gate
+    releases on exit) or ``False`` if a render is already in flight, in which
+    case the press is logged and dropped. This coalesces a rapid tap-tap-tap
+    down to "first wins, rest are no-ops" — without it, gpiozero queues
+    subsequent events behind the slow eInk refresh and the user sees
+    unpredictable multi-second delays.
+    """
+    if not state.render_lock.acquire(blocking=False):
+        _log(f"button {name}: busy (render in flight), press ignored")
+        yield False
+        return
+    try:
+        yield True
+    finally:
+        state.render_lock.release()
 
 
 def _build_button_handlers(
@@ -489,26 +520,29 @@ def _build_button_handlers(
     telemetry_path = args.telemetry_path or None
 
     def on_skip() -> None:
-        _log("button A: skip")
-        try:
-            with state.lock:
-                previous = state.last_quote_id
-            if previous is not None:
-                # Ban the currently-shown quote so the next pick filters it out for the week.
-                with state.ledger_lock:
-                    pick_quote_module.append_history(history_path, previous[0], previous[1])
+        with _button_render_gate(state, "A (skip)") as acquired:
+            if not acquired:
+                return
+            _log("button A: skip")
+            try:
                 with state.lock:
-                    # Remember what we just banned so A long-press can reverse it.
-                    state.last_skipped = previous
-            time_str = current_time_str()
-            quote_id = peek_quote_id(time_str, history_path=history_path, history_days=args.history_days)
-            _do_render(args, state, time_str, history_path, quote_id=quote_id)
-            if quote_id is not None:
-                with state.ledger_lock:
-                    pick_quote_module.append_history(history_path, quote_id[0], quote_id[1])
-        except Exception as exc:
-            _log(f"skip failed: {exc!r}", err=True)
-            append_telemetry(telemetry_path, {"bucket": current_bucket(), "error": repr(exc), "mode": "skip"})
+                    previous = state.last_quote_id
+                if previous is not None:
+                    # Ban the currently-shown quote so the next pick filters it out for the week.
+                    with state.ledger_lock:
+                        pick_quote_module.append_history(history_path, previous[0], previous[1])
+                    with state.lock:
+                        # Remember what we just banned so A long-press can reverse it.
+                        state.last_skipped = previous
+                time_str = current_time_str()
+                quote_id = peek_quote_id(time_str, history_path=history_path, history_days=args.history_days)
+                _render_unlocked(args, state, time_str, history_path, quote_id=quote_id)
+                if quote_id is not None:
+                    with state.ledger_lock:
+                        pick_quote_module.append_history(history_path, quote_id[0], quote_id[1])
+            except Exception as exc:
+                _log(f"skip failed: {exc!r}", err=True)
+                append_telemetry(telemetry_path, {"bucket": current_bucket(), "error": repr(exc), "mode": "skip"})
 
     def on_unskip() -> None:
         """Button A held 2s: reverse the most recent skip.
@@ -521,70 +555,80 @@ def _build_button_handlers(
         serialised against the main loop's ``append_history`` via
         ``state.ledger_lock`` so a concurrent append is not silently lost.
         """
-        _log("button A held: un-skip")
-        try:
-            with state.lock:
-                target = state.last_skipped
-                state.last_skipped = None
-            if target is None:
-                _log("un-skip: no recently-skipped quote recorded")
+        with _button_render_gate(state, "A (unskip)") as acquired:
+            if not acquired:
                 return
-            with state.ledger_lock:
-                removed = pick_quote_module.remove_last_history_entry(history_path, target[0], target[1])
-            _log(f"un-skip: removed ledger entry for source={target[0]} line={target[1]} ok={removed}")
-            time_str = current_time_str()
-            quote_id = peek_quote_id(time_str, history_path=history_path, history_days=args.history_days)
-            _do_render(args, state, time_str, history_path, quote_id=quote_id)
-            if quote_id is not None:
+            _log("button A held: un-skip")
+            try:
+                with state.lock:
+                    target = state.last_skipped
+                    state.last_skipped = None
+                if target is None:
+                    _log("un-skip: no recently-skipped quote recorded")
+                    return
                 with state.ledger_lock:
-                    pick_quote_module.append_history(history_path, quote_id[0], quote_id[1])
-        except Exception as exc:
-            _log(f"un-skip failed: {exc!r}", err=True)
-            append_telemetry(telemetry_path, {"bucket": current_bucket(), "error": repr(exc), "mode": "unskip"})
+                    removed = pick_quote_module.remove_last_history_entry(history_path, target[0], target[1])
+                _log(f"un-skip: removed ledger entry for source={target[0]} line={target[1]} ok={removed}")
+                time_str = current_time_str()
+                quote_id = peek_quote_id(time_str, history_path=history_path, history_days=args.history_days)
+                _render_unlocked(args, state, time_str, history_path, quote_id=quote_id)
+                if quote_id is not None:
+                    with state.ledger_lock:
+                        pick_quote_module.append_history(history_path, quote_id[0], quote_id[1])
+            except Exception as exc:
+                _log(f"un-skip failed: {exc!r}", err=True)
+                append_telemetry(telemetry_path, {"bucket": current_bucket(), "error": repr(exc), "mode": "unskip"})
 
     def on_toggle_theme() -> None:
-        try:
-            time_str = current_time_str()
-            with state.lock:
-                current = state.last_effective_theme or resolve_effective_theme(
-                    state.theme_arg, time_str, state.manual_theme,
-                )
-                state.manual_theme = "dark" if current == "default" else "default"
-                save_runtime_state(args.state_path, state.snapshot_for_persistence())
-                quote_id = state.last_quote_id
-            _log(f"button B: theme -> {state.manual_theme}")
-            _do_render(args, state, time_str, history_path, quote_id=quote_id)
-        except Exception as exc:
-            _log(f"theme toggle failed: {exc!r}", err=True)
-            append_telemetry(telemetry_path, {"bucket": current_bucket(), "error": repr(exc), "mode": "theme"})
+        with _button_render_gate(state, "B (theme)") as acquired:
+            if not acquired:
+                return
+            try:
+                time_str = current_time_str()
+                with state.lock:
+                    current = state.last_effective_theme or resolve_effective_theme(
+                        state.theme_arg, time_str, state.manual_theme,
+                    )
+                    state.manual_theme = "dark" if current == "default" else "default"
+                    save_runtime_state(args.state_path, state.snapshot_for_persistence())
+                    quote_id = state.last_quote_id
+                _log(f"button B: theme -> {state.manual_theme}")
+                _render_unlocked(args, state, time_str, history_path, quote_id=quote_id)
+            except Exception as exc:
+                _log(f"theme toggle failed: {exc!r}", err=True)
+                append_telemetry(telemetry_path, {"bucket": current_bucket(), "error": repr(exc), "mode": "theme"})
 
     def on_source_card() -> None:
-        _log("button C: source card")
-        try:
-            time_str = current_time_str()
-            quote_id = peek_quote_id(time_str, history_path=history_path, history_days=args.history_days)
-            _do_render(args, state, time_str, history_path, mode="card", quote_id=quote_id)
+        with _button_render_gate(state, "C (card)") as acquired:
+            if not acquired:
+                return
+            _log("button C: source card")
+            try:
+                time_str = current_time_str()
+                quote_id = peek_quote_id(time_str, history_path=history_path, history_days=args.history_days)
+                _render_unlocked(args, state, time_str, history_path, mode="card", quote_id=quote_id)
 
-            def restore() -> None:
-                # The card needs to come down at the 5-second mark — relying on the
-                # next loop tick would leave it up for up to --interval-seconds (60s
-                # default). Re-pick (the bucket may have moved during the 5s) and
-                # render the normal frame ourselves; render_lock serializes us
-                # against the loop.
-                try:
-                    rs_time = current_time_str()
-                    rs_quote = peek_quote_id(rs_time, history_path=history_path, history_days=args.history_days)
-                    _do_render(args, state, rs_time, history_path, quote_id=rs_quote)
-                except Exception as restore_exc:
-                    _log(f"source card restore failed: {restore_exc!r}", err=True)
+                def restore() -> None:
+                    # The card needs to come down at the 5-second mark — relying on the
+                    # next loop tick would leave it up for up to --interval-seconds (60s
+                    # default). Re-pick (the bucket may have moved during the 5s) and
+                    # render the normal frame ourselves via the BLOCKING _do_render so
+                    # the card is guaranteed to be taken down even if another handler
+                    # has the render lock at the 5s mark.
+                    try:
+                        rs_time = current_time_str()
+                        rs_quote = peek_quote_id(rs_time, history_path=history_path, history_days=args.history_days)
+                        _do_render(args, state, rs_time, history_path, quote_id=rs_quote)
+                    except Exception as restore_exc:
+                        _log(f"source card restore failed: {restore_exc!r}", err=True)
 
-            timer = threading.Timer(5.0, restore)
-            # Daemon so a pending restore doesn't block process exit on SIGTERM / KeyboardInterrupt.
-            timer.daemon = True
-            timer.start()
-        except Exception as exc:
-            _log(f"source card failed: {exc!r}", err=True)
-            append_telemetry(telemetry_path, {"bucket": current_bucket(), "error": repr(exc), "mode": "card"})
+                timer = threading.Timer(5.0, restore)
+                # Daemon so a pending restore doesn't block process exit on SIGTERM / KeyboardInterrupt.
+                timer.daemon = True
+                timer.start()
+            except Exception as exc:
+                _log(f"source card failed: {exc!r}", err=True)
+                append_telemetry(telemetry_path, {"bucket": current_bucket(), "error": repr(exc), "mode": "card"})
 
     def on_shutdown() -> None:
         """Button D held 2s: display the goodnight frame and invoke the shutdown command.
@@ -609,46 +653,50 @@ def _build_button_handlers(
         if not cmd:
             _log("button D held: --shutdown-command is empty, skipping system shutdown")
             return
-        _log("button D held: shutdown")
-        with state.lock:
-            state.manual_quiet = True
-            save_runtime_state(args.state_path, state.snapshot_for_persistence())
-        try:
-            if args.quiet_image:
-                with state.render_lock:
+        with _button_render_gate(state, "D (shutdown)") as acquired:
+            if not acquired:
+                return
+            _log("button D held: shutdown")
+            with state.lock:
+                state.manual_quiet = True
+                save_runtime_state(args.state_path, state.snapshot_for_persistence())
+            try:
+                if args.quiet_image:
                     _display_quiet_image(
                         args.quiet_image, args.output, args.display_script, reason="shutdown",
                     )
-        except Exception as exc:
-            _log(f"shutdown pre-frame failed: {exc!r}", err=True)
-        try:
-            subprocess.check_call(shlex.split(cmd))
-        except Exception as exc:
-            _log(f"shutdown command {cmd!r} failed: {exc!r}", err=True)
-            append_telemetry(telemetry_path, {"bucket": current_bucket(), "error": repr(exc), "mode": "shutdown"})
+            except Exception as exc:
+                _log(f"shutdown pre-frame failed: {exc!r}", err=True)
+            try:
+                subprocess.check_call(shlex.split(cmd))
+            except Exception as exc:
+                _log(f"shutdown command {cmd!r} failed: {exc!r}", err=True)
+                append_telemetry(telemetry_path, {"bucket": current_bucket(), "error": repr(exc), "mode": "shutdown"})
 
     def on_quiet_toggle() -> None:
-        try:
-            with state.lock:
-                state.manual_quiet = not state.manual_quiet
-                save_runtime_state(args.state_path, state.snapshot_for_persistence())
-                state.last_bucket = None  # force the loop to repaint on exit
-                state.last_quote_id = None
-                # Snapshot inside the lock so a concurrent toggle can't flip the
-                # branch we take below.
-                quiet_now = state.manual_quiet
-            _log(f"button D: manual quiet -> {quiet_now}")
-            if quiet_now and args.quiet_image:
-                with state.render_lock:
+        with _button_render_gate(state, "D (quiet)") as acquired:
+            if not acquired:
+                return
+            try:
+                with state.lock:
+                    state.manual_quiet = not state.manual_quiet
+                    save_runtime_state(args.state_path, state.snapshot_for_persistence())
+                    state.last_bucket = None  # force the loop to repaint on exit
+                    state.last_quote_id = None
+                    # Snapshot inside the lock so a concurrent toggle can't flip the
+                    # branch we take below.
+                    quiet_now = state.manual_quiet
+                _log(f"button D: manual quiet -> {quiet_now}")
+                if quiet_now and args.quiet_image:
                     _display_quiet_image(args.quiet_image, args.output, args.display_script)
-            elif not quiet_now:
-                # Wake to the current time so the user sees something immediately.
-                time_str = current_time_str()
-                quote_id = peek_quote_id(time_str, history_path=history_path, history_days=args.history_days)
-                _do_render(args, state, time_str, history_path, quote_id=quote_id)
-        except Exception as exc:
-            _log(f"quiet toggle failed: {exc!r}", err=True)
-            append_telemetry(telemetry_path, {"bucket": current_bucket(), "error": repr(exc), "mode": "quiet"})
+                elif not quiet_now:
+                    # Wake to the current time so the user sees something immediately.
+                    time_str = current_time_str()
+                    quote_id = peek_quote_id(time_str, history_path=history_path, history_days=args.history_days)
+                    _render_unlocked(args, state, time_str, history_path, quote_id=quote_id)
+            except Exception as exc:
+                _log(f"quiet toggle failed: {exc!r}", err=True)
+                append_telemetry(telemetry_path, {"bucket": current_bucket(), "error": repr(exc), "mode": "quiet"})
 
     short_handlers = {
         "A": on_skip,
@@ -670,7 +718,13 @@ def _maybe_start_buttons(args: argparse.Namespace, state: RuntimeState):
     try:
         import inky_buttons
         short_handlers, hold_handlers = _build_button_handlers(args, state)
-        return inky_buttons.start_listener(short_handlers, hold_handlers=hold_handlers)
+
+        def _press_logger(label: str, pin: int) -> None:
+            _log(f"button {label} (GPIO {pin}): pressed")
+
+        return inky_buttons.start_listener(
+            short_handlers, hold_handlers=hold_handlers, press_logger=_press_logger,
+        )
     except Exception as exc:
         _log(f"button listener disabled ({exc!r}); pass --buttons-off to silence", err=True)
         return None

--- a/tests/test_inky_buttons.py
+++ b/tests/test_inky_buttons.py
@@ -155,3 +155,40 @@ class TestHoldDispatch:
         assert button.when_released is None
         button.when_pressed()
         assert short_calls == ["B"]
+
+
+class TestPressLogger:
+    """``press_logger`` fires on every hardware press regardless of short/long dispatch."""
+
+    def test_press_logger_fires_for_simple_button(self):
+        seen: list[tuple[str, int]] = []
+        buttons = inky_buttons.start_listener(
+            {"B": lambda: None},
+            press_logger=lambda label, pin: seen.append((label, pin)),
+        )
+        _button_for_label(buttons, "B").when_pressed()
+        assert seen == [("B", inky_buttons.BUTTON_GPIO["B"])]
+
+    def test_press_logger_fires_for_hold_enabled_button(self):
+        seen: list[tuple[str, int]] = []
+        buttons = inky_buttons.start_listener(
+            {"A": lambda: None},
+            hold_handlers={"A": lambda: None},
+            press_logger=lambda label, pin: seen.append((label, pin)),
+        )
+        _button_for_label(buttons, "A").when_pressed()
+        assert seen == [("A", inky_buttons.BUTTON_GPIO["A"])]
+
+    def test_press_logger_exception_does_not_suppress_handler(self):
+        """A broken press_logger must not prevent the real handler from running."""
+        fired: list[str] = []
+
+        def boom(label, pin):
+            raise RuntimeError("logger blew up")
+
+        buttons = inky_buttons.start_listener(
+            {"C": lambda: fired.append("C")},
+            press_logger=boom,
+        )
+        _button_for_label(buttons, "C").when_pressed()
+        assert fired == ["C"]

--- a/tests/test_run_clock.py
+++ b/tests/test_run_clock.py
@@ -1572,3 +1572,73 @@ class TestStartupImage:
             with pytest.raises(KeyboardInterrupt):
                 run_clock.main()
         assert displayed == []
+
+
+class TestButtonRenderGate:
+    """Rapid presses must not queue behind an in-flight render.
+
+    The Spectra 6 refresh is 10–20 s per frame, so gpiozero's default
+    behavior (queue each press until the prior callback returns) makes the
+    clock feel unresponsive for up to a minute after a burst of taps. The
+    gate uses a non-blocking ``acquire`` so the first press wins and the
+    rest are logged and dropped.
+    """
+
+    def _args(self, tmp_path, **overrides):
+        defaults = dict(
+            render_script="render_quote.py",
+            output=str(tmp_path / "current.png"),
+            width=800, height=480, display_script=None,
+            mode="debug", theme="default",
+            history_path="", history_days=7, telemetry_path="",
+            state_path="", quiet_image="", shutdown_command="",
+        )
+        defaults.update(overrides)
+        return argparse.Namespace(**defaults)
+
+    def test_skip_dropped_when_render_lock_busy(self, tmp_path, capsys):
+        args = self._args(tmp_path)
+        state = run_clock.RuntimeState("default")
+        state.render_lock.acquire()  # Simulate an in-flight render.
+        try:
+            with patch("run_clock.render_now") as mock_render, \
+                 patch("run_clock.peek_quote_id", return_value=("src", 1, "q", "mt")), \
+                 patch("run_clock.current_time_str", return_value="10:00"), \
+                 patch("run_clock.current_bucket", return_value="h10_exact"):
+                short, _hold = run_clock._build_button_handlers(args, state)
+                short["A"]()
+        finally:
+            state.render_lock.release()
+        assert not mock_render.called
+        assert "busy" in capsys.readouterr().out
+
+    def test_theme_dropped_when_render_lock_busy_leaves_state_untouched(self, tmp_path):
+        """A dropped press must not mutate persisted state — otherwise tapping
+        B during a render would silently flip manual_theme while the user sees
+        no change, and the next tick would re-render with a surprise theme."""
+        args = self._args(tmp_path, state_path=str(tmp_path / "state.json"))
+        state = run_clock.RuntimeState("default")
+        state.render_lock.acquire()
+        try:
+            with patch("run_clock.render_now"), \
+                 patch("run_clock.save_runtime_state") as mock_save, \
+                 patch("run_clock.current_time_str", return_value="10:00"):
+                short, _hold = run_clock._build_button_handlers(args, state)
+                short["B"]()
+        finally:
+            state.render_lock.release()
+        assert state.manual_theme is None
+        assert not mock_save.called
+
+    def test_release_is_released_even_if_handler_raises(self, tmp_path):
+        """Gate must release the lock on handler exception so subsequent presses work."""
+        args = self._args(tmp_path)
+        state = run_clock.RuntimeState("default")
+        with patch("run_clock.peek_quote_id", side_effect=RuntimeError("boom")), \
+             patch("run_clock.current_time_str", return_value="10:00"), \
+             patch("run_clock.current_bucket", return_value="h10_exact"):
+            short, _hold = run_clock._build_button_handlers(args, state)
+            short["A"]()  # Exception is caught by handler's try/except; gate must still release.
+        # Lock should be free now; acquiring non-blocking must succeed.
+        assert state.render_lock.acquire(blocking=False)
+        state.render_lock.release()


### PR DESCRIPTION
A burst of button taps on the Inky Impression used to queue behind each
other and fire over the span of ~60 seconds, because the Spectra 6 takes
10-20 s to refresh per frame and every handler held state.render_lock for
that entire window. Gate each handler with a non-blocking acquire: first
press wins, rest are logged and dropped. Also log every confirmed press
with its GPIO pin at the listener level, and ship probe_buttons.py so a
pin-mapping mismatch can be diagnosed without editing the runtime code.