### PR TITLE
Ignore pytest coverage and editable-install build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 __pycache__/
 *.pyc
 .DS_Store
+.coverage
+*.egg-info/
 research/raw-gutenberg/
 output/*
 !output/.gitkeep

--- a/tests/test_bucket_coverage.py
+++ b/tests/test_bucket_coverage.py
@@ -1,7 +1,11 @@
 """Tests for bucket_coverage.py"""
 from __future__ import annotations
 
+import json
+
+import bucket_coverage as bc
 from bucket_coverage import build_summary, expected_buckets, render_markdown
+from tests.conftest import make_row
 
 
 class TestExpectedBuckets:
@@ -162,3 +166,43 @@ class TestRenderMarkdown:
             if line.startswith("- `h") and "_exact`" in line
         ]
         assert len(empty_section_lines) == 2
+
+
+class TestLoadRows:
+    def test_rebuckets_from_normalized_time(self, tmp_jsonl):
+        row = make_row(normalized_time="03:32", fuzzy_bucket="bogus")
+        path = tmp_jsonl([row])
+        rows = bc.load_rows(path)
+        assert rows[0]["fuzzy_bucket"] == "h3_half_past"
+
+    def test_invalid_normalized_time_preserves_existing_bucket(self, tmp_jsonl):
+        row = make_row(normalized_time="not-a-time", fuzzy_bucket="h3_exact")
+        path = tmp_jsonl([row])
+        rows = bc.load_rows(path)
+        assert rows[0]["fuzzy_bucket"] == "h3_exact"
+
+
+class TestMainCLI:
+    def test_writes_json_and_markdown(self, tmp_path, tmp_jsonl, monkeypatch, capsys):
+        input_path = tmp_jsonl([
+            make_row(fuzzy_bucket="h3_exact", normalized_time="03:00", daypart_bucket="morning"),
+            make_row(fuzzy_bucket="h3_exact", normalized_time="03:00", daypart_bucket="morning"),
+            make_row(fuzzy_bucket="h7_half_past", normalized_time="07:30", daypart_bucket="morning"),
+        ])
+        out_json = tmp_path / "coverage.json"
+        out_md = tmp_path / "coverage.md"
+        monkeypatch.setattr(
+            "sys.argv",
+            ["bucket_coverage.py", str(input_path), "--output-json", str(out_json), "--output-md", str(out_md)],
+        )
+        exit_code = bc.main()
+        assert exit_code == 0
+        summary = json.loads(out_json.read_text())
+        assert summary["total_rows"] == 3
+        assert summary["populated_bucket_count"] == 2
+        assert summary["total_expected_buckets"] == 144
+        md = out_md.read_text()
+        assert "# Bucket Coverage Report" in md
+        out = capsys.readouterr().out
+        assert "Coverage:" in out
+        assert "Empty buckets:" in out

--- a/tests/test_clean_display_quotes.py
+++ b/tests/test_clean_display_quotes.py
@@ -1,7 +1,10 @@
 """Tests for clean_display_quotes.py — sentence extraction and fragment detection."""
 from __future__ import annotations
 
+import json
+
 import clean_display_quotes as cdq
+from tests.conftest import make_row
 
 # ---------------------------------------------------------------------------
 # split_sentences
@@ -181,3 +184,35 @@ class TestBestDisplayQuote:
         assert "IN WHICH PHILEAS FOGG ASTOUNDS PASSEPARTOUT" not in text
         assert is_frag is False
         assert status == "complete_sentence"
+
+
+class TestMainCLI:
+    def test_writes_cleaned_rows(self, tmp_path, tmp_jsonl, monkeypatch, capsys):
+        rows = [
+            make_row(
+                quote_text="It was three o'clock.",
+                context_text="She arrived. It was three o'clock. Everyone cheered.",
+                matched_text="three o'clock",
+            ),
+            make_row(
+                quote_text="",
+                context_text="",
+                matched_text="noon",
+            ),
+        ]
+        input_path = tmp_jsonl(rows)
+        output_path = tmp_path / "cleaned.jsonl"
+        monkeypatch.setattr(
+            "sys.argv",
+            ["clean_display_quotes.py", str(input_path), "--output", str(output_path)],
+        )
+        assert cdq.main() == 0
+        written = [json.loads(line) for line in output_path.read_text().splitlines()]
+        assert len(written) == 2
+        assert written[0]["cleanup_status"] == "complete_sentence"
+        assert written[0]["display_fragment"] is False
+        assert written[1]["cleanup_status"] == "empty"
+        assert written[1]["display_fragment"] is True
+        out = capsys.readouterr().out
+        assert "Wrote 2 cleaned" in out
+        assert "Fragment fallbacks:" in out

--- a/tests/test_gutenberg_time_miner.py
+++ b/tests/test_gutenberg_time_miner.py
@@ -353,3 +353,261 @@ class TestIterCandidates:
         from pathlib import Path
         candidates = list(gtm.iter_candidates(Path("test.txt"), None, text, 220, max_per_file=2))
         assert len(candidates) == 2
+
+
+# ---------------------------------------------------------------------------
+# text_files_from_inputs
+# ---------------------------------------------------------------------------
+
+class TestTextFilesFromInputs:
+    def test_file_input(self, tmp_path):
+        f = tmp_path / "a.txt"
+        f.write_text("hi")
+        result = list(gtm.text_files_from_inputs([str(f)]))
+        assert result == [f]
+
+    def test_directory_input_recurses(self, tmp_path):
+        (tmp_path / "a.txt").write_text("x")
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        (sub / "b.txt").write_text("y")
+        names = sorted(p.name for p in gtm.text_files_from_inputs([str(tmp_path)]))
+        assert names == ["a.txt", "b.txt"]
+
+    def test_missing_path_raises(self, tmp_path):
+        import pytest
+        with pytest.raises(FileNotFoundError):
+            list(gtm.text_files_from_inputs([str(tmp_path / "nope.txt")]))
+
+
+# ---------------------------------------------------------------------------
+# fetch_gutenberg_text
+# ---------------------------------------------------------------------------
+
+class TestFetchGutenbergText:
+    def test_cache_hit_skips_network(self, tmp_path, monkeypatch):
+        cached = tmp_path / "pg1234.txt"
+        cached.write_text("cached content")
+        # If urlopen is called we'd get a NotImplementedError
+        monkeypatch.setattr(gtm.urllib.request, "urlopen", lambda *a, **kw: (_ for _ in ()).throw(RuntimeError("should not be called")))
+        result = gtm.fetch_gutenberg_text("1234", tmp_path)
+        assert result == cached
+        assert result.read_text() == "cached content"
+
+    def test_downloads_and_writes(self, tmp_path, monkeypatch):
+        class FakeResponse:
+            def __init__(self, payload):
+                self._payload = payload
+            def read(self):
+                return self._payload
+            def __enter__(self):
+                return self
+            def __exit__(self, *a):
+                return False
+
+        def fake_urlopen(url, timeout=30):
+            return FakeResponse(b"downloaded body")
+
+        monkeypatch.setattr(gtm.urllib.request, "urlopen", fake_urlopen)
+        result = gtm.fetch_gutenberg_text("9999", tmp_path)
+        assert result.exists()
+        assert result.read_text() == "downloaded body"
+
+    def test_all_urls_fail_raises(self, tmp_path, monkeypatch):
+        import pytest
+
+        def fake_urlopen(url, timeout=30):
+            raise gtm.urllib.error.URLError("nope")
+
+        monkeypatch.setattr(gtm.urllib.request, "urlopen", fake_urlopen)
+        with pytest.raises(RuntimeError, match="Failed to fetch"):
+            gtm.fetch_gutenberg_text("4242", tmp_path)
+
+    def test_falls_through_to_next_pattern(self, tmp_path, monkeypatch):
+        calls = {"n": 0}
+
+        class FakeResponse:
+            def read(self):
+                return b"second pattern body"
+            def __enter__(self):
+                return self
+            def __exit__(self, *a):
+                return False
+
+        def fake_urlopen(url, timeout=30):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise gtm.urllib.error.URLError("first pattern 404")
+            return FakeResponse()
+
+        monkeypatch.setattr(gtm.urllib.request, "urlopen", fake_urlopen)
+        result = gtm.fetch_gutenberg_text("7", tmp_path)
+        assert calls["n"] == 2
+        assert result.read_text() == "second pattern body"
+
+
+# ---------------------------------------------------------------------------
+# mine / main / writers
+# ---------------------------------------------------------------------------
+
+class TestMine:
+    def _args(self, **kwargs):
+        import argparse
+        defaults = {
+            "gutenberg_id": [],
+            "input": [],
+            "download_dir": "data/gutenberg",
+            "output": "unused.jsonl",
+            "format": "jsonl",
+            "context_chars": 100,
+            "max_per_file": 0,
+            "max_total": 0,
+            "print_sample": 0,
+            "exclude_match_type": [],
+            "strict": False,
+            "skip_fetch_errors": False,
+        }
+        defaults.update(kwargs)
+        return argparse.Namespace(**defaults)
+
+    def test_no_inputs_raises_system_exit(self, tmp_path):
+        import pytest
+        with pytest.raises(SystemExit):
+            gtm.mine(self._args(download_dir=str(tmp_path)))
+
+    def test_local_file_mined(self, tmp_path):
+        f = tmp_path / "book.txt"
+        f.write_text("It was three o'clock in the afternoon.")
+        candidates = gtm.mine(self._args(input=[str(f)], download_dir=str(tmp_path)))
+        assert len(candidates) >= 1
+        assert any(c.match_type == "oclock_word" for c in candidates)
+
+    def test_strict_excludes_daypart_and_digital(self, tmp_path):
+        f = tmp_path / "book.txt"
+        f.write_text("At 14:30 it was afternoon. She arrived at three o'clock.")
+        candidates = gtm.mine(self._args(input=[str(f)], download_dir=str(tmp_path), strict=True))
+        match_types = {c.match_type for c in candidates}
+        assert "digital" not in match_types
+        assert "daypart" not in match_types
+        assert "oclock_word" in match_types
+
+    def test_exclude_match_type_filters(self, tmp_path):
+        f = tmp_path / "book.txt"
+        f.write_text("It was three o'clock in the afternoon.")
+        candidates = gtm.mine(self._args(
+            input=[str(f)], download_dir=str(tmp_path),
+            exclude_match_type=["oclock_word"],
+        ))
+        assert all(c.match_type != "oclock_word" for c in candidates)
+
+    def test_max_total_caps_results(self, tmp_path):
+        f = tmp_path / "book.txt"
+        f.write_text(" ".join(f"It was {w} o'clock." for w in ["one", "two", "three", "four", "five"]))
+        candidates = gtm.mine(self._args(
+            input=[str(f)], download_dir=str(tmp_path), max_total=2,
+        ))
+        assert len(candidates) == 2
+
+    def test_skip_fetch_errors_continues(self, tmp_path, monkeypatch, capsys):
+        def fake_fetch(ebook_id, download_dir):
+            raise RuntimeError("simulated 404")
+
+        monkeypatch.setattr(gtm, "fetch_gutenberg_text", fake_fetch)
+        local = tmp_path / "local.txt"
+        local.write_text("It was five o'clock in the morning.")
+        candidates = gtm.mine(self._args(
+            gutenberg_id=["404"],
+            input=[str(local)],
+            download_dir=str(tmp_path),
+            skip_fetch_errors=True,
+        ))
+        # Local file still mined despite the bad Gutenberg id.
+        assert any(c.match_type == "oclock_word" for c in candidates)
+        err = capsys.readouterr().err
+        assert "Skipping Gutenberg id 404" in err
+
+    def test_fetch_failure_without_skip_reraises(self, tmp_path, monkeypatch):
+        import pytest
+
+        def fake_fetch(ebook_id, download_dir):
+            raise RuntimeError("simulated 404")
+
+        monkeypatch.setattr(gtm, "fetch_gutenberg_text", fake_fetch)
+        with pytest.raises(RuntimeError):
+            gtm.mine(self._args(gutenberg_id=["404"], download_dir=str(tmp_path)))
+
+    def test_uses_downloaded_gutenberg_text(self, tmp_path, monkeypatch):
+        def fake_fetch(ebook_id, download_dir):
+            p = Path(download_dir) / f"pg{ebook_id}.txt"
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text("It was four o'clock in the afternoon.")
+            return p
+
+        from pathlib import Path  # local to avoid scope clash
+        monkeypatch.setattr(gtm, "fetch_gutenberg_text", fake_fetch)
+        candidates = gtm.mine(self._args(gutenberg_id=["42"], download_dir=str(tmp_path)))
+        assert any(c.source_id == "42" for c in candidates)
+
+
+class TestWriters:
+    def test_write_jsonl(self, tmp_path):
+        text = "It was three o'clock."
+        from pathlib import Path
+        candidates = list(gtm.iter_candidates(Path("a.txt"), "1", text, 100, 0))
+        out = tmp_path / "out.jsonl"
+        count = gtm.write_jsonl(out, candidates)
+        assert count == len(candidates)
+        import json
+        rows = [json.loads(line) for line in out.read_text().splitlines()]
+        assert all("normalized_time" in r for r in rows)
+
+    def test_write_csv(self, tmp_path):
+        text = "It was three o'clock."
+        from pathlib import Path
+        candidates = list(gtm.iter_candidates(Path("a.txt"), "1", text, 100, 0))
+        out = tmp_path / "out.csv"
+        count = gtm.write_csv(out, candidates)
+        assert count == len(candidates)
+        body = out.read_text()
+        assert "normalized_time" in body.splitlines()[0]
+
+
+class TestMainCLI:
+    def test_jsonl_output_and_sample_print(self, tmp_path, monkeypatch, capsys):
+        book = tmp_path / "book.txt"
+        book.write_text("It was three o'clock in the afternoon.\nThe bell struck four o'clock.")
+        out = tmp_path / "candidates.jsonl"
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "gutenberg_time_miner.py",
+                "--input", str(book),
+                "--output", str(out),
+                "--download-dir", str(tmp_path / "dl"),
+                "--print-sample", "2",
+            ],
+        )
+        assert gtm.main() == 0
+        assert out.exists()
+        lines = out.read_text().strip().splitlines()
+        assert len(lines) >= 2
+        captured = capsys.readouterr().out
+        assert "Wrote" in captured
+
+    def test_csv_output_format(self, tmp_path, monkeypatch):
+        book = tmp_path / "book.txt"
+        book.write_text("It was three o'clock in the afternoon.")
+        out = tmp_path / "candidates.csv"
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "gutenberg_time_miner.py",
+                "--input", str(book),
+                "--output", str(out),
+                "--download-dir", str(tmp_path / "dl"),
+                "--format", "csv",
+            ],
+        )
+        assert gtm.main() == 0
+        body = out.read_text()
+        assert "normalized_time" in body.splitlines()[0]

--- a/tests/test_gutenberg_time_miner.py
+++ b/tests/test_gutenberg_time_miner.py
@@ -1,7 +1,12 @@
 """Tests for gutenberg_time_miner.py — regex patterns, time parsing, bucket logic."""
 from __future__ import annotations
 
+import json
 import re
+import sys
+from pathlib import Path
+
+import pytest
 
 import gutenberg_time_miner as gtm
 
@@ -341,7 +346,6 @@ class TestIterCandidates:
             "By half past eight the house was quiet. "
             "Quarter to ten she departed."
         )
-        from pathlib import Path
         candidates = list(gtm.iter_candidates(Path("test.txt"), None, text, 220, 0))
         match_types = {c.match_type for c in candidates}
         assert "oclock_word" in match_types
@@ -350,7 +354,6 @@ class TestIterCandidates:
 
     def test_max_per_file_limits_results(self):
         text = " ".join([f"It was {w} o'clock." for w in ["one", "two", "three", "four", "five"]])
-        from pathlib import Path
         candidates = list(gtm.iter_candidates(Path("test.txt"), None, text, 220, max_per_file=2))
         assert len(candidates) == 2
 
@@ -375,7 +378,6 @@ class TestTextFilesFromInputs:
         assert names == ["a.txt", "b.txt"]
 
     def test_missing_path_raises(self, tmp_path):
-        import pytest
         with pytest.raises(FileNotFoundError):
             list(gtm.text_files_from_inputs([str(tmp_path / "nope.txt")]))
 
@@ -388,8 +390,11 @@ class TestFetchGutenbergText:
     def test_cache_hit_skips_network(self, tmp_path, monkeypatch):
         cached = tmp_path / "pg1234.txt"
         cached.write_text("cached content")
-        # If urlopen is called we'd get a NotImplementedError
-        monkeypatch.setattr(gtm.urllib.request, "urlopen", lambda *a, **kw: (_ for _ in ()).throw(RuntimeError("should not be called")))
+
+        def exploding_urlopen(*args, **kwargs):
+            raise AssertionError("urlopen must not be called when cache is warm")
+
+        monkeypatch.setattr(gtm.urllib.request, "urlopen", exploding_urlopen)
         result = gtm.fetch_gutenberg_text("1234", tmp_path)
         assert result == cached
         assert result.read_text() == "cached content"
@@ -414,8 +419,6 @@ class TestFetchGutenbergText:
         assert result.read_text() == "downloaded body"
 
     def test_all_urls_fail_raises(self, tmp_path, monkeypatch):
-        import pytest
-
         def fake_urlopen(url, timeout=30):
             raise gtm.urllib.error.URLError("nope")
 
@@ -452,26 +455,20 @@ class TestFetchGutenbergText:
 
 class TestMine:
     def _args(self, **kwargs):
-        import argparse
-        defaults = {
-            "gutenberg_id": [],
-            "input": [],
-            "download_dir": "data/gutenberg",
-            "output": "unused.jsonl",
-            "format": "jsonl",
-            "context_chars": 100,
-            "max_per_file": 0,
-            "max_total": 0,
-            "print_sample": 0,
-            "exclude_match_type": [],
-            "strict": False,
-            "skip_fetch_errors": False,
-        }
-        defaults.update(kwargs)
-        return argparse.Namespace(**defaults)
+        # Derive defaults from the real parser so a new CLI flag can't silently
+        # leave tests running against a stale default dict. parse_args() reads
+        # sys.argv with no override, so stub it for the duration of the call.
+        original_argv = sys.argv
+        sys.argv = ["gutenberg_time_miner.py"]
+        try:
+            args = gtm.parse_args()
+        finally:
+            sys.argv = original_argv
+        for key, value in kwargs.items():
+            setattr(args, key, value)
+        return args
 
     def test_no_inputs_raises_system_exit(self, tmp_path):
-        import pytest
         with pytest.raises(SystemExit):
             gtm.mine(self._args(download_dir=str(tmp_path)))
 
@@ -527,13 +524,11 @@ class TestMine:
         assert "Skipping Gutenberg id 404" in err
 
     def test_fetch_failure_without_skip_reraises(self, tmp_path, monkeypatch):
-        import pytest
-
         def fake_fetch(ebook_id, download_dir):
             raise RuntimeError("simulated 404")
 
         monkeypatch.setattr(gtm, "fetch_gutenberg_text", fake_fetch)
-        with pytest.raises(RuntimeError):
+        with pytest.raises(RuntimeError, match="simulated 404"):
             gtm.mine(self._args(gutenberg_id=["404"], download_dir=str(tmp_path)))
 
     def test_uses_downloaded_gutenberg_text(self, tmp_path, monkeypatch):
@@ -543,7 +538,6 @@ class TestMine:
             p.write_text("It was four o'clock in the afternoon.")
             return p
 
-        from pathlib import Path  # local to avoid scope clash
         monkeypatch.setattr(gtm, "fetch_gutenberg_text", fake_fetch)
         candidates = gtm.mine(self._args(gutenberg_id=["42"], download_dir=str(tmp_path)))
         assert any(c.source_id == "42" for c in candidates)
@@ -552,18 +546,15 @@ class TestMine:
 class TestWriters:
     def test_write_jsonl(self, tmp_path):
         text = "It was three o'clock."
-        from pathlib import Path
         candidates = list(gtm.iter_candidates(Path("a.txt"), "1", text, 100, 0))
         out = tmp_path / "out.jsonl"
         count = gtm.write_jsonl(out, candidates)
         assert count == len(candidates)
-        import json
         rows = [json.loads(line) for line in out.read_text().splitlines()]
         assert all("normalized_time" in r for r in rows)
 
     def test_write_csv(self, tmp_path):
         text = "It was three o'clock."
-        from pathlib import Path
         candidates = list(gtm.iter_candidates(Path("a.txt"), "1", text, 100, 0))
         out = tmp_path / "out.csv"
         count = gtm.write_csv(out, candidates)
@@ -575,7 +566,7 @@ class TestWriters:
 class TestMainCLI:
     def test_jsonl_output_and_sample_print(self, tmp_path, monkeypatch, capsys):
         book = tmp_path / "book.txt"
-        book.write_text("It was three o'clock in the afternoon.\nThe bell struck four o'clock.")
+        book.write_text("She waited until three o'clock. Later, four o'clock struck.")
         out = tmp_path / "candidates.jsonl"
         monkeypatch.setattr(
             "sys.argv",
@@ -585,14 +576,19 @@ class TestMainCLI:
                 "--output", str(out),
                 "--download-dir", str(tmp_path / "dl"),
                 "--print-sample", "2",
+                "--exclude-match-type", "clock_struck",  # keep the assertion tight
             ],
         )
         assert gtm.main() == 0
         assert out.exists()
-        lines = out.read_text().strip().splitlines()
-        assert len(lines) >= 2
+        rows = [json.loads(line) for line in out.read_text().splitlines()]
+        assert [r["matched_text"].lower() for r in rows] == ["three o'clock", "four o'clock"]
+        assert all(r["match_type"] == "oclock_word" for r in rows)
         captured = capsys.readouterr().out
-        assert "Wrote" in captured
+        assert "Wrote 2 candidates" in captured
+        # --print-sample 2 prints one "[1]" and one "[2]" header
+        assert "[1]" in captured
+        assert "[2]" in captured
 
     def test_csv_output_format(self, tmp_path, monkeypatch):
         book = tmp_path / "book.txt"

--- a/tests/test_jsonl_io.py
+++ b/tests/test_jsonl_io.py
@@ -1,0 +1,44 @@
+"""Tests for jsonl_io.iter_jsonl — the shared malformed-line-tolerant reader."""
+from __future__ import annotations
+
+from jsonl_io import iter_jsonl
+
+
+class TestIterJsonl:
+    def test_reads_valid_rows(self, tmp_path):
+        path = tmp_path / "rows.jsonl"
+        path.write_text('{"a": 1}\n{"a": 2}\n', encoding="utf-8")
+        assert list(iter_jsonl(path)) == [{"a": 1}, {"a": 2}]
+
+    def test_skips_blank_lines(self, tmp_path):
+        path = tmp_path / "rows.jsonl"
+        path.write_text('{"a": 1}\n\n   \n{"a": 2}\n', encoding="utf-8")
+        assert list(iter_jsonl(path)) == [{"a": 1}, {"a": 2}]
+
+    def test_malformed_line_logged_and_skipped(self, tmp_path, capsys):
+        path = tmp_path / "rows.jsonl"
+        path.write_text('{"a": 1}\nnot-json\n{"a": 2}\n', encoding="utf-8")
+        rows = list(iter_jsonl(path))
+        assert rows == [{"a": 1}, {"a": 2}]
+        err = capsys.readouterr().err
+        assert "rows.jsonl:2" in err
+        assert "skipping malformed JSON" in err
+
+    def test_all_blank_yields_nothing(self, tmp_path):
+        path = tmp_path / "empty.jsonl"
+        path.write_text("\n  \n\t\n", encoding="utf-8")
+        assert list(iter_jsonl(path)) == []
+
+    def test_trailing_newline_not_required(self, tmp_path):
+        path = tmp_path / "rows.jsonl"
+        path.write_text('{"a": 1}', encoding="utf-8")
+        assert list(iter_jsonl(path)) == [{"a": 1}]
+
+    def test_multiple_malformed_lines_each_logged(self, tmp_path, capsys):
+        path = tmp_path / "rows.jsonl"
+        path.write_text('nope\n{"ok": true}\nstill-bad\n', encoding="utf-8")
+        rows = list(iter_jsonl(path))
+        assert rows == [{"ok": True}]
+        err = capsys.readouterr().err
+        assert "rows.jsonl:1" in err
+        assert "rows.jsonl:3" in err

--- a/tests/test_merge_candidates.py
+++ b/tests/test_merge_candidates.py
@@ -1,6 +1,8 @@
 """Tests for merge_candidates.py — text normalization and deduplication."""
 from __future__ import annotations
 
+import json
+
 import merge_candidates as mc
 from tests.conftest import make_row
 
@@ -122,3 +124,42 @@ class TestDedupe:
         merged, _ = mc.dedupe(records)
         assert "canonical_quote" in merged[0]
         assert "canonical_context" in merged[0]
+
+
+class TestIterRecords:
+    def test_yields_records_with_canonical_fields(self, tmp_jsonl):
+        path = tmp_jsonl([
+            make_row(quote_text="Hello World.", context_text="  Hello   World.  "),
+        ])
+        records = list(mc.iter_records([str(path)]))
+        assert len(records) == 1
+        assert records[0].canonical_quote == "hello world"
+        assert records[0].canonical_context == "hello world"
+
+
+class TestMainCLI:
+    def test_writes_merged_and_summary(self, tmp_path, tmp_jsonl, monkeypatch, capsys):
+        input_path = tmp_jsonl([
+            make_row(quote_text="A unique quote.", source_id="1"),
+            make_row(quote_text="Another quote.", source_id="2"),
+            make_row(quote_text="A unique quote.", source_id="1"),  # duplicate
+        ])
+        output_path = tmp_path / "merged.jsonl"
+        summary_path = tmp_path / "summary.json"
+        monkeypatch.setattr(
+            "sys.argv",
+            ["merge_candidates.py", str(input_path), "--output", str(output_path), "--summary", str(summary_path)],
+        )
+        exit_code = mc.main()
+        assert exit_code == 0
+        assert output_path.exists()
+        assert summary_path.exists()
+        lines = output_path.read_text().strip().splitlines()
+        assert len(lines) == 2  # duplicate removed
+        summary = json.loads(summary_path.read_text())
+        assert summary["input_rows"] == 3
+        assert summary["deduped_rows"] == 2
+        assert summary["duplicates_removed"] == 1
+        out = capsys.readouterr().out
+        assert "Wrote 2 deduped" in out
+        assert "Removed 1 duplicates" in out

--- a/tests/test_pick_quote.py
+++ b/tests/test_pick_quote.py
@@ -416,3 +416,54 @@ class TestRecentHistory:
         # No history_path passed → no file reads even if ~/.litclock exists.
         result = pq.select_quote(bucket="h3_exact", input_path=str(corpus_path), overrides_path=str(overrides_path))
         assert result["source_id"] == "1"
+
+
+class TestLoadOverrides:
+    def test_missing_file_returns_defaults(self, tmp_path):
+        result = pq.load_overrides(tmp_path / "does-not-exist.json")
+        assert result == {"ban_source_ids": [], "boost_source_ids": [], "preferred_buckets": {}}
+
+    def test_valid_file_parsed(self, tmp_path):
+        path = tmp_path / "ov.json"
+        path.write_text(json.dumps({
+            "ban_source_ids": ["1"],
+            "boost_source_ids": ["2"],
+            "preferred_buckets": {"h3_exact": 42},
+        }))
+        result = pq.load_overrides(path)
+        assert result["ban_source_ids"] == ["1"]
+        assert result["preferred_buckets"] == {"h3_exact": 42}
+
+    def test_unknown_preferred_bucket_warns_on_stderr(self, tmp_path, capsys):
+        path = tmp_path / "ov.json"
+        path.write_text(json.dumps({
+            "ban_source_ids": [],
+            "boost_source_ids": [],
+            "preferred_buckets": {"h3_exact": 1, "h99_bogus": 2, "not_a_bucket": 3},
+        }))
+        pq.load_overrides(path)
+        err = capsys.readouterr().err
+        assert "unknown buckets" in err
+        assert "h99_bogus" in err
+        assert "not_a_bucket" in err
+        assert "h3_exact" not in err  # valid bucket must not be listed
+
+    def test_all_valid_preferred_buckets_silent(self, tmp_path, capsys):
+        path = tmp_path / "ov.json"
+        path.write_text(json.dumps({
+            "ban_source_ids": [],
+            "boost_source_ids": [],
+            "preferred_buckets": {"h3_exact": 1, "h12_quarter_to": 2},
+        }))
+        pq.load_overrides(path)
+        assert capsys.readouterr().err == ""
+
+    def test_non_dict_preferred_buckets_does_not_crash(self, tmp_path, capsys):
+        path = tmp_path / "ov.json"
+        path.write_text(json.dumps({
+            "ban_source_ids": [],
+            "boost_source_ids": [],
+            "preferred_buckets": ["oops", "list"],
+        }))
+        pq.load_overrides(path)
+        assert capsys.readouterr().err == ""

--- a/tests/test_probe_buttons.py
+++ b/tests/test_probe_buttons.py
@@ -65,7 +65,9 @@ class TestLog:
 
 class TestMain:
     def test_returns_1_when_gpiozero_missing(self, monkeypatch, capsys):
-        # Remove gpiozero from sys.modules and prevent fallback imports
+        # A None entry in sys.modules is CPython's cached-ImportError sentinel:
+        # the next `from gpiozero import Button` raises ModuleNotFoundError without
+        # hitting the import machinery, so we don't need gpiozero uninstalled.
         monkeypatch.setitem(sys.modules, "gpiozero", None)
         rc = probe_buttons.main([])
         assert rc == 1

--- a/tests/test_probe_buttons.py
+++ b/tests/test_probe_buttons.py
@@ -1,0 +1,140 @@
+"""Tests for probe_buttons.py — standalone GPIO diagnostic script.
+
+``gpiozero`` is not available in CI, so we stub it in ``sys.modules`` and
+replace ``signal.pause`` with a KeyboardInterrupt so ``main()`` doesn't hang.
+"""
+from __future__ import annotations
+
+import signal
+import sys
+import types
+
+import pytest
+
+import probe_buttons
+
+
+class FakeButton:
+    """Captures constructor args and simulates a press."""
+
+    instances: list["FakeButton"] = []
+
+    def __init__(self, pin, *, pull_up=True, bounce_time=None):
+        self.pin = pin
+        self.pull_up = pull_up
+        self.bounce_time = bounce_time
+        self.when_pressed = None
+        self.when_released = None
+        FakeButton.instances.append(self)
+
+
+@pytest.fixture
+def stub_gpiozero(monkeypatch):
+    FakeButton.instances = []
+    fake_module = types.ModuleType("gpiozero")
+    fake_module.Button = FakeButton
+    monkeypatch.setitem(sys.modules, "gpiozero", fake_module)
+    return fake_module
+
+
+@pytest.fixture
+def stub_signal_pause(monkeypatch):
+    def raise_interrupt():
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(signal, "pause", raise_interrupt)
+
+
+class TestDefaults:
+    def test_default_pins_covers_inky_impression(self):
+        assert 5 in probe_buttons.DEFAULT_PINS
+        assert 6 in probe_buttons.DEFAULT_PINS
+        assert 16 in probe_buttons.DEFAULT_PINS
+        assert 24 in probe_buttons.DEFAULT_PINS
+
+
+class TestLog:
+    def test_log_prints_iso_timestamp(self, capsys):
+        probe_buttons._log("hello")
+        captured = capsys.readouterr().out
+        assert "hello" in captured
+        # ISO-ish "[YYYY-MM-DDTHH:MM:SS]" prefix
+        assert captured.startswith("[")
+        assert "T" in captured.split("]")[0]
+
+
+class TestMain:
+    def test_returns_1_when_gpiozero_missing(self, monkeypatch, capsys):
+        # Remove gpiozero from sys.modules and prevent fallback imports
+        monkeypatch.setitem(sys.modules, "gpiozero", None)
+        rc = probe_buttons.main([])
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "gpiozero not available" in err
+
+    def test_attaches_default_pins(self, stub_gpiozero, stub_signal_pause):
+        rc = probe_buttons.main([])
+        assert rc == 0
+        pins = sorted(b.pin for b in FakeButton.instances)
+        assert pins == sorted(probe_buttons.DEFAULT_PINS)
+        for btn in FakeButton.instances:
+            assert btn.pull_up is True
+            assert btn.bounce_time == 0.05
+            assert callable(btn.when_pressed)
+            assert callable(btn.when_released)
+
+    def test_custom_pins_and_bounce(self, stub_gpiozero, stub_signal_pause):
+        rc = probe_buttons.main(["--pins", "7", "8", "--bounce", "0.2"])
+        assert rc == 0
+        pins = sorted(b.pin for b in FakeButton.instances)
+        assert pins == [7, 8]
+        assert all(b.bounce_time == 0.2 for b in FakeButton.instances)
+
+    def test_pull_down_flag(self, stub_gpiozero, stub_signal_pause):
+        probe_buttons.main(["--pull-down", "--pins", "5"])
+        assert FakeButton.instances[0].pull_up is False
+
+    def test_returns_1_when_no_pins_attach(self, monkeypatch, capsys):
+        fake_module = types.ModuleType("gpiozero")
+
+        def exploding_button(pin, *, pull_up=True, bounce_time=None):
+            raise RuntimeError(f"GPIO {pin} busy")
+
+        fake_module.Button = exploding_button
+        monkeypatch.setitem(sys.modules, "gpiozero", fake_module)
+
+        rc = probe_buttons.main(["--pins", "5"])
+        assert rc == 1
+        captured = capsys.readouterr()
+        assert "attach FAILED" in captured.out
+        assert "No pins attached" in captured.err
+
+    def test_partial_failure_still_continues(self, monkeypatch, stub_signal_pause, capsys):
+        attached: list[FakeButton] = []
+        fake_module = types.ModuleType("gpiozero")
+
+        def maybe_fail(pin, *, pull_up=True, bounce_time=None):
+            if pin == 5:
+                raise RuntimeError("pin 5 is busy")
+            btn = FakeButton(pin, pull_up=pull_up, bounce_time=bounce_time)
+            attached.append(btn)
+            return btn
+
+        fake_module.Button = maybe_fail
+        monkeypatch.setitem(sys.modules, "gpiozero", fake_module)
+
+        rc = probe_buttons.main(["--pins", "5", "6"])
+        assert rc == 0
+        assert [b.pin for b in attached] == [6]
+        captured = capsys.readouterr().out
+        assert "attach FAILED" in captured
+        assert "listening on GPIO 6" in captured
+
+    def test_press_callback_logs_pin(self, stub_gpiozero, stub_signal_pause, capsys):
+        probe_buttons.main(["--pins", "7"])
+        btn = FakeButton.instances[0]
+        btn.when_pressed()
+        btn.when_released()
+        out = capsys.readouterr().out
+        assert "GPIO 7: PRESSED" in out
+        assert "GPIO 7: released" in out

--- a/tests/test_quality_filter.py
+++ b/tests/test_quality_filter.py
@@ -1,7 +1,10 @@
 """Tests for quality_filter.py — penalty scoring logic."""
 from __future__ import annotations
 
+import json
+
 import quality_filter as qf
+from tests.conftest import make_row
 
 
 def score(text, fragment=False, status="complete_sentence"):
@@ -181,3 +184,48 @@ class TestScoreFloor:
         text = "work chapter ebook 1:00-2:00 am pm"
         s, _ = score(text, fragment=True, status="empty")
         assert s == 0
+
+
+class TestMainCLI:
+    def test_annotates_rows_and_writes_output(self, tmp_path, tmp_jsonl, monkeypatch, capsys):
+        input_rows = [
+            make_row(
+                display_quote="It was exactly three o'clock when the carriage arrived at the door of Mansfield Park.",
+                display_fragment=False,
+                cleanup_status="complete_sentence",
+            ),
+            make_row(
+                display_quote="bad",  # fragment + too_short + weak_ending
+                display_fragment=True,
+                cleanup_status="fragment_fallback",
+            ),
+        ]
+        input_path = tmp_jsonl(input_rows)
+        output_path = tmp_path / "quality.jsonl"
+        monkeypatch.setattr(
+            "sys.argv",
+            ["quality_filter.py", str(input_path), "--output", str(output_path)],
+        )
+        exit_code = qf.main()
+        assert exit_code == 0
+        written = [json.loads(line) for line in output_path.read_text().splitlines()]
+        assert len(written) == 2
+        assert written[0]["quality_score"] == 100
+        assert written[0]["quality_flags"] == []
+        assert written[1]["quality_score"] < 50
+        assert "fragment" in written[1]["quality_flags"]
+        out = capsys.readouterr().out
+        assert "Wrote 2 quality-scored" in out
+
+    def test_handles_missing_display_quote_field(self, tmp_path, tmp_jsonl, monkeypatch):
+        row = make_row()
+        del row["display_quote"]
+        input_path = tmp_jsonl([row])
+        output_path = tmp_path / "quality.jsonl"
+        monkeypatch.setattr(
+            "sys.argv",
+            ["quality_filter.py", str(input_path), "--output", str(output_path)],
+        )
+        assert qf.main() == 0
+        written = json.loads(output_path.read_text().splitlines()[0])
+        assert "quality_score" in written

--- a/tests/test_target_sparse_buckets.py
+++ b/tests/test_target_sparse_buckets.py
@@ -1,6 +1,9 @@
 """Tests for target_sparse_buckets.py"""
 from __future__ import annotations
 
+import json
+
+import target_sparse_buckets as tsb
 from target_sparse_buckets import expected_targets, sentence_window, templates_for_bucket
 
 
@@ -129,3 +132,92 @@ class TestSentenceWindow:
         _, context, _ = sentence_window(text, start, start + 4, context_chars=20)
         # context should have normalized whitespace
         assert "  " not in context
+
+
+class TestSearchBucket:
+    def test_finds_matching_phrase(self, tmp_path):
+        pg = tmp_path / "pg1234.txt"
+        pg.write_text("The morning was quiet. It was five past three when she looked up.\n")
+        results = tsb.search_bucket("h3_five_past", tmp_path)
+        assert len(results) == 1
+        hit = results[0]
+        assert hit["source_id"] == "1234"
+        assert hit["target_bucket"] == "h3_five_past"
+        assert hit["resolved_bucket"] == "h3_five_past"
+        assert "five past three" in hit["matched_text"].lower()
+        assert "five past three" in hit["quote_text"].lower()
+        assert hit["line_number"] == 1
+
+    def test_empty_templates_returns_empty(self, tmp_path):
+        pg = tmp_path / "pg1.txt"
+        pg.write_text("Nothing interesting here.\n")
+        assert tsb.search_bucket("h3_exact", tmp_path) == []
+
+    def test_non_pg_stem_has_null_source_id(self, tmp_path):
+        book = tmp_path / "local_book.txt"
+        book.write_text("It was quarter to eight in the cold morning.\n")
+        results = tsb.search_bucket("h7_quarter_to", tmp_path)
+        assert len(results) == 1
+        assert results[0]["source_id"] is None
+        assert results[0]["source_path"].endswith("local_book.txt")
+
+    def test_dedupes_same_position(self, tmp_path):
+        # "five to three" appears in templates as both "five to {next_hour}"
+        # and "five minutes to {next_hour}" — the same text match should not fire twice.
+        pg = tmp_path / "pg2.txt"
+        pg.write_text("It was five to three.\n")
+        results = tsb.search_bucket("h2_five_to", tmp_path)
+        # Only one match per (start, end, implied_state) position
+        positions = {(r["match_start"], r["match_end"]) for r in results}
+        assert len(results) == len(positions)
+
+    def test_implied_state_differs_from_target_bucket(self, tmp_path):
+        # "fifty-five minutes past two" is templated under h2_five_to with implied_state=five_to;
+        # resolved bucket should still be h2_five_to.
+        pg = tmp_path / "pg3.txt"
+        pg.write_text("She arrived at fifty-five minutes past two precisely.\n")
+        results = tsb.search_bucket("h2_five_to", tmp_path)
+        assert len(results) == 1
+        assert results[0]["resolved_bucket"] == "h2_five_to"
+
+    def test_multiple_files_searched(self, tmp_path):
+        (tmp_path / "pg1.txt").write_text("It was half past four in the garden.\n")
+        (tmp_path / "pg2.txt").write_text("The clock chimed half past four downstairs.\n")
+        results = tsb.search_bucket("h4_half_past", tmp_path)
+        source_ids = {r["source_id"] for r in results}
+        assert source_ids == {"1", "2"}
+
+
+class TestMainCLI:
+    def test_writes_targeted_candidates(self, tmp_path, monkeypatch, capsys):
+        search_dir = tmp_path / "gutenberg"
+        search_dir.mkdir()
+        (search_dir / "pg1.txt").write_text("It was five past three when the letter came.\n")
+        (search_dir / "pg2.txt").write_text("The clock struck half past nine sharp.\n")
+
+        coverage_path = tmp_path / "coverage.json"
+        coverage_path.write_text(json.dumps({
+            "empty_buckets": ["h3_five_past"],
+            "sparse_buckets": [{"bucket": "h9_half_past", "count": 1}],
+        }))
+        output_path = tmp_path / "targeted.jsonl"
+
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "target_sparse_buckets.py",
+                str(coverage_path),
+                "--search-dir", str(search_dir),
+                "--output", str(output_path),
+                "--max-buckets", "10",
+            ],
+        )
+        assert tsb.main() == 0
+        assert output_path.exists()
+        lines = output_path.read_text().strip().splitlines()
+        assert len(lines) == 2
+        buckets = {json.loads(line)["target_bucket"] for line in lines}
+        assert buckets == {"h3_five_past", "h9_half_past"}
+        out = capsys.readouterr().out
+        assert "Targeted buckets searched: 2" in out
+        assert "Targeted candidates found: 2" in out


### PR DESCRIPTION
.coverage (from pytest-cov) and *.egg-info/ (from `pip install -e`) are
local build/test artifacts and should not be tracked.

https://claude.ai/code/session_019Ah1up9fMGsvUND5YtAb4c