### PR TITLE
tests: expand coverage with 10 new test suites

### DIFF
--- a/tests/test_buckets_properties.py
+++ b/tests/test_buckets_properties.py
@@ -1,0 +1,161 @@
+"""Property-based / exhaustive tests for the bucket algebra.
+
+The bucket primitives (``buckets.py``) are the single source of truth for the
+whole pipeline — a drift here breaks the miner, the picker, the renderer, and
+every downstream tool. The search space is small (1440 HH:MM strings × 60
+minute values) so we can enumerate exhaustively rather than sample.
+
+Hypothesis-style property tests would add a dependency for no real gain when
+exhaustive enumeration is cheap. These tests are the exhaustive equivalent.
+"""
+from __future__ import annotations
+
+import pytest
+
+from buckets import (
+    BUCKET_ORDER,
+    DEFAULT_BUCKET_MINUTES,
+    bucket_for_time,
+    minute_bucket,
+    neighbor_buckets,
+)
+
+
+def _all_buckets() -> list[str]:
+    return [f"h{h}_{state}" for h in range(1, 13) for state in BUCKET_ORDER]
+
+
+class TestMinuteBucketExhaustive:
+    def test_every_valid_minute_maps_to_a_known_state(self):
+        for m in range(60):
+            state = minute_bucket(m)
+            assert state in BUCKET_ORDER
+
+    def test_default_bucket_minutes_roundtrip(self):
+        """For every canonical minute M, ``minute_bucket(M)`` equals the state
+        whose ``DEFAULT_BUCKET_MINUTES`` entry is M. This locks in the two-way
+        mapping between minutes and state names."""
+        for state, m in DEFAULT_BUCKET_MINUTES.items():
+            assert minute_bucket(m) == state, f"minute {m} → {minute_bucket(m)} but default says {state}"
+
+    def test_rounding_is_monotonic_per_half_bucket(self):
+        """Minutes within ±2 of a canonical value all map to that state.
+        Formalizes the 5-minute window centered on each canonical minute.
+
+        The rule is ``((minute + 2) // 5) * 5``; minute=58..59 round up to 60
+        and wrap to ``exact`` (the next hour). So ``five_to`` owns 53..57,
+        not 53..58. ``exact`` owns 58..59 and 0..2.
+        """
+        for state, canonical in DEFAULT_BUCKET_MINUTES.items():
+            for offset in (-2, -1, 0, 1, 2):
+                m = canonical + offset
+                if m < 0 or m >= 60:
+                    continue
+                assert minute_bucket(m) == state, f"{m} → {minute_bucket(m)}, expected {state}"
+
+    def test_top_of_hour_wraparound_58_59_are_exact(self):
+        assert minute_bucket(58) == "exact"
+        assert minute_bucket(59) == "exact"
+
+    def test_rejects_out_of_range(self):
+        with pytest.raises(ValueError):
+            minute_bucket(-1)
+        with pytest.raises(ValueError):
+            minute_bucket(60)
+
+
+class TestBucketForTimeExhaustive:
+    def test_every_hhmm_returns_known_bucket(self):
+        known = set(_all_buckets())
+        for h in range(24):
+            for m in range(60):
+                bucket = bucket_for_time(f"{h:02d}:{m:02d}")
+                assert bucket in known, f"{h:02d}:{m:02d} → {bucket!r} not in known buckets"
+
+    def test_hour_wraps_to_12_format(self):
+        # 24-hour 0 → h12, 13 → h1, etc.
+        assert bucket_for_time("00:00") == "h12_exact"
+        assert bucket_for_time("12:00") == "h12_exact"
+        assert bucket_for_time("13:00") == "h1_exact"
+        assert bucket_for_time("23:00") == "h11_exact"
+
+    def test_minute_58_rolls_hour_forward(self):
+        assert bucket_for_time("03:58") == "h4_exact"
+        assert bucket_for_time("11:58") == "h12_exact"  # 12-hour wrap
+        assert bucket_for_time("12:58") == "h1_exact"
+        assert bucket_for_time("23:58") == "h12_exact"  # 24→0→h12
+
+    def test_am_pm_collision_is_expected(self):
+        """3:15 AM and 3:15 PM bucket identically — the picker relies on this
+        (a quote mentioning ``3:15`` appears for both times of day). If this
+        ever changes, pick_quote's fallback walker needs to be reviewed too."""
+        for h in range(12):
+            for m in range(60):
+                morning = bucket_for_time(f"{h:02d}:{m:02d}")
+                afternoon = bucket_for_time(f"{h + 12:02d}:{m:02d}")
+                assert morning == afternoon, f"{h}:{m} vs {h+12}:{m} diverge"
+
+
+class TestNeighborBucketsProperties:
+    @pytest.mark.parametrize("bucket", _all_buckets())
+    def test_contains_exactly_12_buckets(self, bucket):
+        assert len(neighbor_buckets(bucket)) == 12
+
+    @pytest.mark.parametrize("bucket", _all_buckets())
+    def test_self_is_first(self, bucket):
+        assert neighbor_buckets(bucket)[0] == bucket
+
+    @pytest.mark.parametrize("bucket", _all_buckets())
+    def test_all_unique(self, bucket):
+        neighbors = neighbor_buckets(bucket)
+        assert len(set(neighbors)) == len(neighbors), f"duplicate neighbor: {neighbors}"
+
+    @pytest.mark.parametrize("bucket", _all_buckets())
+    def test_all_share_same_hour(self, bucket):
+        """The fallback walker never crosses hour boundaries — a 3:02 quote
+        can fall back to 3:05 or 3:10 but never to 4:00 or 2:55."""
+        hour_part = bucket.split("_", 1)[0]
+        for neighbor in neighbor_buckets(bucket):
+            assert neighbor.startswith(f"{hour_part}_"), f"{neighbor} escapes hour {hour_part}"
+
+    @pytest.mark.parametrize("bucket", _all_buckets())
+    def test_all_neighbors_are_valid_buckets(self, bucket):
+        known = set(_all_buckets())
+        for neighbor in neighbor_buckets(bucket):
+            assert neighbor in known, f"invalid neighbor {neighbor!r}"
+
+    @pytest.mark.parametrize("bucket", _all_buckets())
+    def test_distance_ordering_is_alternating(self, bucket):
+        """Neighbours appear in order 0, -1, +1, -2, +2, … relative to the
+        starting state index. This is what pick_quote documents."""
+        state = bucket.split("_", 1)[1]
+        idx = BUCKET_ORDER.index(state)
+        distances = []
+        for neighbor in neighbor_buckets(bucket):
+            n_state = neighbor.split("_", 1)[1]
+            distances.append(BUCKET_ORDER.index(n_state) - idx)
+        # Absolute distances must be non-decreasing.
+        abs_dists = [abs(d) for d in distances]
+        for i in range(1, len(abs_dists)):
+            assert abs_dists[i] >= abs_dists[i - 1], f"non-monotonic distance order: {abs_dists}"
+
+
+class TestBucketInvariants:
+    """Properties that cross primitives."""
+
+    def test_bucket_for_time_state_matches_minute_bucket_when_no_rollover(self):
+        for h in range(24):
+            for m in range(58):  # 58, 59 roll forward; skip
+                bucket = bucket_for_time(f"{h:02d}:{m:02d}")
+                state = bucket.split("_", 1)[1]
+                assert state == minute_bucket(m), f"{h}:{m} bucket state {state} vs {minute_bucket(m)}"
+
+    def test_canonical_time_for_bucket_roundtrips(self):
+        """For every (h, canonical_minute_state) pair, bucket_for_time of
+        ``h:canonical_minute`` returns the matching bucket. This is the
+        invariant contact_sheet.py relies on for placing tiles."""
+        for h12 in range(1, 13):
+            h24 = 0 if h12 == 12 else h12  # Use AM for simplicity
+            for state, minute in DEFAULT_BUCKET_MINUTES.items():
+                bucket = bucket_for_time(f"{h24:02d}:{minute:02d}")
+                assert bucket == f"h{h12}_{state}", f"{h24}:{minute} → {bucket}, expected h{h12}_{state}"

--- a/tests/test_cli_main_smoke.py
+++ b/tests/test_cli_main_smoke.py
@@ -1,0 +1,206 @@
+"""Smoke tests for every script's CLI ``main()`` entry point.
+
+Existing modules (``test_pick_quote.py``, ``test_render_quote.py``, …) already
+exercise each library surface thoroughly, but they tend to import functions
+directly and call them in-process. These tests instead shell out to
+``python -m <script>`` so we catch the class of breakage that unit tests miss:
+
+* An argparse default that evaluates to ``None`` on import (``--input`` required
+  unexpectedly).
+* A top-level ``import`` that blows up on a fresh checkout (e.g. deleted
+  module, missing ``if __name__ == "__main__"`` guard).
+* A ``--help`` that crashes inside argparse formatter (rare but brutal).
+
+The goal is shallow but broad: every script gets at least ``--help``, and where
+a trivial no-op invocation is possible (small fake JSONL input), that too.
+These tests deliberately avoid heavy cases — the per-script test modules own
+behavioural coverage; this is a boot-time tripwire.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Scripts whose --help should always exit 0.
+HELP_SCRIPTS = [
+    "apply_content_overrides",
+    "bucket_coverage",
+    "clean_display_quotes",
+    "contact_sheet",
+    "display_inky",
+    "enrich_metadata",
+    "fix_legacy_buckets",
+    "fix_substring_time_matches",
+    "gutenberg_time_miner",
+    "import_targeted_hits",
+    "litclock_health",
+    "merge_candidates",
+    "pick_quote",
+    "probe_buttons",
+    "quality_filter",
+    "render_quote",
+    "run_clock",
+    "target_sparse_buckets",
+]
+
+
+def _run(args: list[str], **kwargs) -> subprocess.CompletedProcess:
+    """Run ``python -m <script>`` from the repo root."""
+    return subprocess.run(
+        [sys.executable, *args],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        timeout=30,
+        **kwargs,
+    )
+
+
+@pytest.mark.parametrize("script", HELP_SCRIPTS)
+def test_help_exits_zero(script):
+    """Every script's ``--help`` must exit 0 and print usage."""
+    result = _run([f"{script}.py", "--help"])
+    assert result.returncode == 0, f"{script} --help exited {result.returncode}: {result.stderr}"
+    assert "usage" in result.stdout.lower(), f"{script} --help produced no usage line"
+
+
+class TestPickQuoteMain:
+    def test_time_flag_runs_end_to_end(self, tmp_path):
+        """``pick_quote --time HH:MM`` must emit valid JSON with required fields
+        against the shipped corpus."""
+        result = _run(["pick_quote.py", "--time", "14:30", "--history-path", ""])
+        assert result.returncode == 0, result.stderr
+        payload = json.loads(result.stdout)
+        assert "display_quote" in payload
+        assert "resolved_bucket" in payload
+        assert "used_fallback" in payload
+
+    def test_bucket_flag_runs(self):
+        result = _run(["pick_quote.py", "--bucket", "h2_half_past", "--history-path", ""])
+        assert result.returncode == 0, result.stderr
+        payload = json.loads(result.stdout)
+        assert payload.get("resolved_bucket", "").startswith("h2_")
+
+
+class TestLitclockHealthMain:
+    def test_missing_telemetry_exits_1(self, tmp_path):
+        """``litclock_health --telemetry-path <missing>`` exits 1 (not 0, not crash)."""
+        result = _run(["litclock_health.py", "--telemetry-path", str(tmp_path / "nope.jsonl")])
+        assert result.returncode == 1, f"expected 1, got {result.returncode}: {result.stderr}"
+
+    def test_empty_telemetry_json_mode(self, tmp_path):
+        """``--json`` with an empty-but-existing log emits valid JSON even with zero entries."""
+        log = tmp_path / "telemetry.jsonl"
+        log.write_text("", encoding="utf-8")
+        result = _run(["litclock_health.py", "--telemetry-path", str(log), "--json"])
+        # Empty log behaves like missing (exit 1) in current implementation —
+        # we care that it's JSON on stdout OR a clean exit code, not a traceback.
+        assert "Traceback" not in result.stderr, result.stderr
+
+    def test_fail_if_no_renders_flag_sets_exit_2(self, tmp_path):
+        """``--fail-if-no-renders`` on a silent window must exit 2, not 0."""
+        log = tmp_path / "telemetry.jsonl"
+        log.write_text("", encoding="utf-8")
+        result = _run([
+            "litclock_health.py",
+            "--telemetry-path", str(log),
+            "--hours", "1",
+            "--fail-if-no-renders",
+        ])
+        # Exit code 1 (no log) or 2 (no renders) are both valid "unhealthy"
+        # signals; the regression we're catching is exit 0.
+        assert result.returncode != 0, f"silent window exited 0: {result.stdout}"
+
+
+class TestPipelineStageMains:
+    """Each pipeline stage should run cleanly on a small valid input."""
+
+    def _write_rows(self, tmp_path: Path, rows: list[dict], name: str = "in.jsonl") -> Path:
+        path = tmp_path / name
+        with path.open("w", encoding="utf-8") as f:
+            for row in rows:
+                f.write(json.dumps(row) + "\n")
+        return path
+
+    def test_merge_candidates_on_single_input(self, tmp_path):
+        """Merging a single harvest file should produce a dedup summary."""
+        rows = [{
+            "source_id": "1",
+            "source_path": "x.txt",
+            "match_type": "oclock_word",
+            "matched_text": "three o'clock",
+            "quote_text": "It was three o'clock.",
+            "context_text": "It was three o'clock in the afternoon.",
+            "hour": 3, "minute": 0,
+            "normalized_time": "03:00",
+            "fuzzy_bucket": "h3_exact",
+            "daypart_bucket": None,
+            "line_number": 1,
+            "match_start": 7,
+            "match_end": 20,
+        }]
+        inp = self._write_rows(tmp_path, rows)
+        out = tmp_path / "merged.jsonl"
+        result = _run(["merge_candidates.py", str(inp), "--output", str(out)])
+        assert result.returncode == 0, result.stderr
+        assert out.exists()
+        merged = [json.loads(line) for line in out.read_text(encoding="utf-8").splitlines() if line]
+        assert len(merged) == 1
+        assert "canonical_quote" in merged[0]
+
+    def test_quality_filter_adds_score(self, tmp_path):
+        rows = [{
+            "source_id": "1",
+            "source_path": "x.txt",
+            "match_type": "oclock_word",
+            "matched_text": "three o'clock",
+            "quote_text": "It was three o'clock in the afternoon.",
+            "context_text": "It was three o'clock in the afternoon.",
+            "hour": 3, "minute": 0,
+            "normalized_time": "03:00",
+            "fuzzy_bucket": "h3_exact",
+            "daypart_bucket": None,
+            "line_number": 1,
+            "match_start": 7,
+            "match_end": 20,
+            "canonical_quote": "it was three o'clock in the afternoon.",
+            "canonical_context": "it was three o'clock in the afternoon.",
+            "display_quote": "It was three o'clock in the afternoon.",
+            "display_fragment": False,
+            "cleanup_status": "complete_sentence",
+        }]
+        inp = self._write_rows(tmp_path, rows)
+        out = tmp_path / "scored.jsonl"
+        result = _run(["quality_filter.py", str(inp), "--output", str(out)])
+        assert result.returncode == 0, result.stderr
+        scored = [json.loads(line) for line in out.read_text(encoding="utf-8").splitlines() if line]
+        assert "quality_score" in scored[0]
+        assert isinstance(scored[0]["quality_score"], int)
+        assert "quality_flags" in scored[0]
+
+
+class TestRunClockOnce:
+    """``run_clock --once`` is the most-used smoke entry point — cron / systemd
+    start with it during first bring-up."""
+
+    def test_once_renders_a_frame(self, tmp_path):
+        out = tmp_path / "frame.png"
+        result = _run([
+            "run_clock.py",
+            "--once",
+            "--output", str(out),
+            "--mode", "production",
+            "--history-path", "",
+            "--state-path", "",
+            "--telemetry-path", "",
+            "--quiet-off",
+        ])
+        assert result.returncode == 0, f"run_clock --once failed: {result.stderr}"
+        assert out.exists(), "--once did not produce a frame"
+        assert out.stat().st_size > 0, "--once produced an empty PNG"

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -91,18 +91,21 @@ class TestConcurrentLedgerAppend:
     def test_concurrent_appends_produce_well_formed_jsonl(self, tmp_path):
         """N threads each appending M entries concurrently should produce
         exactly N*M valid JSON lines — no interleaved writes, no dropped
-        entries. ``append_history`` uses O_APPEND + small writes so the
-        kernel provides atomicity at the line level."""
+        entries. ``append_history`` opens the file with ``mode="a"`` (O_APPEND)
+        and writes one short JSON line per call; on POSIX, writes smaller than
+        ``PIPE_BUF`` (4096 on Linux) to an O_APPEND file are atomic, so threads
+        calling ``append_history`` concurrently — with NO external lock — must
+        still produce line-atomic output.
+        """
         path = tmp_path / "history.jsonl"
         n_threads = 8
         n_per_thread = 25
 
-        ledger_lock = threading.Lock()
-
         def worker(tid: int):
             for i in range(n_per_thread):
-                with ledger_lock:
-                    pick_quote.append_history(str(path), f"src-{tid}", i)
+                # Intentionally no lock — we're verifying kernel-level atomicity,
+                # not application-level serialisation.
+                pick_quote.append_history(str(path), f"src-{tid}", i)
 
         threads = [threading.Thread(target=worker, args=(i,)) for i in range(n_threads)]
         for t in threads:
@@ -202,24 +205,9 @@ class TestRenderGateFairness:
         assert dropped_count == 20
 
 
-class TestActionThreadSafety:
-    def test_action_theme_toggles_do_not_lose_updates(self, tmp_path):
-        """Sequential action_theme calls with the stub render mock; verify
-        ``manual_theme`` reflects the toggle count correctly (even, 8 flips,
-        ends on default)."""
-        args = _args(tmp_path)
-        state = run_clock.RuntimeState("default")
-        state.last_effective_theme = "default"
-
-        with patch("run_clock.render_now"), \
-             patch("run_clock.current_time_str", return_value="10:00"), \
-             patch("run_clock.current_bucket", return_value="h10_exact"):
-            for _ in range(8):
-                result = run_clock.action_theme(args, state, label="test")
-                assert result["ok"] is True
-
-        # 8 toggles: default → dark → default → … → default (even parity).
-        assert state.manual_theme == "default"
+class TestActionBusyBehavior:
+    """The busy/drop contract is genuinely concurrent: a second caller must
+    observe the render_lock held by someone else and bail out."""
 
     def test_action_theme_is_dropped_when_render_in_flight(self, tmp_path):
         """If another thread is rendering, action_theme must return
@@ -233,3 +221,55 @@ class TestActionThreadSafety:
             result = run_clock.action_theme(args, state, label="test")
         assert result == {"ok": False, "error": "busy"}
         assert state.manual_theme is None, "theme must NOT have been mutated while busy"
+
+    def test_parallel_theme_toggles_with_one_blocked_by_lock(self, tmp_path):
+        """Launch two concurrent action_theme calls; the one that arrives
+        while render_lock is held must drop, the other must succeed. This is
+        the actual multi-thread property run_clock's HTTP + GPIO paths rely on."""
+        args = _args(tmp_path)
+        state = run_clock.RuntimeState("default")
+        state.last_effective_theme = "default"
+
+        holder_in = threading.Event()
+        holder_release = threading.Event()
+        results: list[dict] = []
+
+        def holder():
+            with state.render_lock:
+                holder_in.set()
+                holder_release.wait(timeout=2)
+
+        def tap():
+            results.append(run_clock.action_theme(args, state, label="tap"))
+
+        h = threading.Thread(target=holder)
+        h.start()
+        holder_in.wait(timeout=2)
+        t = threading.Thread(target=tap)
+        t.start()
+        t.join(timeout=2)
+        holder_release.set()
+        h.join(timeout=2)
+
+        assert results == [{"ok": False, "error": "busy"}]
+        assert state.manual_theme is None
+
+
+class TestActionThemeToggleArithmetic:
+    """Not a concurrency test — locks in the even/odd parity of manual_theme
+    under repeated toggling so a signed-int regression surfaces immediately."""
+
+    def test_eight_sequential_toggles_end_on_default(self, tmp_path):
+        args = _args(tmp_path)
+        state = run_clock.RuntimeState("default")
+        state.last_effective_theme = "default"
+
+        with patch("run_clock.render_now"), \
+             patch("run_clock.current_time_str", return_value="10:00"), \
+             patch("run_clock.current_bucket", return_value="h10_exact"):
+            for _ in range(8):
+                result = run_clock.action_theme(args, state, label="test")
+                assert result["ok"] is True
+
+        # 8 toggles: default → dark → default → … → default (even parity).
+        assert state.manual_theme == "default"

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -1,0 +1,235 @@
+"""Concurrency / lock-ordering stress tests.
+
+The main loop, button handlers, and the curator web server all live in the
+same process and share three locks on ``RuntimeState``:
+
+* ``render_lock``   — whoever holds this is painting to the panel
+* ``ledger_lock``   — serialises ``append_history`` / ``remove_last_history_entry``
+* ``lock``          — protects scalar state fields (``manual_theme`` etc.)
+
+These tests don't try to exhaustively verify correctness under every
+interleaving (impossible in Python without model checking). They lock in the
+observable guarantees the code comments promise:
+
+* ``_button_render_gate`` drops presses during in-flight renders rather than
+  queuing — so a burst of taps during a slow Spectra 6 refresh does NOT
+  execute N handlers N ticks later.
+* ``append_history`` under ``ledger_lock`` produces well-formed JSONL even
+  under concurrent writers.
+* ``remove_last_history_entry`` is atomic — a concurrent reader never sees
+  a torn ledger.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import threading
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+import pick_quote
+import run_clock
+
+
+def _args(tmp_path: Path, **overrides) -> argparse.Namespace:
+    defaults = dict(
+        render_script="render_quote.py",
+        output=str(tmp_path / "current.png"),
+        width=800,
+        height=480,
+        display_script=None,
+        mode="debug",
+        theme="default",
+        history_path=str(tmp_path / "history.jsonl"),
+        history_days=7,
+        telemetry_path="",
+        state_path=str(tmp_path / "state.json"),
+        quiet_image="",
+        shutdown_command="",
+    )
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+class TestRenderGateDropsConcurrentPresses:
+    def test_second_press_is_dropped_while_first_holds_lock(self, tmp_path, capsys):
+        """A second button press that arrives while a render is in flight is
+        dropped (returns without running its body), NOT queued. This is the
+        "first press wins" contract documented in run_clock."""
+        state = run_clock.RuntimeState("default")
+        first_entered = threading.Event()
+        release_first = threading.Event()
+        observed = []
+
+        def slow_first():
+            with run_clock._button_render_gate(state, "first") as acquired:
+                observed.append(("first", acquired))
+                first_entered.set()
+                release_first.wait(timeout=2)
+
+        def immediate_second():
+            with run_clock._button_render_gate(state, "second") as acquired:
+                observed.append(("second", acquired))
+
+        t1 = threading.Thread(target=slow_first)
+        t1.start()
+        first_entered.wait(timeout=2)
+        t2 = threading.Thread(target=immediate_second)
+        t2.start()
+        t2.join(timeout=2)
+        release_first.set()
+        t1.join(timeout=2)
+
+        assert ("first", True) in observed
+        assert ("second", False) in observed, "second press should have been dropped, not queued"
+
+
+class TestConcurrentLedgerAppend:
+    def test_concurrent_appends_produce_well_formed_jsonl(self, tmp_path):
+        """N threads each appending M entries concurrently should produce
+        exactly N*M valid JSON lines — no interleaved writes, no dropped
+        entries. ``append_history`` uses O_APPEND + small writes so the
+        kernel provides atomicity at the line level."""
+        path = tmp_path / "history.jsonl"
+        n_threads = 8
+        n_per_thread = 25
+
+        ledger_lock = threading.Lock()
+
+        def worker(tid: int):
+            for i in range(n_per_thread):
+                with ledger_lock:
+                    pick_quote.append_history(str(path), f"src-{tid}", i)
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(n_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+        assert path.exists()
+        lines = path.read_text(encoding="utf-8").splitlines()
+        assert len(lines) == n_threads * n_per_thread
+        parsed = [json.loads(line) for line in lines]  # must not raise
+        keys = {(e["source_id"], e["line_number"]) for e in parsed}
+        assert len(keys) == n_threads * n_per_thread, "some appends were lost or collided"
+
+    def test_unskip_rewrite_is_atomic_under_concurrent_reader(self, tmp_path):
+        """``remove_last_history_entry`` rewrites the ledger atomically
+        (via ``atomic_io.atomic_write_text``). A reader running concurrently
+        with the rewrite sees either the pre-rewrite or the post-rewrite
+        content — never a torn/empty ledger."""
+        path = tmp_path / "history.jsonl"
+        for i in range(50):
+            pick_quote.append_history(str(path), "src-X", i)
+
+        stop = threading.Event()
+        errors: list[str] = []
+        reader_counts: list[int] = []
+
+        def reader():
+            while not stop.is_set():
+                try:
+                    content = path.read_text(encoding="utf-8")
+                    lines = [l for l in content.splitlines() if l.strip()]
+                    for line in lines:
+                        json.loads(line)  # every line must be valid JSON
+                    reader_counts.append(len(lines))
+                except json.JSONDecodeError as exc:
+                    errors.append(f"torn ledger: {exc}")
+                except FileNotFoundError:
+                    errors.append("ledger disappeared")
+
+        t = threading.Thread(target=reader)
+        t.start()
+        try:
+            for i in range(10):
+                pick_quote.remove_last_history_entry(str(path), "src-X", 49 - i)
+                time.sleep(0.001)
+        finally:
+            stop.set()
+            t.join(timeout=2)
+
+        assert not errors, f"reader saw corruption: {errors[:3]}"
+        assert reader_counts, "reader never ran"
+
+
+class TestRenderGateFairness:
+    def test_many_bursty_presses_resolve_to_at_most_in_flight_count(self, tmp_path):
+        """When 20 handlers fire concurrently while one slow renderer holds the
+        lock, only the first should get ``acquired=True``; the rest must see
+        ``False`` and drop immediately."""
+        state = run_clock.RuntimeState("default")
+        running = threading.Event()
+        release = threading.Event()
+        acquired_count = 0
+        dropped_count = 0
+        count_lock = threading.Lock()
+
+        def slow_holder():
+            with run_clock._button_render_gate(state, "holder") as acquired:
+                assert acquired
+                running.set()
+                release.wait(timeout=5)
+
+        def taps():
+            nonlocal acquired_count, dropped_count
+            with run_clock._button_render_gate(state, "tap") as acquired:
+                with count_lock:
+                    if acquired:
+                        acquired_count += 1
+                    else:
+                        dropped_count += 1
+
+        holder = threading.Thread(target=slow_holder)
+        holder.start()
+        running.wait(timeout=2)
+
+        tappers = [threading.Thread(target=taps) for _ in range(20)]
+        for t in tappers:
+            t.start()
+        for t in tappers:
+            t.join(timeout=2)
+
+        release.set()
+        holder.join(timeout=2)
+
+        # Every one of the 20 tappers arrived while the holder had the lock.
+        assert acquired_count == 0
+        assert dropped_count == 20
+
+
+class TestActionThreadSafety:
+    def test_action_theme_toggles_do_not_lose_updates(self, tmp_path):
+        """Sequential action_theme calls with the stub render mock; verify
+        ``manual_theme`` reflects the toggle count correctly (even, 8 flips,
+        ends on default)."""
+        args = _args(tmp_path)
+        state = run_clock.RuntimeState("default")
+        state.last_effective_theme = "default"
+
+        with patch("run_clock.render_now"), \
+             patch("run_clock.current_time_str", return_value="10:00"), \
+             patch("run_clock.current_bucket", return_value="h10_exact"):
+            for _ in range(8):
+                result = run_clock.action_theme(args, state, label="test")
+                assert result["ok"] is True
+
+        # 8 toggles: default → dark → default → … → default (even parity).
+        assert state.manual_theme == "default"
+
+    def test_action_theme_is_dropped_when_render_in_flight(self, tmp_path):
+        """If another thread is rendering, action_theme must return
+        ``{"ok": False, "error": "busy"}`` without touching state."""
+        args = _args(tmp_path)
+        state = run_clock.RuntimeState("default")
+        state.last_effective_theme = "default"
+
+        # Hold the render lock so the gate rejects.
+        with state.render_lock:
+            result = run_clock.action_theme(args, state, label="test")
+        assert result == {"ok": False, "error": "busy"}
+        assert state.manual_theme is None, "theme must NOT have been mutated while busy"

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -28,8 +28,6 @@ import time
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
-
 import pick_quote
 import run_clock
 
@@ -137,7 +135,7 @@ class TestConcurrentLedgerAppend:
             while not stop.is_set():
                 try:
                     content = path.read_text(encoding="utf-8")
-                    lines = [l for l in content.splitlines() if l.strip()]
+                    lines = [line for line in content.splitlines() if line.strip()]
                     for line in lines:
                         json.loads(line)  # every line must be valid JSON
                     reader_counts.append(len(lines))

--- a/tests/test_corpus_invariants.py
+++ b/tests/test_corpus_invariants.py
@@ -1,0 +1,234 @@
+"""Invariants over the shipped runtime corpus.
+
+These tests read ``assets/candidates-attributed.jsonl`` (the picker's default
+input) and assert schema / bucket / metadata invariants that the pipeline is
+supposed to guarantee. A break here typically means a miner or cleanup stage
+regressed and a rebuild is needed.
+
+The checks are *schema* and *cross-field consistency* — not statistical checks
+like "every bucket must have >= N quotes" (that's ``bucket_coverage.py``'s job).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from buckets import BUCKET_ORDER, bucket_for_time, minute_bucket
+
+CORPUS_PATH = Path(__file__).resolve().parent.parent / "assets" / "candidates-attributed.jsonl"
+
+pytestmark = pytest.mark.skipif(not CORPUS_PATH.exists(), reason="shipped corpus missing")
+
+
+@pytest.fixture(scope="module")
+def corpus_rows() -> list[dict]:
+    rows = []
+    with CORPUS_PATH.open(encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                rows.append(json.loads(line))
+    return rows
+
+
+class TestCorpusSchema:
+    def test_corpus_is_nonempty(self, corpus_rows):
+        assert len(corpus_rows) > 100, "corpus looks suspiciously small"
+
+    def test_required_fields_present(self, corpus_rows):
+        required = {
+            "source_id",
+            "match_type",
+            "matched_text",
+            "display_quote",
+            "display_fragment",
+            "cleanup_status",
+            "quality_score",
+            "quality_flags",
+        }
+        for row in corpus_rows:
+            missing = required - set(row.keys())
+            assert not missing, f"row missing fields {missing}: {row.get('source_id')}:{row.get('line_number')}"
+
+    def test_quality_score_range(self, corpus_rows):
+        for row in corpus_rows:
+            score = row["quality_score"]
+            assert isinstance(score, int), f"quality_score must be int, got {type(score).__name__}"
+            assert 0 <= score <= 100, f"quality_score {score} out of [0, 100]"
+
+    def test_quality_flags_is_list_of_str(self, corpus_rows):
+        for row in corpus_rows:
+            flags = row["quality_flags"]
+            assert isinstance(flags, list)
+            assert all(isinstance(f, str) for f in flags)
+
+    def test_display_fragment_is_bool(self, corpus_rows):
+        for row in corpus_rows:
+            assert isinstance(row["display_fragment"], bool)
+
+    def test_cleanup_status_is_known(self, corpus_rows):
+        allowed = {"complete_sentence", "fragment_fallback", "empty"}
+        for row in corpus_rows:
+            assert row["cleanup_status"] in allowed, f"unknown cleanup_status {row['cleanup_status']!r}"
+
+    def test_display_quote_is_nonempty_string(self, corpus_rows):
+        for row in corpus_rows:
+            dq = row["display_quote"]
+            assert isinstance(dq, str)
+            assert dq.strip(), f"empty display_quote at {row.get('source_id')}:{row.get('line_number')}"
+
+
+VALID_FUZZY_BUCKETS = {f"h{h}_{state}" for h in range(1, 13) for state in BUCKET_ORDER}
+VALID_DAYPART_BUCKETS = {
+    "midnight", "small_hours", "dawn", "morning", "noon", "afternoon",
+    "dusk", "evening", "night",
+}
+
+
+class TestBucketConsistency:
+    def test_fuzzy_bucket_is_known_or_null(self, corpus_rows):
+        valid = VALID_FUZZY_BUCKETS | {None}
+        for row in corpus_rows:
+            bucket = row.get("fuzzy_bucket")
+            assert bucket in valid, f"unknown fuzzy_bucket {bucket!r}"
+
+    def test_daypart_bucket_is_known_or_null(self, corpus_rows):
+        valid = VALID_DAYPART_BUCKETS | {None}
+        for row in corpus_rows:
+            bucket = row.get("daypart_bucket")
+            assert bucket in valid, f"unknown daypart_bucket {bucket!r}"
+
+    def test_fuzzy_bucket_matches_hour_minute(self, corpus_rows):
+        """When hour/minute are set, fuzzy_bucket must match what buckets.py computes.
+
+        This catches legacy 8-state bucket names (``just_after``, ``half_pastish``)
+        that should have been purged by ``fix_legacy_buckets.py``.
+        """
+        mismatches = []
+        for row in corpus_rows:
+            hour = row.get("hour")
+            minute = row.get("minute")
+            bucket = row.get("fuzzy_bucket")
+            if hour is None or minute is None or bucket is None:
+                continue
+            expected = bucket_for_time(f"{int(hour):02d}:{int(minute):02d}")
+            if bucket != expected:
+                mismatches.append((row.get("source_id"), row.get("line_number"), hour, minute, bucket, expected))
+        assert not mismatches, (
+            f"fuzzy_bucket disagrees with buckets.bucket_for_time for {len(mismatches)} rows; "
+            f"first offender: {mismatches[0]}"
+        )
+
+    def test_normalized_time_parses_when_hour_minute_set(self, corpus_rows):
+        for row in corpus_rows:
+            hour = row.get("hour")
+            minute = row.get("minute")
+            norm = row.get("normalized_time")
+            if hour is None and minute is None:
+                continue
+            assert norm, "normalized_time must be set when hour/minute are set"
+            parts = norm.split(":")
+            assert len(parts) == 2 and parts[0].isdigit() and parts[1].isdigit()
+            h, m = int(parts[0]), int(parts[1])
+            assert 0 <= h <= 23
+            assert 0 <= m <= 59
+
+    def test_hour_minute_in_valid_range(self, corpus_rows):
+        for row in corpus_rows:
+            hour = row.get("hour")
+            minute = row.get("minute")
+            if hour is not None:
+                assert 0 <= int(hour) <= 23
+            if minute is not None:
+                assert 0 <= int(minute) <= 59
+
+    def test_time_or_daypart_always_present(self, corpus_rows):
+        """Every row must have at least one of fuzzy_bucket or daypart_bucket —
+        otherwise it's unroutable by the picker."""
+        for row in corpus_rows:
+            assert row.get("fuzzy_bucket") or row.get("daypart_bucket"), (
+                f"row {row.get('source_id')}:{row.get('line_number')} has no bucket of any kind"
+            )
+
+
+class TestDeduplication:
+    # Current corpus has a small number of duplicate-position rows arising from
+    # the merge stage intentionally NOT dedup-ing across match_type (a
+    # `minutes_past_to` regex hit and a `targeted_phrase` hit at the same
+    # offset both survive). This test locks in that count as a ceiling so a
+    # merge-stage regression that silently doubles the corpus fires loudly.
+    MAX_POSITION_DUPLICATES = 40
+
+    def test_duplicate_position_rows_below_ceiling(self, corpus_rows):
+        seen = set()
+        dupes = []
+        for row in corpus_rows:
+            sid = row.get("source_id")
+            ln = row.get("line_number")
+            if sid is None or ln is None:
+                continue
+            key = (sid, ln, row.get("match_start"), row.get("match_end"))
+            if key in seen:
+                dupes.append(key)
+            seen.add(key)
+        assert len(dupes) <= self.MAX_POSITION_DUPLICATES, (
+            f"{len(dupes)} duplicate (source_id, line_number, match_start, match_end) rows "
+            f"exceeds ceiling {self.MAX_POSITION_DUPLICATES} — merge stage regression?"
+        )
+
+    def test_canonical_quote_dedup_within_bucket(self, corpus_rows):
+        """Within a (fuzzy_bucket, canonical_quote) pair, rows should be unique —
+        that's the merge_candidates dedup key. Violations mean merge silently dropped.
+        """
+        seen = set()
+        dupes = 0
+        for row in corpus_rows:
+            bucket = row.get("fuzzy_bucket")
+            canonical = row.get("canonical_quote")
+            normalized = row.get("normalized_time")
+            daypart = row.get("daypart_bucket")
+            if not canonical:
+                continue
+            key = (normalized, bucket, daypart, canonical)
+            if key in seen:
+                dupes += 1
+            seen.add(key)
+        # Lock current count as the ceiling. A clean corpus would be 0, but
+        # targeted_phrase vs original-regex collisions leave a known residue.
+        assert dupes <= 40, f"{dupes} rows violate the merge_candidates dedup key (ceiling 40)"
+
+
+class TestMetadataCoverage:
+    def test_author_title_present_on_gutenberg_rows(self, corpus_rows):
+        """Rows with a numeric source_id come from cached Gutenberg downloads, so
+        enrich_metadata should have attached author+title to the overwhelming
+        majority. Allow a small slop (some Gutenberg texts have unparseable
+        headers) but flag regressions."""
+        gutenberg_rows = [r for r in corpus_rows if str(r.get("source_id", "")).isdigit()]
+        if not gutenberg_rows:
+            pytest.skip("no gutenberg-sourced rows in corpus")
+        with_metadata = sum(1 for r in gutenberg_rows if r.get("author") and r.get("title"))
+        ratio = with_metadata / len(gutenberg_rows)
+        assert ratio >= 0.90, f"metadata coverage dropped to {ratio:.1%} of gutenberg rows — did enrich_metadata break?"
+
+
+class TestBucketsHelpers:
+    """Paranoid sanity checks on the primitives the invariants depend on."""
+
+    def test_bucket_order_is_twelve_states(self):
+        # 12 rounded-minute states; paired with 12 hours that's the 144 full buckets.
+        assert len(BUCKET_ORDER) == 12
+
+    def test_bucket_for_time_suffix_matches_minute_bucket(self):
+        for h in range(24):
+            for m in range(60):
+                suffix = minute_bucket(m)
+                # minute 58–59 rolls the hour forward to "exact", so for those minutes
+                # the bucket for the CURRENT hour may end in a different state from
+                # minute_bucket(m) when the time string is recomputed below — skip.
+                if m >= 58:
+                    continue
+                bucket = bucket_for_time(f"{h:02d}:{m:02d}")
+                assert bucket.endswith(f"_{suffix}"), f"{h:02d}:{m:02d} → {bucket} but state {suffix!r}"

--- a/tests/test_miner_match_types.py
+++ b/tests/test_miner_match_types.py
@@ -15,8 +15,6 @@ up in the wrong bucket).
 """
 from __future__ import annotations
 
-import pytest
-
 import gutenberg_time_miner as miner
 
 

--- a/tests/test_miner_match_types.py
+++ b/tests/test_miner_match_types.py
@@ -1,0 +1,228 @@
+"""Match-type matrix tests for gutenberg_time_miner.
+
+The existing ``test_gutenberg_time_miner.py`` covers the happy paths. This
+module focuses on the combinatorial space of match types × edge cases that
+the regex library has to get right:
+
+* Each match_type has a positive example (should produce a row with known
+  ``hour``, ``minute``).
+* Each match_type has a negative example that matches the pattern but is
+  correctly rejected (chapter-context digital, out-of-range hour, etc.).
+
+Most misses here mean the miner is silently dropping quotes (hard to notice
+at runtime) or producing wrong hour/minute (obvious, because the quote ends
+up in the wrong bucket).
+"""
+from __future__ import annotations
+
+import pytest
+
+import gutenberg_time_miner as miner
+
+
+def _first_candidate(text: str, match_type: str | None = None):
+    """Return the first Candidate produced by the miner, optionally filtered
+    to a single match_type."""
+    for c in miner.iter_candidates(
+        source_path="test.txt",
+        source_id=None,
+        text=text,
+        context_chars=120,
+        max_per_file=0,
+    ):
+        if match_type is None or c.match_type == match_type:
+            return c
+    return None
+
+
+class TestDigitalMatchType:
+    def test_simple_time_matches(self):
+        # Note: miner's digital regex uses IGNORECASE, so [A-Z] matches any letter —
+        # the lookahead (?!\s+[A-Z][a-z]) rejects times followed by <ws><word>,
+        # which rules out "14:30 on the dot". Close with punctuation to match.
+        c = _first_candidate("They arrived at 14:30. End of story.", "digital")
+        assert c is not None
+        assert c.hour == 14
+        assert c.minute == 30
+        assert c.normalized_time == "14:30"
+
+    def test_midnight_digital(self):
+        c = _first_candidate("The log showed 00:00. End of story.", "digital")
+        assert c is not None
+        assert c.hour == 0
+        assert c.minute == 0
+
+    def test_rejects_hour_over_23(self):
+        c = _first_candidate("Psalm 25:1 is clear.", "digital")
+        assert c is None, "25:01 must not be accepted as a digital time"
+
+    def test_rejects_chapter_context(self):
+        c = _first_candidate("See Chapter 14:30 for details.", "digital")
+        assert c is None
+
+    def test_rejects_psalm_context(self):
+        c = _first_candidate("As Psalm 14:30 teaches us well.", "digital")
+        assert c is None
+
+    def test_rejects_verse_context(self):
+        c = _first_candidate("Verse 14:30 records the event.", "digital")
+        assert c is None
+
+
+class TestOclockWordMatchType:
+    def test_three_oclock(self):
+        c = _first_candidate("It was three o'clock in the afternoon.", "oclock_word")
+        assert c is not None
+        assert c.hour == 3
+        assert c.minute == 0
+
+    def test_twelve_oclock(self):
+        c = _first_candidate("The bell tolled twelve o'clock sharp.", "oclock_word")
+        assert c is not None
+        assert c.hour == 12
+        assert c.minute == 0
+
+    def test_curly_apostrophe(self):
+        c = _first_candidate("It was three o’clock in the afternoon.", "oclock_word")
+        assert c is not None
+        assert c.hour == 3
+
+
+class TestQuarterHalfMatchType:
+    def test_quarter_past(self):
+        c = _first_candidate("At quarter past six, they left.", "quarter_half")
+        assert c is not None
+        assert c.hour == 6
+        assert c.minute == 15
+
+    def test_half_past(self):
+        c = _first_candidate("Half past two had come and gone.", "quarter_half")
+        assert c is not None
+        assert c.hour == 2
+        assert c.minute == 30
+
+    def test_hyphenated_half_past(self):
+        c = _first_candidate("It was half-past ten when we arrived.", "quarter_half")
+        # The regex may or may not accept hyphenation; just verify it doesn't crash.
+        if c is not None:
+            assert c.minute == 30
+
+
+class TestQuarterToMatchType:
+    def test_quarter_to_eight(self):
+        c = _first_candidate("Quarter to eight the bell rang.", "quarter_to")
+        assert c is not None
+        # "quarter to eight" means 7:45.
+        assert c.hour == 7
+        assert c.minute == 45
+
+    def test_quarter_to_one_wraps_to_twelve(self):
+        c = _first_candidate("Quarter to one the mail arrived.", "quarter_to")
+        assert c is not None
+        assert c.hour == 12
+        assert c.minute == 45
+
+
+class TestMinutesPastToMatchType:
+    def test_ten_minutes_past_five(self):
+        c = _first_candidate("At ten minutes past five they met.", "minutes_past_to")
+        assert c is not None
+        assert c.hour == 5
+        assert c.minute == 10
+
+    def test_twenty_minutes_to_three(self):
+        # "twenty minutes to three" = 2:40
+        c = _first_candidate("Twenty minutes to three the carriage stopped.", "minutes_past_to")
+        assert c is not None
+        assert c.hour == 2
+        assert c.minute == 40
+
+    def test_twenty_minutes_to_one_wraps(self):
+        c = _first_candidate("Twenty minutes to one the clock struck.", "minutes_past_to")
+        assert c is not None
+        assert c.hour == 12
+        assert c.minute == 40
+
+
+class TestJustAfterBeforeMatchType:
+    def test_shortly_after_three(self):
+        # The regex requires o'clock after the hourword (or a bare daypart).
+        c = _first_candidate("Shortly after three o'clock the rain came.", "just_after_before")
+        assert c is not None
+        assert c.hour == 3
+        assert c.minute == 3
+
+    def test_just_before_five(self):
+        c = _first_candidate("Just before five o'clock the shop closed.", "just_after_before")
+        assert c is not None
+        assert c.hour == 5
+        assert c.minute == 57
+
+    def test_almost_ten(self):
+        c = _first_candidate("Almost ten o'clock when the bell rang.", "just_after_before")
+        assert c is not None
+        assert c.hour == 10
+        assert c.minute == 57
+
+    def test_towards_dusk_uses_daypart_branch(self):
+        """The alternate branch of just_after_before accepts a bare daypart."""
+        c = _first_candidate("Towards dusk the fog thickened.", "just_after_before")
+        assert c is not None
+        assert c.daypart_bucket == "dusk"
+
+
+class TestClockStruckMatchType:
+    def test_struck_midnight(self):
+        c = _first_candidate("The clock struck midnight as they left.", "clock_struck")
+        assert c is not None
+        assert c.hour == 0
+        assert c.minute == 0
+
+    def test_struck_noon(self):
+        c = _first_candidate("The clock struck noon over the square.", "clock_struck")
+        assert c is not None
+        assert c.hour == 12
+        assert c.minute == 0
+
+    def test_struck_three(self):
+        c = _first_candidate("The clock struck three in the drawing room.", "clock_struck")
+        assert c is not None
+        assert c.hour == 3
+        assert c.minute == 0
+
+
+class TestDaypartMatchType:
+    def test_bare_dawn(self):
+        c = _first_candidate("They rode out at dawn toward the coast.", "daypart")
+        assert c is not None
+        assert c.daypart_bucket == "dawn"
+        assert c.hour is None
+        assert c.minute is None
+
+    def test_bare_dusk(self):
+        c = _first_candidate("By dusk the forest had grown silent.", "daypart")
+        assert c is not None
+        assert c.daypart_bucket == "dusk"
+
+
+class TestMatchedTextWhitespaceCollapsing:
+    def test_embedded_newline_is_collapsed(self):
+        """Miner collapses whitespace within matched_text so phrases captured
+        across a source-line break become a single clean phrase. This used to
+        be a fix_legacy_buckets repair; it is now done inline."""
+        text = "He met her at half\npast two that afternoon."
+        c = _first_candidate(text, "quarter_half")
+        assert c is not None
+        assert "\n" not in c.matched_text
+        assert c.matched_text == "half past two"
+
+
+class TestMineStrict:
+    def test_strict_excludes_daypart(self):
+        """--strict is used in production harvests to cut false positives;
+        daypart matches (bare ``dawn``, ``evening``) are usually noise."""
+        text = "It was three o'clock in the afternoon. They rode at dawn."
+        candidates = list(miner.iter_candidates("t.txt", None, text, 120, 0))
+        strict = [c for c in candidates if c.match_type != "daypart"]
+        assert any(c.match_type == "daypart" for c in candidates)
+        assert all(c.match_type != "daypart" for c in strict)

--- a/tests/test_miner_match_types.py
+++ b/tests/test_miner_match_types.py
@@ -101,11 +101,13 @@ class TestQuarterHalfMatchType:
         assert c.hour == 2
         assert c.minute == 30
 
-    def test_hyphenated_half_past(self):
+    def test_hyphenated_half_past_is_not_matched(self):
+        """The quarter_half regex uses ``\\s+`` between "half" and "past" — it
+        does NOT accept "half-past". Documenting this explicitly so the day
+        someone adds hyphen support, they also update this test rather than
+        silently changing observable behaviour."""
         c = _first_candidate("It was half-past ten when we arrived.", "quarter_half")
-        # The regex may or may not accept hyphenation; just verify it doesn't crash.
-        if c is not None:
-            assert c.minute == 30
+        assert c is None
 
 
 class TestQuarterToMatchType:

--- a/tests/test_pick_quote.py
+++ b/tests/test_pick_quote.py
@@ -571,3 +571,110 @@ class TestLoadOverrides:
         }))
         pq.load_overrides(path)
         assert capsys.readouterr().err == ""
+
+
+class TestInferQuoteMinute:
+    """The matched-text fallback is the only way to recover a minute when
+    ``normalized_time`` is missing. It drives ``minute_distance_penalty`` and
+    therefore directly affects which candidate wins in a given bucket, so
+    every pattern in ``EXACT_MINUTE_PATTERNS`` needs explicit coverage."""
+
+    def test_prefers_normalized_time_when_present(self):
+        row = {"normalized_time": "03:17", "matched_text": "quarter past three"}
+        # Normalized time wins even when matched_text disagrees.
+        assert pq.infer_quote_minute(row) == 17
+
+    def test_malformed_normalized_time_falls_through_to_matched_text(self):
+        row = {"normalized_time": "not-a-time", "matched_text": "quarter past three"}
+        assert pq.infer_quote_minute(row) == 15
+
+    def test_no_normalized_time_uses_matched_text(self):
+        row = {"matched_text": "half past eleven"}
+        assert pq.infer_quote_minute(row) == 30
+
+    def test_returns_none_when_nothing_matches(self):
+        row = {"matched_text": "a vague reference"}
+        assert pq.infer_quote_minute(row) is None
+
+    def test_empty_row(self):
+        assert pq.infer_quote_minute({}) is None
+
+    @pytest.mark.parametrize("phrase,minute", [
+        ("o’clock", 0),
+        ("oclock", 0),
+        ("the clock struck twelve", 0),
+        ("five minutes past two", 5),
+        ("five past two", 5),
+        ("ten minutes past four", 10),
+        ("ten past four", 10),
+        ("quarter past six", 15),
+        ("twenty minutes past three", 20),
+        ("twenty past three", 20),
+        ("half past nine", 30),
+        ("half-past nine", 30),
+        ("twenty-five minutes to three", 35),
+        ("twenty five to three", 35),
+        ("twenty minutes to three", 40),
+        ("twenty to three", 40),
+        ("quarter to eight", 45),
+        ("ten minutes to one", 50),
+        ("ten to one", 50),
+        ("five minutes to two", 55),
+        ("five to two", 55),
+    ])
+    def test_matched_text_patterns(self, phrase, minute):
+        row = {"matched_text": phrase}
+        assert pq.infer_quote_minute(row) == minute
+
+    def test_matched_text_case_insensitive(self):
+        row = {"matched_text": "QUARTER PAST THREE"}
+        assert pq.infer_quote_minute(row) == 15
+
+    def test_matched_text_with_embedded_newline(self):
+        # gutenberg_time_miner now collapses newlines, but legacy rows may still
+        # contain them — infer_quote_minute normalises before matching.
+        row = {"matched_text": "half\npast two"}
+        assert pq.infer_quote_minute(row) == 30
+
+    def test_known_substring_collision_twenty_five_past_matches_shorter_pattern(self):
+        # Documents a known limitation: "twenty-five minutes past" contains
+        # "five minutes past" (the 5-minute pattern) and dict-iteration order
+        # means the shorter pattern wins. In practice rows reach this code path
+        # only when normalized_time is missing, so the impact is minimal — but
+        # future callers should be aware.
+        row = {"matched_text": "twenty-five minutes past seven"}
+        assert pq.infer_quote_minute(row) == 5
+
+
+class TestMinuteDistancePenalty:
+    def test_returns_99_when_quote_minute_unknown(self):
+        row = {"matched_text": "some vague phrase"}
+        # Row has no normalized_time and no recognisable matched-text pattern.
+        assert pq.minute_distance_penalty(row, "h3_exact", "03:00") == 99
+
+    def test_returns_99_when_requested_is_unparseable(self):
+        row = {"normalized_time": "03:15"}
+        # bucket is a non-standard state name so DEFAULT_BUCKET_MINUTES returns None
+        assert pq.minute_distance_penalty(row, "h3_nonsense", None) == 99
+
+    def test_exact_distance_zero(self):
+        row = {"normalized_time": "03:15"}
+        assert pq.minute_distance_penalty(row, "h3_quarter_past", "03:15") == 0
+
+    def test_distance_uses_absolute_value(self):
+        row = {"normalized_time": "03:10"}
+        assert pq.minute_distance_penalty(row, "h3_quarter_past", "03:15") == 5
+
+
+class TestSourceRarityPenalty:
+    def test_no_source_id_returns_zero(self):
+        assert pq.source_rarity_penalty({"source_id": None}, pq.Counter({"1234": 10})) == 0
+        assert pq.source_rarity_penalty({}, pq.Counter({"1234": 10})) == 0
+
+    def test_returns_count_for_known_source(self):
+        counts = pq.Counter({"1234": 7})
+        assert pq.source_rarity_penalty({"source_id": "1234"}, counts) == 7
+
+    def test_unknown_source_returns_zero(self):
+        counts = pq.Counter({"1234": 7})
+        assert pq.source_rarity_penalty({"source_id": "9999"}, counts) == 0

--- a/tests/test_pipeline_integration.py
+++ b/tests/test_pipeline_integration.py
@@ -1,0 +1,202 @@
+"""End-to-end pipeline smoke test.
+
+Feeds a tiny synthetic Gutenberg-style text through every stage of the
+pipeline (miner → merge → clean → quality → enrich → apply_overrides → pick
+→ render) and asserts a PNG falls out. The value of this test is NOT deep
+per-stage coverage (every stage has its own module already), but catching
+inter-stage schema drift: a field one stage stops emitting that a later stage
+silently assumes is present.
+
+Why this belongs in its own module: it cuts across nearly every top-level
+script, so it has no natural home in a per-stage test file.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import pytest
+
+try:
+    from PIL import Image  # noqa: F401
+    PIL_AVAILABLE = True
+except ImportError:
+    PIL_AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(not PIL_AVAILABLE, reason="Pillow not installed")
+
+import apply_content_overrides
+import clean_display_quotes
+import enrich_metadata
+import gutenberg_time_miner as miner
+import merge_candidates
+import pick_quote
+import quality_filter
+import render_quote
+
+
+# A minimal but realistic Gutenberg body. Must include a Gutenberg-style header
+# (so enrich_metadata picks up Title / Author) and enough phrasing that every
+# active match_type can fire at least once.
+GUTENBERG_TEXT = """The Project Gutenberg eBook of Tiny Test Book
+
+Title: Tiny Test Book
+Author: Test Author
+
+*** START OF THE PROJECT GUTENBERG EBOOK TINY TEST BOOK ***
+
+It was three o'clock in the afternoon when she arrived at the gate,
+the sun still high above the orchard wall. She had agreed to meet him
+at quarter past six, and now feared she would be late returning home.
+
+At half past eight the clock in the hall began to chime, and the old
+man stirred in his chair. "Ten minutes past nine," he murmured, not
+quite awake, glancing at the mantelpiece clock.
+
+Shortly after noon the messenger returned with news from the village.
+The clock struck midnight just as the last guest departed from the hall,
+leaving the ballroom echoing and still.
+"""
+
+
+def _write_jsonl(path: Path, rows: list[dict]) -> None:
+    with path.open("w", encoding="utf-8") as f:
+        for row in rows:
+            f.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    rows = []
+    with path.open(encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                rows.append(json.loads(line))
+    return rows
+
+
+class TestPipelineEndToEnd:
+    def test_harvest_through_render_produces_png(self, tmp_path):
+        """Full pipeline smoke test — the most important regression guard
+        against inter-stage schema drift."""
+        # --- 1. Harvest -----------------------------------------------------
+        # The miner reads the file under download_dir/pg<id>.txt when given
+        # --gutenberg-id, but here we point --input at the file directly and
+        # post-stamp source_id so the downstream enrich step can find it.
+        cache_dir = tmp_path / "gutenberg"
+        cache_dir.mkdir()
+        book = cache_dir / "pg9999.txt"
+        book.write_text(GUTENBERG_TEXT, encoding="utf-8")
+
+        mine_args = argparse.Namespace(
+            gutenberg_id=[],
+            input=[str(book)],
+            download_dir=str(cache_dir),
+            context_chars=120,
+            max_per_file=0,
+            max_total=0,
+            exclude_match_type=[],
+            strict=False,
+            skip_fetch_errors=False,
+        )
+        candidates = miner.mine(mine_args)
+        assert candidates, "miner produced no candidates from the synthetic text"
+
+        harvest_path = tmp_path / "candidates.jsonl"
+        miner.write_jsonl(harvest_path, candidates)
+        harvest_rows = _read_jsonl(harvest_path)
+        for row in harvest_rows:
+            # Without --gutenberg-id the miner leaves source_id=None. Stamp it
+            # here so enrich_metadata can associate the row with pg9999.txt.
+            row["source_id"] = "9999"
+        _write_jsonl(harvest_path, harvest_rows)
+
+        # --- 2. Merge (dedup) ----------------------------------------------
+        records = list(merge_candidates.iter_records([str(harvest_path)]))
+        merged_rows, merge_stats = merge_candidates.dedupe(records)
+        assert merged_rows, "merge dropped every row (dedup bug?)"
+        assert merge_stats.get("deduped_rows", 0) == len(merged_rows)
+        merged_path = tmp_path / "merged.jsonl"
+        _write_jsonl(merged_path, merged_rows)
+
+        # --- 3. Clean display quotes ---------------------------------------
+        cleaned_rows = []
+        for row in merged_rows:
+            quote, fragment, status = clean_display_quotes.best_display_quote(row)
+            row = dict(row)
+            row["display_quote"] = quote
+            row["display_fragment"] = fragment
+            row["cleanup_status"] = status
+            cleaned_rows.append(row)
+        assert all("display_quote" in r for r in cleaned_rows)
+
+        # --- 4. Quality filter ---------------------------------------------
+        quality_rows = []
+        for row in cleaned_rows:
+            score, flags = quality_filter.score_quote(
+                row.get("display_quote") or "",
+                row.get("display_fragment", False),
+                row.get("cleanup_status") or "",
+            )
+            row = dict(row)
+            row["quality_score"] = score
+            row["quality_flags"] = flags
+            quality_rows.append(row)
+        assert all(isinstance(r["quality_flags"], list) for r in quality_rows)
+        assert all(0 <= r["quality_score"] <= 100 for r in quality_rows)
+
+        # --- 5. Enrich metadata --------------------------------------------
+        title, author = enrich_metadata.parse_header(book)
+        enriched_rows = []
+        for row in quality_rows:
+            row = dict(row)
+            if not row.get("author") and author:
+                row["author"] = author
+            if not row.get("title") and title:
+                row["title"] = title
+            enriched_rows.append(row)
+        assert any(r.get("title") == "Tiny Test Book" for r in enriched_rows), (
+            "enrich_metadata did not pick up Title header"
+        )
+        assert any(r.get("author") == "Test Author" for r in enriched_rows)
+
+        # --- 6. Apply content overrides (no-op sidecar) --------------------
+        patched_rows, applied = apply_content_overrides.apply_overrides(enriched_rows, {})
+        assert applied == 0  # empty sidecar → no patches
+        final_path = tmp_path / "candidates-attributed.jsonl"
+        _write_jsonl(final_path, patched_rows)
+
+        # --- 7. Pick a quote for 03:00 -------------------------------------
+        overrides = {"ban_source_ids": [], "boost_source_ids": [], "preferred_buckets": {}}
+        picked = pick_quote.select_quote(
+            time_str="03:00",
+            input_path=str(final_path),
+            rows=patched_rows,
+            overrides=overrides,
+            history_path=None,
+            history_days=0,
+            min_quality=0,
+        )
+        assert picked["display_quote"], "pick_quote returned no display_quote"
+        assert picked["bucket"] == "h3_exact"
+
+        # --- 8. Render to PNG ----------------------------------------------
+        output_path = tmp_path / "render.png"
+        image = render_quote.render("03:00", picked, 800, 480, mode="production", theme="default")
+        image.save(output_path, format="PNG")
+        image.close()
+        assert output_path.exists()
+        assert output_path.stat().st_size > 1024, "rendered PNG is suspiciously small"
+
+        with output_path.open("rb") as f:
+            magic = f.read(8)
+        assert magic == b"\x89PNG\r\n\x1a\n", "output is not a valid PNG"
+
+    def test_pipeline_survives_empty_corpus(self, tmp_path):
+        """Every stage must cope with an empty input without crashing."""
+        merged, stats = merge_candidates.dedupe(iter([]))
+        assert merged == []
+        patched, applied = apply_content_overrides.apply_overrides([], {})
+        assert patched == []
+        assert applied == 0

--- a/tests/test_pipeline_integration.py
+++ b/tests/test_pipeline_integration.py
@@ -26,15 +26,14 @@ except ImportError:
 
 pytestmark = pytest.mark.skipif(not PIL_AVAILABLE, reason="Pillow not installed")
 
-import apply_content_overrides
-import clean_display_quotes
-import enrich_metadata
-import gutenberg_time_miner as miner
-import merge_candidates
-import pick_quote
-import quality_filter
-import render_quote
-
+import apply_content_overrides  # noqa: E402
+import clean_display_quotes  # noqa: E402
+import enrich_metadata  # noqa: E402
+import gutenberg_time_miner as miner  # noqa: E402
+import merge_candidates  # noqa: E402
+import pick_quote  # noqa: E402
+import quality_filter  # noqa: E402
+import render_quote  # noqa: E402
 
 # A minimal but realistic Gutenberg body. Must include a Gutenberg-style header
 # (so enrich_metadata picks up Title / Author) and enough phrasing that every

--- a/tests/test_pipeline_integration.py
+++ b/tests/test_pipeline_integration.py
@@ -33,7 +33,9 @@ import gutenberg_time_miner as miner  # noqa: E402
 import merge_candidates  # noqa: E402
 import pick_quote  # noqa: E402
 import quality_filter  # noqa: E402
-import render_quote  # noqa: E402
+
+if PIL_AVAILABLE:
+    import render_quote  # noqa: E402
 
 # A minimal but realistic Gutenberg body. Must include a Gutenberg-style header
 # (so enrich_metadata picks up Title / Author) and enough phrasing that every

--- a/tests/test_render_quote.py
+++ b/tests/test_render_quote.py
@@ -279,27 +279,39 @@ class TestLoadFontFallback:
         assert capsys.readouterr().err == ""
 
 
-class TestResolveDisplayMatchPrefixFallback:
-    """When a match_text doesn't appear verbatim in the quote text but shares
-    a time-phrase prefix, resolve_display_match should find the fuller phrase."""
+class TestResolveDisplayMatch:
+    """``resolve_display_match`` has three code paths — direct regex, prefix
+    walk, and fall-through. Each needs explicit coverage."""
 
-    def test_prefix_fallback_finds_longer_phrase(self):
+    def test_direct_match_wins(self):
+        """Path 1: normalized_match appears verbatim in the text."""
+        text = "It was quarter past six in the evening."
+        assert rq.resolve_display_match(text, "quarter past six") == "quarter past six"
+
+    def test_prefix_walk_extends_match_across_hyphen(self):
+        """Path 2: direct regex fails (trailing hyphen blocks the isolation
+        lookahead) but the prefix walk finds the fuller hyphenated form and
+        returns it because it startswith the requested match."""
+        text = "The clock read five minutes past three-fifteen that night."
+        # Direct path fails: "three" is followed by "-fifteen" which trips the
+        # (?!-[A-Za-z0-9]) lookahead. Prefix walk for "five minutes past" picks
+        # up "five minutes past three-fifteen" and the startswith check accepts it.
+        result = rq.resolve_display_match(text, "five minutes past three")
+        assert result == "five minutes past three-fifteen"
+
+    def test_fall_through_returns_normalized_match_when_nothing_found(self):
+        """Path 3: match_text not in text and no prefix walk candidate starts
+        with it — return the normalized match as-is so the caller has *some*
+        phrase to bold, even if it never appears in the rendered quote."""
         text = "It was five minutes past three when the bell rang."
-        # match_text starts with the same prefix but differs by trailing words.
+        # Prefix walk finds "five minutes past three" but that does not
+        # startswith "five minutes past noon", so Path 2 rejects and we fall through.
         result = rq.resolve_display_match(text, "five minutes past noon")
-        # The prefix walk looks for "five minutes past <word>" in text. Since
-        # that doesn't start with "five minutes past noon", we fall through to
-        # returning the normalized_match as-is.
         assert result == "five minutes past noon"
 
     def test_empty_match_returns_empty(self):
         assert rq.resolve_display_match("It was three o'clock.", "") == ""
         assert rq.resolve_display_match("text", "   ") == ""
-
-    def test_direct_match_wins(self):
-        text = "It was quarter past six in the evening."
-        result = rq.resolve_display_match(text, "quarter past six")
-        assert result == "quarter past six"
 
 
 class TestTokenizeQuoteEdge:

--- a/tests/test_render_quote.py
+++ b/tests/test_render_quote.py
@@ -255,6 +255,119 @@ class TestFallbackTitle:
     def test_falls_back_to_source_stem_without_source_id(self):
         assert rq.fallback_title({"source_path": "data/gutenberg/pg1661.txt"}) == "pg1661"
 
+    def test_returns_none_when_no_metadata(self):
+        assert rq.fallback_title({}) is None
+        assert rq.fallback_title({"source_id": "", "source_path": ""}) is None
+
+
+class TestLoadFontFallback:
+    """When every TTF candidate is missing, ``load_font`` must log a one-shot
+    warning and return the PIL bitmap default — never crash."""
+
+    def test_missing_candidates_returns_default_and_warns_once(self, monkeypatch, capsys):
+        # Force the fallback path by flipping the module-level guard.
+        monkeypatch.setattr(rq, "_FONT_FALLBACK_WARNED", False)
+        # All candidate paths report as missing.
+        monkeypatch.setattr(rq.Path, "exists", lambda self: False)
+        font = rq.load_font(["/nope/one.ttf", "/nope/two.ttf"], size=24)
+        assert font is not None  # the bitmap default
+        err = capsys.readouterr().err
+        assert "no TrueType font found" in err
+        # Second call must NOT warn again (one-shot).
+        capsys.readouterr()  # drain
+        rq.load_font(["/nope/three.ttf"], size=24)
+        assert capsys.readouterr().err == ""
+
+
+class TestResolveDisplayMatchPrefixFallback:
+    """When a match_text doesn't appear verbatim in the quote text but shares
+    a time-phrase prefix, resolve_display_match should find the fuller phrase."""
+
+    def test_prefix_fallback_finds_longer_phrase(self):
+        text = "It was five minutes past three when the bell rang."
+        # match_text starts with the same prefix but differs by trailing words.
+        result = rq.resolve_display_match(text, "five minutes past noon")
+        # The prefix walk looks for "five minutes past <word>" in text. Since
+        # that doesn't start with "five minutes past noon", we fall through to
+        # returning the normalized_match as-is.
+        assert result == "five minutes past noon"
+
+    def test_empty_match_returns_empty(self):
+        assert rq.resolve_display_match("It was three o'clock.", "") == ""
+        assert rq.resolve_display_match("text", "   ") == ""
+
+    def test_direct_match_wins(self):
+        text = "It was quarter past six in the evening."
+        result = rq.resolve_display_match(text, "quarter past six")
+        assert result == "quarter past six"
+
+
+class TestTokenizeQuoteEdge:
+    def test_empty_match_returns_plain_segment(self):
+        segments = rq.tokenize_quote("Just a plain quote.", "")
+        assert segments == [("Just a plain quote.", False)]
+
+    def test_unmatched_text_returns_plain(self):
+        segments = rq.tokenize_quote("Nothing matches here.", "three o'clock")
+        assert segments == [("Nothing matches here.", False)]
+
+    def test_trailing_punctuation_included_in_bold(self):
+        # The match-end walker extends past ”/", '/', ., ;, :, !, ?
+        segments = rq.tokenize_quote('It was "three o\'clock!"', "three o'clock")
+        # One of the middle segments should end with trailing punctuation.
+        bold_chunks = [text for text, is_bold in segments if is_bold]
+        assert bold_chunks, "expected at least one bold chunk"
+
+
+class TestFitQuoteExhaustion:
+    """When the text is so long it can't fit even at ``font_min``, fit_quote
+    must still return the font_min wrap rather than looping forever."""
+
+    def test_returns_font_min_when_no_size_fits(self):
+        from PIL import Image as _Image, ImageDraw as _ImageDraw
+        img = _Image.new("RGB", (800, 480), (255, 255, 255))
+        draw = _ImageDraw.Draw(img)
+        # An absurdly long "word" (no spaces) with impossibly tight max_height
+        # forces the loop to exhaust without a fit.
+        text = "Supercalifragilistic " * 40
+        regular_font, bold_font, wrapped, line_height, size = rq.fit_quote(
+            draw, text, match_text="",
+            max_width=720, max_height=20,  # tiny height forces exhaustion
+            font_max=30, font_min=12, line_height_mult=1.2,
+        )
+        assert size == 12  # floored at font_min
+        assert wrapped  # still produced SOME wrapped output
+
+
+class TestLineWidth:
+    def test_sums_chunk_widths(self):
+        from PIL import Image as _Image, ImageDraw as _ImageDraw
+        img = _Image.new("RGB", (400, 100), (255, 255, 255))
+        draw = _ImageDraw.Draw(img)
+        font = rq.load_font(rq.QUOTE_FONT_SEMIBOLD_CANDIDATES, size=20)
+        bold = rq.load_font(rq.QUOTE_FONT_BOLD_CANDIDATES, size=20)
+        line = [("Hello", False), (" ", False), ("world", True)]
+        w = rq.line_width(draw, line, font, bold)
+        assert w > 0
+
+    def test_empty_line_is_zero(self):
+        from PIL import Image as _Image, ImageDraw as _ImageDraw
+        img = _Image.new("RGB", (400, 100), (255, 255, 255))
+        draw = _ImageDraw.Draw(img)
+        font = rq.load_font(rq.QUOTE_FONT_SEMIBOLD_CANDIDATES, size=20)
+        bold = rq.load_font(rq.QUOTE_FONT_BOLD_CANDIDATES, size=20)
+        assert rq.line_width(draw, [], font, bold) == 0
+
+
+class TestWrapTextEmpty:
+    def test_empty_text_produces_no_lines(self):
+        from PIL import Image as _Image, ImageDraw as _ImageDraw
+        img = _Image.new("RGB", (400, 100), (255, 255, 255))
+        draw = _ImageDraw.Draw(img)
+        font = rq.load_font(rq.QUOTE_FONT_SEMIBOLD_CANDIDATES, size=20)
+        lines = rq.wrap_text(draw, "", font, 300)
+        assert lines == []
+
 
 class TestThemes:
     def test_dark_theme_palette_values(self):

--- a/tests/test_render_quote.py
+++ b/tests/test_render_quote.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import pytest
 
 try:
-    from PIL import Image
+    from PIL import Image, ImageDraw
     PIL_AVAILABLE = True
 except ImportError:
     PIL_AVAILABLE = False
@@ -145,6 +145,27 @@ class TestResolveDisplayMatch:
         tokens = rq.tokenize_quote(text, "Towards night")
         assert tokens == [(text, False)]
 
+    def test_prefix_walk_extends_match_across_hyphen(self):
+        """Path 2: direct regex fails (trailing hyphen blocks the isolation
+        lookahead) but the prefix walk finds the fuller hyphenated form and
+        returns it because it startswith the requested match."""
+        text = "The clock read five minutes past three-fifteen that night."
+        # Direct path fails: "three" is followed by "-fifteen" which trips the
+        # (?!-[A-Za-z0-9]) lookahead. Prefix walk for "five minutes past" picks
+        # up "five minutes past three-fifteen" and the startswith check accepts it.
+        result = rq.resolve_display_match(text, "five minutes past three")
+        assert result == "five minutes past three-fifteen"
+
+    def test_fall_through_returns_normalized_match_when_nothing_found(self):
+        """Path 3: match_text not in text and no prefix walk candidate starts
+        with it — return the normalized match as-is so the caller has *some*
+        phrase to bold, even if it never appears in the rendered quote."""
+        text = "It was five minutes past three when the bell rang."
+        # Prefix walk finds "five minutes past three" but that does not
+        # startswith "five minutes past noon", so Path 2 rejects and we fall through.
+        result = rq.resolve_display_match(text, "five minutes past noon")
+        assert result == "five minutes past noon"
+
 
 # ---------------------------------------------------------------------------
 # tokenize_quote
@@ -279,39 +300,7 @@ class TestLoadFontFallback:
         assert capsys.readouterr().err == ""
 
 
-class TestResolveDisplayMatch:
-    """``resolve_display_match`` has three code paths — direct regex, prefix
-    walk, and fall-through. Each needs explicit coverage."""
-
-    def test_direct_match_wins(self):
-        """Path 1: normalized_match appears verbatim in the text."""
-        text = "It was quarter past six in the evening."
-        assert rq.resolve_display_match(text, "quarter past six") == "quarter past six"
-
-    def test_prefix_walk_extends_match_across_hyphen(self):
-        """Path 2: direct regex fails (trailing hyphen blocks the isolation
-        lookahead) but the prefix walk finds the fuller hyphenated form and
-        returns it because it startswith the requested match."""
-        text = "The clock read five minutes past three-fifteen that night."
-        # Direct path fails: "three" is followed by "-fifteen" which trips the
-        # (?!-[A-Za-z0-9]) lookahead. Prefix walk for "five minutes past" picks
-        # up "five minutes past three-fifteen" and the startswith check accepts it.
-        result = rq.resolve_display_match(text, "five minutes past three")
-        assert result == "five minutes past three-fifteen"
-
-    def test_fall_through_returns_normalized_match_when_nothing_found(self):
-        """Path 3: match_text not in text and no prefix walk candidate starts
-        with it — return the normalized match as-is so the caller has *some*
-        phrase to bold, even if it never appears in the rendered quote."""
-        text = "It was five minutes past three when the bell rang."
-        # Prefix walk finds "five minutes past three" but that does not
-        # startswith "five minutes past noon", so Path 2 rejects and we fall through.
-        result = rq.resolve_display_match(text, "five minutes past noon")
-        assert result == "five minutes past noon"
-
-    def test_empty_match_returns_empty(self):
-        assert rq.resolve_display_match("It was three o'clock.", "") == ""
-        assert rq.resolve_display_match("text", "   ") == ""
+# (TestResolveDisplayMatch extensions moved into the existing class above.)
 
 
 class TestTokenizeQuoteEdge:
@@ -336,9 +325,8 @@ class TestFitQuoteExhaustion:
     must still return the font_min wrap rather than looping forever."""
 
     def test_returns_font_min_when_no_size_fits(self):
-        from PIL import Image as _Image, ImageDraw as _ImageDraw
-        img = _Image.new("RGB", (800, 480), (255, 255, 255))
-        draw = _ImageDraw.Draw(img)
+        img = Image.new("RGB", (800, 480), (255, 255, 255))
+        draw = ImageDraw.Draw(img)
         # An absurdly long "word" (no spaces) with impossibly tight max_height
         # forces the loop to exhaust without a fit.
         text = "Supercalifragilistic " * 40
@@ -353,9 +341,8 @@ class TestFitQuoteExhaustion:
 
 class TestLineWidth:
     def test_sums_chunk_widths(self):
-        from PIL import Image as _Image, ImageDraw as _ImageDraw
-        img = _Image.new("RGB", (400, 100), (255, 255, 255))
-        draw = _ImageDraw.Draw(img)
+        img = Image.new("RGB", (400, 100), (255, 255, 255))
+        draw = ImageDraw.Draw(img)
         font = rq.load_font(rq.QUOTE_FONT_SEMIBOLD_CANDIDATES, size=20)
         bold = rq.load_font(rq.QUOTE_FONT_BOLD_CANDIDATES, size=20)
         line = [("Hello", False), (" ", False), ("world", True)]
@@ -363,9 +350,8 @@ class TestLineWidth:
         assert w > 0
 
     def test_empty_line_is_zero(self):
-        from PIL import Image as _Image, ImageDraw as _ImageDraw
-        img = _Image.new("RGB", (400, 100), (255, 255, 255))
-        draw = _ImageDraw.Draw(img)
+        img = Image.new("RGB", (400, 100), (255, 255, 255))
+        draw = ImageDraw.Draw(img)
         font = rq.load_font(rq.QUOTE_FONT_SEMIBOLD_CANDIDATES, size=20)
         bold = rq.load_font(rq.QUOTE_FONT_BOLD_CANDIDATES, size=20)
         assert rq.line_width(draw, [], font, bold) == 0
@@ -373,9 +359,8 @@ class TestLineWidth:
 
 class TestWrapTextEmpty:
     def test_empty_text_produces_no_lines(self):
-        from PIL import Image as _Image, ImageDraw as _ImageDraw
-        img = _Image.new("RGB", (400, 100), (255, 255, 255))
-        draw = _ImageDraw.Draw(img)
+        img = Image.new("RGB", (400, 100), (255, 255, 255))
+        draw = ImageDraw.Draw(img)
         font = rq.load_font(rq.QUOTE_FONT_SEMIBOLD_CANDIDATES, size=20)
         lines = rq.wrap_text(draw, "", font, 300)
         assert lines == []

--- a/tests/test_run_clock.py
+++ b/tests/test_run_clock.py
@@ -2019,3 +2019,244 @@ class TestMaybePruneTelemetry:
         args = self._args(tmp_path, retain_days=0)
         run_clock._maybe_prune_telemetry(args, state, telemetry_path=str(tmp_path / "t.jsonl"))
         assert calls == []
+
+
+class TestActionExceptionBranches:
+    """Every ``action_*`` wraps its body in ``except Exception`` so a failure
+    can't kill the GPIO listener thread or the HTTP worker. These tests inject
+    failures into the inner render path and verify (a) the error is logged to
+    telemetry, (b) the returned dict shape is ``{"ok": False, "error": <repr>}``,
+    and (c) no exception escapes to the caller.
+    """
+
+    def _args(self, tmp_path, **overrides):
+        defaults = dict(
+            render_script="render_quote.py",
+            output=str(tmp_path / "current.png"),
+            width=800,
+            height=480,
+            display_script=None,
+            mode="debug",
+            theme="default",
+            history_path=str(tmp_path / "history.jsonl"),
+            history_days=7,
+            telemetry_path=str(tmp_path / "telemetry.jsonl"),
+            state_path=str(tmp_path / "state.json"),
+            quiet_image="",
+            shutdown_command="",
+        )
+        defaults.update(overrides)
+        return argparse.Namespace(**defaults)
+
+    def _read_telemetry(self, tmp_path) -> list[dict]:
+        """Read every rotated telemetry sibling (date-suffixed). Tests may see
+        zero or one file depending on whether ``append_telemetry`` ran."""
+        entries = []
+        for path in tmp_path.glob("telemetry-*.jsonl"):
+            for line in path.read_text(encoding="utf-8").splitlines():
+                if line.strip():
+                    entries.append(json.loads(line))
+        return entries
+
+    def test_skip_renders_failure_returns_error_dict(self, tmp_path):
+        args = self._args(tmp_path)
+        state = run_clock.RuntimeState("default")
+        state.last_quote_id = ("src-old", 5, "q-old", "mt-old")
+        with patch("run_clock.peek_quote_id", return_value=("src-new", 7, "q-new", "mt-new")), \
+             patch("run_clock._render_unlocked", side_effect=RuntimeError("panel disconnected")), \
+             patch("run_clock.current_time_str", return_value="10:00"), \
+             patch("run_clock.current_bucket", return_value="h10_exact"):
+            result = run_clock.action_skip(args, state, label="web")
+        assert result["ok"] is False
+        assert "panel disconnected" in result["error"]
+        entries = self._read_telemetry(tmp_path)
+        assert any(e.get("mode") == "skip" and "panel disconnected" in e.get("error", "") for e in entries)
+
+    def test_unskip_remove_entry_failure_returns_error_dict(self, tmp_path):
+        args = self._args(tmp_path)
+        state = run_clock.RuntimeState("default")
+        state.last_skipped = ("src-banned", 42)
+        with patch("run_clock.pick_quote_module.remove_last_history_entry",
+                   side_effect=OSError("disk full")), \
+             patch("run_clock.current_bucket", return_value="h10_exact"):
+            result = run_clock.action_unskip(args, state, label="web")
+        assert result["ok"] is False
+        assert "disk full" in result["error"]
+        entries = self._read_telemetry(tmp_path)
+        assert any(e.get("mode") == "unskip" for e in entries)
+
+    def test_theme_render_failure_returns_error_dict(self, tmp_path):
+        args = self._args(tmp_path)
+        state = run_clock.RuntimeState("default")
+        state.last_effective_theme = "default"
+        with patch("run_clock._render_unlocked", side_effect=RuntimeError("pillow boom")), \
+             patch("run_clock.current_time_str", return_value="10:00"), \
+             patch("run_clock.current_bucket", return_value="h10_exact"):
+            result = run_clock.action_theme(args, state, label="web")
+        assert result["ok"] is False
+        assert "pillow boom" in result["error"]
+        # Even though the render failed, the theme preference was already toggled
+        # and persisted — that write happens before _render_unlocked.
+        assert state.manual_theme == "dark"
+
+    def test_quiet_render_failure_returns_error_dict(self, tmp_path):
+        args = self._args(tmp_path)
+        state = run_clock.RuntimeState("default")
+        state.manual_quiet = True  # toggling will flip to False and try to wake-render
+        with patch("run_clock._render_unlocked", side_effect=RuntimeError("no corpus")), \
+             patch("run_clock.peek_quote_id", return_value=("src", 1, "q", "mt")), \
+             patch("run_clock.current_time_str", return_value="10:00"), \
+             patch("run_clock.current_bucket", return_value="h10_exact"):
+            result = run_clock.action_quiet(args, state, label="web")
+        assert result["ok"] is False
+        assert "no corpus" in result["error"]
+
+    def test_rerender_failure_returns_error_dict(self, tmp_path):
+        args = self._args(tmp_path)
+        state = run_clock.RuntimeState("default")
+        with patch("run_clock.peek_quote_id", return_value=("src", 1, "q", "mt")), \
+             patch("run_clock._render_unlocked", side_effect=RuntimeError("pick failed")), \
+             patch("run_clock.current_time_str", return_value="10:00"), \
+             patch("run_clock.current_bucket", return_value="h10_exact"):
+            result = run_clock.action_rerender(args, state, label="web")
+        assert result["ok"] is False
+        assert "pick failed" in result["error"]
+        entries = self._read_telemetry(tmp_path)
+        assert any(e.get("mode") == "rerender" for e in entries)
+
+    def test_all_actions_return_busy_when_render_lock_held(self, tmp_path):
+        """Non-blocking acquire must return {'ok': False, 'error': 'busy'}
+        for every action when another thread holds render_lock."""
+        args = self._args(tmp_path)
+        state = run_clock.RuntimeState("default")
+        # Simulate an in-flight render by holding render_lock in this test.
+        state.render_lock.acquire()
+        try:
+            for action in (
+                run_clock.action_skip, run_clock.action_unskip,
+                run_clock.action_theme, run_clock.action_quiet,
+                run_clock.action_rerender,
+            ):
+                result = action(args, state, label="web")
+                assert result == {"ok": False, "error": "busy"}, f"{action.__name__} did not drop on busy"
+        finally:
+            state.render_lock.release()
+
+    def test_unskip_noop_when_no_last_skipped_returns_ok(self, tmp_path):
+        """Un-skip with an empty ``state.last_skipped`` is a no-op, not an error."""
+        args = self._args(tmp_path)
+        state = run_clock.RuntimeState("default")
+        state.last_skipped = None
+        result = run_clock.action_unskip(args, state, label="web")
+        assert result == {"ok": True, "restored": None}
+
+
+class TestParseArgsBasic:
+    """Smoke coverage for parse_args — the loop entry point."""
+
+    def test_defaults(self, monkeypatch):
+        monkeypatch.setattr("sys.argv", ["run_clock.py"])
+        args = run_clock.parse_args()
+        assert args.quiet_start == "22:00"
+        assert args.quiet_end == "06:00"
+        assert args.mode == "debug"
+        assert args.theme == "default"
+
+    def test_overrides(self, monkeypatch):
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "run_clock.py",
+                "--quiet-start", "23:30",
+                "--quiet-end", "07:00",
+                "--mode", "production",
+                "--theme", "dark",
+            ],
+        )
+        args = run_clock.parse_args()
+        assert args.quiet_start == "23:30"
+        assert args.quiet_end == "07:00"
+        assert args.mode == "production"
+        assert args.theme == "dark"
+
+    def test_invalid_hhmm_is_rejected(self, monkeypatch):
+        monkeypatch.setattr("sys.argv", ["run_clock.py", "--quiet-start", "25:99"])
+        with pytest.raises(SystemExit):
+            run_clock.parse_args()
+
+
+class TestMaybeStartWebServer:
+    """The web server is optional; startup failures must not abort the loop."""
+
+    def _args(self, web_bind=None):
+        return argparse.Namespace(
+            web_bind=web_bind,
+            web_token="",
+            web_token_file=None,
+            output="out.png",
+            history_path="",
+            telemetry_path="",
+            overrides="assets/selection_overrides.json",
+            mode="debug",
+        )
+
+    def test_disabled_when_bind_empty(self):
+        state = run_clock.RuntimeState("default")
+        assert run_clock._maybe_start_web_server(self._args(None), state) is None
+        assert run_clock._maybe_start_web_server(self._args(""), state) is None
+
+    def test_start_failure_logs_and_returns_none(self, monkeypatch, capsys):
+        """If web_server.start_web_server raises, we log and return None —
+        never propagate the exception and never kill the loop."""
+        state = run_clock.RuntimeState("default")
+        import web_server
+        monkeypatch.setattr(web_server, "start_web_server",
+                            lambda *a, **kw: (_ for _ in ()).throw(ValueError("bad bind")))
+        result = run_clock._maybe_start_web_server(self._args("0.0.0.0:8080"), state)
+        assert result is None
+        err = capsys.readouterr().err
+        assert "web UI failed to start" in err and "bad bind" in err
+
+
+class TestResolveWebToken:
+    def _args(self, **kw):
+        return argparse.Namespace(web_token=kw.get("web_token", ""), web_token_file=kw.get("web_token_file"))
+
+    def test_empty_when_unset(self):
+        assert run_clock._resolve_web_token(self._args()) == ""
+
+    def test_reads_from_token_file(self, tmp_path):
+        token_file = tmp_path / "token"
+        token_file.write_text("s3cret\n", encoding="utf-8")
+        assert run_clock._resolve_web_token(self._args(web_token_file=str(token_file))) == "s3cret"
+
+    def test_token_file_wins_over_inline(self, tmp_path):
+        token_file = tmp_path / "token"
+        token_file.write_text("from-file\n", encoding="utf-8")
+        args = self._args(web_token="from-flag", web_token_file=str(token_file))
+        assert run_clock._resolve_web_token(args) == "from-file"
+
+    def test_missing_token_file_falls_back_to_inline(self, tmp_path, capsys):
+        args = self._args(web_token="fallback", web_token_file=str(tmp_path / "nonexistent"))
+        assert run_clock._resolve_web_token(args) == "fallback"
+        assert "unreadable" in capsys.readouterr().err
+
+    def test_missing_file_and_no_inline_returns_empty(self, tmp_path):
+        args = self._args(web_token_file=str(tmp_path / "nope"))
+        assert run_clock._resolve_web_token(args) == ""
+
+
+class TestStopWebServer:
+    def test_none_handle_is_noop(self):
+        run_clock.stop_web_server(None)  # must not raise
+
+    def test_server_close_failure_is_swallowed(self):
+        class BadServer:
+            def shutdown(self):
+                pass
+
+            def server_close(self):
+                raise OSError("already closed")
+        thread = type("T", (), {"join": lambda self, timeout=None: None})()
+        # Must not raise despite server_close failing.
+        run_clock.stop_web_server((BadServer(), thread))

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -701,3 +701,102 @@ class TestTokenResolution:
         state = run_clock.RuntimeState(args.theme)
         assert run_clock._maybe_start_web_server(args, state) is None
         assert "failed to start" in capsys.readouterr().err
+
+
+class TestErrorBranches:
+    """Explicit coverage of the defensive branches that return 4xx/5xx."""
+
+    def test_post_body_too_large_returns_400(self, tmp_path):
+        # MAX_BODY_BYTES is 64KB. A Content-Length header above that must be
+        # rejected by _read_json_body before we allocate anything.
+        server, thread, _state, _args = _start(tmp_path)
+        try:
+            conn = _client(server)
+            # We cannot easily send a huge body in CI, but declaring an oversized
+            # Content-Length via the header is enough — the server reads the int
+            # and raises ValueError before draining the socket.
+            conn.request(
+                "POST", "/api/overrides",
+                body=b"",  # no real body; the Content-Length header is what trips the check
+                headers={
+                    "Content-Type": "application/json",
+                    "Content-Length": str(web_server.MAX_BODY_BYTES + 1),
+                },
+            )
+            resp = conn.getresponse()
+            assert resp.status == 400
+            body = json.loads(resp.read().decode("utf-8"))
+            assert "body too large" in body["error"]
+            conn.close()
+        finally:
+            run_clock.stop_web_server((server, thread))
+
+    def test_api_coverage_malformed_json_returns_500(self, tmp_path, live_server):
+        server, _, _ = live_server
+        bad = tmp_path / "bucket-coverage.json"
+        bad.write_text("not { valid json", encoding="utf-8")
+        server.context.coverage_path = bad
+        status, body = _get(server, "/api/coverage")
+        assert status == 500
+        assert "error" in _json_body(body)
+
+    def test_current_png_missing_returns_404(self, tmp_path, live_server):
+        server, _, args = live_server
+        # Point at a file that doesn't exist.
+        server.context.output_path = tmp_path / "nonexistent.png"
+        status, body = _get(server, "/current.png")
+        assert status == 404
+
+    def test_unknown_get_returns_404(self, live_server):
+        server, _, _ = live_server
+        status, _ = _get(server, "/api/does-not-exist")
+        assert status == 404
+
+    def test_unknown_post_returns_404_before_token_check(self, tmp_path):
+        # Token is required, but an unknown POST path must 404 without revealing
+        # that a token check even happens (avoids fingerprinting by scanners).
+        server, thread, _state, _args = _start(tmp_path, token="sekret")
+        try:
+            status, body = _post(server, "/api/action/bogus", {"x": 1})
+            assert status == 404
+            assert _json_body(body)["error"] == "not found"
+        finally:
+            run_clock.stop_web_server((server, thread))
+
+    def test_get_handler_exception_returns_500(self, tmp_path, live_server, monkeypatch):
+        """Force _api_current to blow up and assert we return 500 (not crash the server)."""
+        server, _, _ = live_server
+        import run_clock as rc
+        monkeypatch.setattr(rc, "current_time_str", lambda: (_ for _ in ()).throw(RuntimeError("clock fail")))
+        status, body = _get(server, "/api/current")
+        assert status == 500
+        assert "clock fail" in _json_body(body)["error"]
+
+    def test_post_handler_exception_returns_500(self, tmp_path, live_server, monkeypatch):
+        """A non-ValueError in a POST handler surfaces as 500, not as a bare 200."""
+        server, _, _ = live_server
+        monkeypatch.setattr(
+            run_clock, "action_rerender",
+            lambda *a, **kw: (_ for _ in ()).throw(RuntimeError("explode")),
+        )
+        status, body = _post(server, "/api/action/rerender", {})
+        assert status == 500
+        assert "explode" in _json_body(body)["error"]
+
+    def test_api_telemetry_non_int_hours_returns_400(self, live_server):
+        server, _, _ = live_server
+        status, body = _get(server, "/api/telemetry?hours=notanumber")
+        assert status == 400
+        assert "hours" in _json_body(body)["error"]
+
+    def test_api_history_non_int_limit_returns_400(self, live_server):
+        server, _, _ = live_server
+        status, body = _get(server, "/api/history?limit=notanumber")
+        assert status == 400
+        assert "limit" in _json_body(body)["error"]
+
+    def test_api_bucket_non_int_top_returns_400(self, live_server):
+        server, _, _ = live_server
+        status, body = _get(server, "/api/bucket/h3_exact?top=notanumber")
+        assert status == 400
+        assert "top" in _json_body(body)["error"]


### PR DESCRIPTION
Raises the suite from 749 tests / 95% coverage to 1781 tests / 96% after
filling gaps surfaced during a coverage audit.

New test modules:
- test_miner_match_types.py: combinatorial match_type x edge-case matrix
  for gutenberg_time_miner (digital, oclock_word, quarter_half, quarter_to,
  minutes_past_to, just_after_before, clock_struck, daypart)
- test_buckets_properties.py: exhaustive property tests over all 1440
  HH:MM times and 144 buckets (no Hypothesis dependency)
- test_corpus_invariants.py: schema/bucket/metadata invariants on the
  shipped assets/candidates-attributed.jsonl
- test_concurrency.py: lock-ordering stress tests for RuntimeState
  render_lock, ledger_lock, and state lock
- test_pipeline_integration.py: end-to-end miner -> merge -> clean ->
  quality -> enrich -> pick smoke test
- test_cli_main_smoke.py: --help and trivial-invocation smoke tests for
  every script's main() entry point

Extensions to existing modules:
- test_pick_quote.py: infer_quote_minute matched-text fallback
- test_run_clock.py: action_skip/unskip/theme/quiet/rerender exception
  branches
- test_render_quote.py: fit-loop exhaustion and font fallback paths
- test_web_server.py: error and edge branches