### PR TITLE
Document curator web UI in setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,16 @@ chmod 640 ~/.litclock/web.token
 python3 run_clock.py --web-bind 0.0.0.0:8080 --web-token-file ~/.litclock/web.token
 ```
 
+The UI is vanilla HTML/JS/CSS served directly from `web/` — no build step, no framework, no extra runtime deps beyond what the clock already needs. When you open it you get:
+
+- **Now showing** — live preview of `output/current.png`, the picked quote text, its attribution (`source_id` + `line_number`), and the matched time phrase the renderer bolded.
+- **Controls** — five buttons that mirror the physical Inky panel: `A · Skip`, `A-hold · Un-skip`, `B · Toggle theme`, `C · Re-render`, `D · Quiet / wake`. Each press returns `{ok: true}` or `{ok: false, error: "busy"}` and is appended to a small in-browser action log.
+- **Telemetry** — renders / errors / p50 / p95 latencies over the last 24h, reading the same date-rotated sidecar that `litclock_health.py` does.
+- **Coverage grid** — 144 bucket cells coloured by corpus depth (from `assets/bucket-coverage.json`); click-through feeds the inspector.
+- **Bucket inspector** — ranked candidate list for any bucket (or `HH:MM`), with every scorer component named so you can see *why* a different quote was not picked.
+- **Overrides editor** — edits `assets/selection_overrides.json` inline; the server validates and atomically rewrites the file, rejecting bad bucket keys with 400.
+- **History** — the anti-repeat ledger, newest first.
+
 The UI shares the render lock with the button handlers, so every mutating action (skip, un-skip, theme, quiet, re-render, overrides save) respects "first press wins": a POST that lands during a 10–20s Spectra 6 refresh returns `409 busy` instead of queueing.
 
 | Endpoint | Purpose |
@@ -377,6 +387,7 @@ That work is intentionally separate from the steady-state render loop.
 - Telemetry at `--telemetry-path` (default `~/.litclock/telemetry.jsonl`) is rotated by date — `run_clock.py` writes to a `telemetry-YYYYMMDD.jsonl` sibling so long-running appliances don't accumulate one unbounded file. One line per render, one per loop-level error. `litclock_health.py --json` feeds systemd / cron health checks and auto-discovers the rotated siblings.
 - The anti-repeat history ledger at `--history-path` (default `~/.litclock/history.jsonl`) is fsynced after each append so a power loss can't leave a buffered entry lost, and the reader logs a one-shot warning if it finds a malformed/torn line.
 - If the Inky button listener dies mid-run (pin claim lost, background thread failed), the loop logs one loud warning plus a telemetry entry with `mode=buttons_dead` and stops retrying — restart the process to reclaim the pins.
+- The optional curator web UI (`--web-bind`) runs in-process on a daemon thread and shares the render lock with the button handlers; it's the safe remote alternative to SSHing in to tap the panel or edit `selection_overrides.json` by hand. LAN binds require `--web-token` / `--web-token-file`.
 - The renderer is tuned for the Pimoroni Inky Impression 7.3 / Spectra 6 800×480 display.
 - Final renders are snapped to the exact Spectra 6 palette for better hardware fidelity.
 - Renderer changes can be surprisingly fragile around text normalization, wrapping, and emphasis/highlight matching, so keep render tests healthy.
@@ -392,6 +403,7 @@ If the clock is behaving oddly, these are the first files to inspect:
 - button/long-press wiring -> `inky_buttons.py`
 - "which GPIO pin did that button actually fire?" -> `python3 probe_buttons.py` on the Pi
 - "is the appliance alive?" -> `python3 litclock_health.py --hours 24` (use `--json` from cron)
+- curator web UI / HTTP endpoints / overrides editor -> `web_server.py` + `web/` (enable with `--web-bind`)
 - telemetry log (one JSONL entry per render/error) -> `~/.litclock/telemetry.jsonl`
 - persisted manual theme / quiet override -> `~/.litclock/state.json`
 - anti-repeat ledger of recently-shown quotes -> `~/.litclock/history.jsonl`

--- a/pi_setup_inky_impression.md
+++ b/pi_setup_inky_impression.md
@@ -83,6 +83,31 @@ python3 litclock_health.py --hours 1 --json --fail-if-no-renders
 
 Wire the JSON form into a once-a-day cron / systemd timer if you want passive alerting without SSH journalctl spelunking.
 
+### Optional: curator web UI
+
+`run_clock.py` ships a small in-process HTTP surface for browsing telemetry / bucket coverage / the current frame and mirroring the four physical buttons from a phone or laptop. It is **off by default** and starts only when `--web-bind HOST:PORT` is passed.
+
+```bash
+# Loopback-only, no auth. Safe for SSH port-forward from your laptop.
+python3 run_clock.py --display-script display_inky.py --web-bind 127.0.0.1:8080
+# then on the laptop: ssh -L 8080:127.0.0.1:8080 pi@litclock
+# and open http://127.0.0.1:8080
+
+# LAN-exposed. POSTs (skip / theme / quiet / re-render / overrides save) require
+# a token; put it in a file so it doesn't show up in `ps` / journald.
+mkdir -p ~/.litclock
+python3 -c "import secrets; print(secrets.token_urlsafe(32))" > ~/.litclock/web.token
+chmod 640 ~/.litclock/web.token
+python3 run_clock.py \
+  --display-script display_inky.py \
+  --web-bind 0.0.0.0:8080 \
+  --web-token-file ~/.litclock/web.token
+```
+
+To enable the UI under systemd, append the same flags to `ExecStart=` in `litclock.service` (commented examples are included in `litclock.service.example`). The UI shares `render_lock` with the button handlers, so a tap on the physical panel and a click in the browser will never render-race — the second one returns `409 busy` instead of queueing. GETs (the `current.png` preview, telemetry, coverage) stay open on all binds; only POSTs are token-gated.
+
+See the "Curator web UI" section in `README.md` for the full endpoint list, UI panel descriptions, and security model.
+
 ### Optional: verify which GPIO pin each button actually fires
 
 If button handling seems wrong on a particular Inky variant, run the standalone probe to confirm the wiring before blaming handler code:


### PR DESCRIPTION
- Add optional curator UI section to pi_setup_inky_impression.md covering
  loopback vs LAN binds, SSH port-forward flow, and token-file generation.
- Expand the README curator UI section with a per-panel description so
  readers know what the UI surfaces before enabling it.
- Cross-link the web UI from README operational notes and the
  "useful files when something breaks" list.