### PR TITLE
ci: split lint, cache pip, tighten triggers and permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,13 +2,43 @@ name: CI
 
 on:
   push:
-    branches: ["**"]
+    branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Run ruff
+        run: ruff check --output-format=github .
+
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.11", "3.12"]
 
@@ -19,23 +49,20 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: pyproject.toml
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest pytest-cov ruff
-          # Pillow is needed by render_quote.py (imported at test time)
-          pip install Pillow
-
-      - name: Run linter
-        run: ruff check .
+          pip install -e ".[dev]"
 
       - name: Run tests with coverage
-        run: |
-          pytest --cov=. --cov-report=term-missing --cov-report=xml -v
+        run: pytest --cov=. --cov-report=term-missing --cov-report=xml -v
 
       - name: Upload coverage report
         uses: actions/upload-artifact@v4
         with:
           name: coverage-${{ matrix.python-version }}
           path: coverage.xml
+          if-no-files-found: error

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -490,7 +490,11 @@ The test suite lives in `tests/` and uses pytest with pytest-cov. There are 18 t
 - coverage: source = `.`, omits `tests/`, `bootstrap_pi_inky.sh`, and `display_inky.py`
 - ruff: line-length 130, target Python 3.11, rules E / W / F / I (E501 ignored)
 
-**CI:** `.github/workflows/ci.yml` runs on every push and PR against Python 3.11 and 3.12. It installs `pytest pytest-cov ruff Pillow`, runs `ruff check .` as a dedicated lint step, then `pytest --cov=. --cov-report=term-missing --cov-report=xml -v`, and uploads a coverage artifact. Keep imports sorted (rule I) — run `ruff check .` locally before pushing.
+**CI:** `.github/workflows/ci.yml` runs on pushes to `main` and on every pull request — feature branches get checked via the `pull_request` trigger only, so `push` + `pull_request` don't double-run. Two jobs:
+- `lint` — single Python 3.12 job running `ruff check --output-format=github .` once, so style feedback lands as inline PR annotations without waiting for the test matrix.
+- `test` — matrix across Python 3.11 / 3.12 running `pytest --cov=. --cov-report=term-missing --cov-report=xml -v`; each matrix cell uploads its `coverage.xml` as `coverage-<py>` with `if-no-files-found: error` so a silent test-collection failure surfaces.
+
+Both jobs install via `pip install -e ".[dev]"` (single source of truth with `pyproject.toml` — no hardcoded `pytest pytest-cov ruff Pillow` list to drift), enable `actions/setup-python`'s pip cache keyed on `pyproject.toml`, set `timeout-minutes` as a hang safety-net, and run with `permissions: contents: read` (least-privilege `GITHUB_TOKEN`). A top-level `concurrency` group cancels superseded PR runs (`cancel-in-progress` only when `github.event_name == 'pull_request'`) so `main`-branch history is preserved while rapid PR pushes don't pile up. The matrix runs with `fail-fast: false` so one Python version failing doesn't hide the other. Keep imports sorted (rule I) — run `ruff check .` locally before pushing.
 
 ### Repo Layout
 


### PR DESCRIPTION
- Restrict push trigger to main; PR branches covered by pull_request only
  (eliminates duplicate runs on every PR-branch push).
- Concurrency group cancels superseded PR runs while preserving main history.
- Least-privilege GITHUB_TOKEN (contents: read) and per-job timeout-minutes.
- Split ruff into its own Python 3.12 job with GitHub annotations output,
  so lint fails fast once instead of running per matrix cell.
- Use pip install -e ".[dev]" so CI deps come from pyproject.toml instead
  of a hardcoded list that can drift.
- Enable actions/setup-python pip cache keyed on pyproject.toml.
- fail-fast: false on the test matrix; if-no-files-found: error on the
  coverage artifact upload so a silent collection failure surfaces.