### PR TITLE
Lock down the runtime module architecture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -493,15 +493,15 @@ Short-press vs long-press dispatch is routed through a tiny `_HoldDispatcher` so
 | `runtime_theme` | `resolve_effective_theme`, `auto_theme_for`, `_maybe_reset_manual_theme_at_midnight` | `runtime_log`, `runtime_state` (+ lazy `run_clock` for midnight persist) |
 | `runtime_actions` | `action_skip/unskip/theme/quiet/rerender`, `_button_render_gate` | `runtime_log`, `runtime_state`, `runtime_theme`, `runtime_quiet` (+ lazy `run_clock` for peek/render/telemetry) |
 
-**Invariant:** every `runtime_*` module imports ≤3 siblings at module load, and only `runtime_actions` / `runtime_theme` touch `run_clock` — and only via `import run_clock` inside a function body, never at module top.
+**Invariant:** every `runtime_*` module imports ≤4 siblings at module load (the dispatch layer in `runtime_actions` touches the most — log, state, theme, quiet — because it coordinates them), and only `runtime_actions` / `runtime_theme` touch `run_clock` — and only via `import run_clock` inside a function body, never at module top.
 
-**Three locks, no nesting.** `RuntimeState` exposes exactly three `threading.Lock`s with disjoint scopes:
+**Three locks, nested only in the documented direction.** `RuntimeState` exposes exactly three `threading.Lock`s:
 
 - **`render_lock`** — coarse. Serialises anything that pushes a frame to the panel (a Spectra 6 refresh can take 10–20s). The main loop acquires it blocking around `render_now`; button and web handlers acquire it *non-blocking* via `_button_render_gate` so a second press during a refresh drops rather than queues.
 - **`state.lock`** — fine. Protects the mutable fields on `RuntimeState` (`manual_theme`, `manual_quiet`, `last_bucket`, `last_quote_id`, `last_effective_theme`, `last_skipped`, `last_seen_date`, `last_pruned_date`). `commit_render_result` is the single seam that writes the `(last_bucket, last_effective_theme, last_quote_id)` triple atomically; the two intentionally-partial writes (the "quote unchanged" branch that only updates `last_bucket`, and the cold-start `last_effective_theme` prime) are inline.
-- **`ledger_lock`** — file I/O. Serialises every read-modify-write on `~/.litclock/history.jsonl`. `run_clock._append_history_after_render` is the single seam for appending after a successful render; button A's long-press un-skip and the skip action both route through it too. `pick_quote.remove_last_history_entry` takes it for the rewrite path.
+- **`ledger_lock`** — file I/O. Serialises every read-modify-write on `~/.litclock/history.jsonl`. `run_clock._append_history_after_render` is the single seam for ledger appends; button A's long-press un-skip and the skip action both route through it too. `pick_quote.remove_last_history_entry` takes it for the rewrite path.
 
-No code path holds two of these locks simultaneously. `render_lock` is released *before* any `state.lock` acquisition inside `_render_unlocked` → `commit_render_result`; `ledger_lock` is always taken after both are released.
+Nesting discipline: `state.lock` is allowed inside `render_lock` (the main loop holds `render_lock` while `_render_unlocked` → `commit_render_result` briefly takes `state.lock`; the action handlers do the same under `_button_render_gate`). `ledger_lock` is never nested with either of the other two — it's always acquired standalone, after both are released. A subprocess call (the `render_quote.py` fork) is never held under `state.lock` or `ledger_lock`.
 
 **Thread ownership.**
 
@@ -538,7 +538,7 @@ button press / web POST
   └─ _append_history_after_render(...)                       # skip/unskip/rerender only
 ```
 
-Theme-toggle and quiet-toggle branches **do not** append to history — they repaint the same `quote_id`, so re-appending would double-record the quote. This is why `_append_history_after_render` lives in `run_clock` (not inside `_render_unlocked`) and is called by the specific action sites that introduce a *new* quote.
+Theme-toggle and quiet-toggle branches **do not** append to history — they repaint the same `quote_id`, so re-appending would double-record the quote. This is why `_append_history_after_render` lives in `run_clock` (not inside `_render_unlocked`): the caller chooses what (if anything) lands in the ledger. The main loop's bucket-change branch appends the newly-rendered quote; `action_skip` appends the *previous* quote (as a ban) *and* the freshly-picked replacement; `action_unskip` / `action_rerender` append the new pick; `action_theme` / `action_quiet` never append.
 
 ### Contact Sheet (`contact_sheet.py`)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -479,6 +479,67 @@ Short-press vs long-press dispatch is routed through a tiny `_HoldDispatcher` so
 
 **Startup frame (`--startup-image`).** Optional PNG pushed to the display once at loop startup, before the first quote render, so the panel doesn't ghost yesterday's frame during cold boot. Off by default (a Spectra 6 refresh takes 10–20s, so the extra round-trip isn't always worth it). Point at any PNG that encodes to the panel's 6-colour palette cleanly.
 
+#### Runtime Module Architecture
+
+`run_clock.py` is a thin orchestrator. The logic it used to own is split across seven focused siblings plus the shared `RuntimeState` class — keep the boundaries tight or the "distributed spaghetti" hazard bites back.
+
+| Module | Owns | Imports from siblings |
+|---|---|---|
+| `runtime_log` | `_log` (timestamped stderr/stdout logger) | — |
+| `runtime_state` | `RuntimeState` class, three locks, `commit_render_result` | — (stdlib only) |
+| `runtime_store` | `load_runtime_state` / `save_runtime_state` (atomic via `atomic_io`) | `runtime_log` |
+| `runtime_telemetry` | `append_telemetry`, `prune_telemetry`, `daily_telemetry_path`, date-rotated JSONL | `runtime_log` |
+| `runtime_quiet` | `in_quiet_hours`, `_display_quiet_image` | `runtime_log` |
+| `runtime_theme` | `resolve_effective_theme`, `auto_theme_for`, `_maybe_reset_manual_theme_at_midnight` | `runtime_log`, `runtime_state` (+ lazy `run_clock` for midnight persist) |
+| `runtime_actions` | `action_skip/unskip/theme/quiet/rerender`, `_button_render_gate` | `runtime_log`, `runtime_state`, `runtime_theme`, `runtime_quiet` (+ lazy `run_clock` for peek/render/telemetry) |
+
+**Invariant:** every `runtime_*` module imports ≤3 siblings at module load, and only `runtime_actions` / `runtime_theme` touch `run_clock` — and only via `import run_clock` inside a function body, never at module top.
+
+**Three locks, no nesting.** `RuntimeState` exposes exactly three `threading.Lock`s with disjoint scopes:
+
+- **`render_lock`** — coarse. Serialises anything that pushes a frame to the panel (a Spectra 6 refresh can take 10–20s). The main loop acquires it blocking around `render_now`; button and web handlers acquire it *non-blocking* via `_button_render_gate` so a second press during a refresh drops rather than queues.
+- **`state.lock`** — fine. Protects the mutable fields on `RuntimeState` (`manual_theme`, `manual_quiet`, `last_bucket`, `last_quote_id`, `last_effective_theme`, `last_skipped`, `last_seen_date`, `last_pruned_date`). `commit_render_result` is the single seam that writes the `(last_bucket, last_effective_theme, last_quote_id)` triple atomically; the two intentionally-partial writes (the "quote unchanged" branch that only updates `last_bucket`, and the cold-start `last_effective_theme` prime) are inline.
+- **`ledger_lock`** — file I/O. Serialises every read-modify-write on `~/.litclock/history.jsonl`. `run_clock._append_history_after_render` is the single seam for appending after a successful render; button A's long-press un-skip and the skip action both route through it too. `pick_quote.remove_last_history_entry` takes it for the rewrite path.
+
+No code path holds two of these locks simultaneously. `render_lock` is released *before* any `state.lock` acquisition inside `_render_unlocked` → `commit_render_result`; `ledger_lock` is always taken after both are released.
+
+**Thread ownership.**
+
+- **Main loop thread** owns tick cadence. Exclusive writer of `state.last_pruned_date`, `state.last_seen_date`, and the quiet-hours local flag. Calls `_append_history_after_render` post-render; *never* holds `render_lock` while calling back into button/web actions.
+- **Button listener thread** (started by `inky_buttons.start_listener`). Fires handlers synchronously. Every handler's body is an `action_*` function wrapped in `_button_render_gate` — so a tap during an in-flight render drops cleanly rather than queueing behind a 20s refresh.
+- **Web server threads** (spawned by `http.server.ThreadingHTTPServer`). `POST /api/action/*` calls the *same* `action_*` functions with `label="web"`. Result dicts map 1:1 to HTTP status: `{ok: True}` → 200, `{error: "busy"}` → 409, `{error: "<repr>"}` → 500.
+
+All three thread families converge on `action_* → _button_render_gate → _render_unlocked → commit_render_result`. There is no parallel "web render path" or "button render path" — this is the point of the refactor.
+
+**Lazy `import run_clock` pattern.** `runtime_actions` and `web_server` do `import run_clock` inside function bodies, not at module top, so Python's module-load graph stays acyclic (`run_clock` imports from `runtime_actions`, but not vice versa at load time). The lookup resolves at call time against `run_clock`'s module globals — which is exactly where the test suite patches fakes (`patch("run_clock.peek_quote_id")`, `patch("run_clock._display_quiet_image")`, etc.). The re-export block at the top of `run_clock.py` exists *for this contract*: every name a test patches under `run_clock.X` is bound at that name. Names that are neither patched nor used internally have been dropped from the block — audit before adding more.
+
+**Runtime call graph (one tick).**
+
+```
+main loop iteration
+  ├─ _maybe_reset_manual_theme_at_midnight(args, state)      # runtime_theme
+  ├─ _check_button_liveness(state, telemetry_path)
+  ├─ _maybe_prune_telemetry(args, state, telemetry_path)     # runtime_telemetry
+  ├─ scheduled_quiet = in_quiet_hours(...)                   # runtime_quiet
+  │
+  ├─ if quiet:  _display_quiet_image(...);  sleep;  continue
+  │
+  ├─ peek_quote_id(...)                                      # pick_quote
+  ├─ with render_lock:  render_now(...)                      # subprocess: render_quote.py
+  ├─ state.commit_render_result(bucket, theme, quote_id)     # runtime_state (takes state.lock)
+  └─ _append_history_after_render(state, ...)                # run_clock (takes ledger_lock)
+
+button press / web POST
+  ├─ action_X(args, state, label=...)                        # runtime_actions
+  ├─ with _button_render_gate(state, ...):                   # non-blocking render_lock
+  ├─ [state.lock mutations]                                  # theme/quiet flip, persistence
+  ├─ _render_unlocked(...)                                   # run_clock (in-gate)
+  │     └─ commit_render_result(...)
+  └─ _append_history_after_render(...)                       # skip/unskip/rerender only
+```
+
+Theme-toggle and quiet-toggle branches **do not** append to history — they repaint the same `quote_id`, so re-appending would double-record the quote. This is why `_append_history_after_render` lives in `run_clock` (not inside `_render_unlocked`) and is called by the specific action sites that introduce a *new* quote.
+
 ### Contact Sheet (`contact_sheet.py`)
 
 Offline QA tool. For each of the 144 `h{1..12}_{state}` buckets, calls `pick_quote.select_quote` at the bucket's canonical `HH:MM` (e.g. `h3_twenty_past` → `03:20`; `h12_*` maps to `00:MM`), renders the full 800×480 frame via `render_quote.render`, and downscales it into a tile on a 12×12 grid. Each tile gets a small `HH:MM  h{hour}_{state}` caption below so you can locate specific buckets at a glance. Flags: `--tile-width`/`--tile-height` (defaults 200×120), `--caption-height` (18), `--margin` (6), `--theme`, and `--mode` — defaults to `production` so the debug footer doesn't dominate small tiles. History filtering is forced off (snapshot of the whole corpus, not anti-repeated picks). Use this to spot regressions after a corpus change: layout bugs, malformed `matched_text`, repeat authors in adjacent buckets, or fallback-bucket frames that look visually wrong.
@@ -516,7 +577,7 @@ POST /api/action/{skip,unskip,theme,quiet,rerender} → mirror physical buttons
 **Security model.** Loopback binds (`127.0.0.1:*`, `localhost:*`, `::1:*`) run without auth — the OS-level trust boundary is sufficient for a single-operator home appliance. Any other bind **requires** `--web-token` or `--web-token-file`; `start_web_server` raises `ValueError` if you try to bind `0.0.0.0` without one, so an operator can't accidentally expose a tokenless POST surface. Tokens are checked against the `X-LitClock-Token` header only — never query strings, which `BaseHTTPRequestHandler` logs to stderr and journald. `_check_token` uses `hmac.compare_digest` for timing-safety. Unknown POST routes return 404 **before** the auth check so a scanner's wrong-token probe doesn't learn the service exists. GETs stay open on every bind (telemetry + coverage + `current.png` are not sensitive and the UI fetches them without credentials). `--web-token-file` is preferred over `--web-token` in production so the secret doesn't show up in `ps`/journald.
 
 **Shared utilities, no duplication.**
-- Atomic writes go through `atomic_io.atomic_write_text` / `atomic_write_bytes` / `atomic_write_lines` (tmp → fsync → `os.replace` → dir fsync), the single durability primitive shared between `save_runtime_state`, `web_server.write_overrides_atomic`, the rendered-PNG writer in `render_quote`, the ledger-rewrite path in `pick_quote.remove_last_history_entry`, and the corpus writeback in `apply_content_overrides`. `run_clock._atomic_write_text` is a thin compatibility shim over the shared helper.
+- Atomic writes go through `atomic_io.atomic_write_text` / `atomic_write_bytes` / `atomic_write_lines` (tmp → fsync → `os.replace` → dir fsync), the single durability primitive shared between `save_runtime_state`, `web_server.write_overrides_atomic`, the rendered-PNG writer in `render_quote`, the ledger-rewrite path in `pick_quote.remove_last_history_entry`, and the corpus writeback in `apply_content_overrides`.
 - Bucket validation uses `pick_quote.valid_bucket_names()` so `POST /api/overrides` rejects the same bad keys that `load_overrides` warns about.
 - Telemetry summarisation reuses `litclock_health.load_entries` and `litclock_health.summarise` directly — the endpoint does not reimplement date-window globbing.
 - `pick_quote.pick_best(..., return_ranked=True)` and `pick_quote.select_candidates(...)` are the single entry point for the bucket-inspector view; the UI projects the raw `score_row` tuple into named fields via `SCORE_COMPONENTS` so the operator can see "lost by minute_penalty=8" rather than a mystery integer.

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -1,0 +1,83 @@
+# Follow-ups
+
+Deferred work items — deliberately carved out of a larger change so the
+landed commit stayed focused and low-risk. Not a bug tracker; each item
+is something the codebase is fine without but would be cleaner with.
+
+## Quiet-hours state machine consolidation
+
+**Context.** The runtime-architecture lockdown (commit
+`ec92075 Lock down the runtime module architecture`) consolidated most
+of the seams between `run_clock.py` and the seven `runtime_*` siblings,
+but deliberately skipped one piece: the quiet-hours state machine. That
+one is behaviour-affecting on the live appliance (panel ghosting,
+shutdown preamble, manual-vs-scheduled interaction) and is isolated
+enough to land separately and revert without unpicking the rest.
+
+**What's still inlined.** `run_clock.py` main loop at roughly lines
+826–862 still owns:
+
+- the `_was_quiet` local flag tracking whether the *previous* tick was
+  in quiet hours,
+- the "just entered quiet" branch that pushes `--quiet-image` to the
+  panel and records the quiet-hours telemetry entry,
+- the "just exited quiet" branch that clears `state.last_bucket` /
+  `state.last_quote_id` to force a repaint on the next normal tick.
+
+`runtime_actions.action_quiet` open-codes the same
+`last_bucket = None; last_quote_id = None` clear for the manual-quiet
+toggle path (around `runtime_actions.py:186–188`) — so the exit-from-quiet
+logic lives in two places.
+
+**Proposal.** Move to `runtime_quiet.py`:
+
+- `compute_quiet(args, state, now) -> bool` — combines scheduled window
+  (`in_quiet_hours`) with `state.manual_quiet` into one boolean.
+- `enter_quiet(args, state, time_str)` — pushes `--quiet-image` under
+  `state.render_lock`, writes the quiet-hours telemetry entry.
+- `exit_quiet(state)` — clears `last_bucket` / `last_quote_id` under
+  `state.lock`. Called by both the main loop (scheduled exit) and
+  `action_quiet` (manual wake).
+
+Move `_was_quiet` onto `RuntimeState.was_quiet: bool` — no lock needed
+since only the main loop writes it.
+
+Loop body then becomes roughly:
+
+```python
+if compute_quiet(args, state, time_str):
+    if not state.was_quiet:
+        enter_quiet(args, state, time_str)
+        state.was_quiet = True
+    if _loop_sleep(state, max(1, args.interval_seconds)):
+        break
+    continue
+
+if state.was_quiet:
+    exit_quiet(state)
+    state.was_quiet = False
+```
+
+**Why it's isolated.** Tests exercising this live in
+`tests/test_run_clock.py` under the quiet-hours classes (grep
+`-k quiet`); `test_concurrency.py` also touches it for lock contention.
+The changes are mostly moving code; the tricky bit is that
+`state.render_lock` must still wrap the `_display_quiet_image` call
+(see `runtime_quiet.py:41`), so the function boundary needs to keep that
+contract.
+
+**Verification when picking it up.**
+
+```bash
+pytest tests/test_run_clock.py -v -k quiet
+pytest tests/test_concurrency.py -v
+python3 run_clock.py --once --buttons-off  # smoke
+# Manual: set --quiet-start / --quiet-end to a 2-minute window spanning
+# "now", watch stderr for exactly one "quiet hours start" log and one
+# "quiet hours end" log as the window opens and closes.
+```
+
+**Source.** The approved plan for this work lives at
+`/root/.claude/plans/lock-down-the-new-immutable-chipmunk.md` §7; treat
+this section as the canonical in-repo reference since that path is
+machine-local.

--- a/run_clock.py
+++ b/run_clock.py
@@ -30,24 +30,19 @@ from runtime_quiet import (  # noqa: F401  re-exported
     in_quiet_hours,
 )
 from runtime_state import RuntimeState  # noqa: F401  re-exported
-from runtime_store import (  # noqa: F401  re-exported
+from runtime_store import (  # noqa: F401  load_runtime_state re-exported for tests
     DEFAULT_STATE_PATH,
-    _atomic_write_text,
-    _resolve_state_path,
     load_runtime_state,
     save_runtime_state,
 )
-from runtime_telemetry import (  # noqa: F401  re-exported
-    _TELEMETRY_DATE_RE,
+from runtime_telemetry import (  # noqa: F401  daily_telemetry_path re-exported for tests
     DEFAULT_TELEMETRY_PATH,
     DEFAULT_TELEMETRY_RETAIN_DAYS,
     append_telemetry,
     daily_telemetry_path,
     prune_telemetry,
 )
-from runtime_theme import (  # noqa: F401  re-exported
-    AUTO_DARK_END_HOUR,
-    AUTO_DARK_START_HOUR,
+from runtime_theme import (  # noqa: F401  auto_theme_for + _maybe_reset_* re-exported for tests
     _maybe_reset_manual_theme_at_midnight,
     auto_theme_for,
     resolve_effective_theme,
@@ -291,6 +286,18 @@ def peek_quote_id(time_str: str, history_path: str | None = None, history_days: 
     )
 
 
+def _append_history_after_render(state: RuntimeState, history_path: str | None, quote_id: tuple) -> None:
+    """Append ``quote_id`` to the anti-repeat ledger under ``state.ledger_lock``.
+
+    Single seam for every caller that has successfully rendered a new quote —
+    the main loop's bucket-change branch and the ``action_*`` handlers for
+    skip / un-skip / rerender. Must NOT be called by theme or quiet toggles,
+    which repaint the same quote and would otherwise double-record it.
+    """
+    with state.ledger_lock:
+        pick_quote_module.append_history(history_path, quote_id[0], quote_id[1])
+
+
 def render_now(
     render_script: str,
     output_path: str,
@@ -377,11 +384,7 @@ def _render_unlocked(args: argparse.Namespace, state: RuntimeState, time_str: st
         history_path=history_path, history_days=args.history_days,
         telemetry_path=args.telemetry_path or None, bucket=actual_bucket, quote_id=quote_id,
     )
-    with state.lock:
-        state.last_bucket = actual_bucket
-        state.last_effective_theme = effective_theme
-        if quote_id is not None:
-            state.last_quote_id = quote_id
+    state.commit_render_result(actual_bucket, effective_theme, quote_id)
 
 
 def _do_render(args: argparse.Namespace, state: RuntimeState, time_str: str, history_path: str | None,
@@ -886,14 +889,9 @@ def main() -> int:
                                 history_path=history_path, history_days=args.history_days,
                                 telemetry_path=telemetry_path, bucket=bucket, quote_id=quote_id,
                             )
-                        with state.lock:
-                            state.last_bucket = bucket
-                            state.last_effective_theme = effective_theme
-                            if quote_id is not None:
-                                state.last_quote_id = quote_id
+                        state.commit_render_result(bucket, effective_theme, quote_id)
                         if quote_id is not None:
-                            with state.ledger_lock:
-                                pick_quote_module.append_history(history_path, quote_id[0], quote_id[1])
+                            _append_history_after_render(state, history_path, quote_id)
                 except Exception as exc:
                     # Keep the loop alive so a transient failure (pick_quote crash, Inky I/O,
                     # missing corpus row, etc.) does not kill the appliance. last_bucket stays

--- a/runtime_actions.py
+++ b/runtime_actions.py
@@ -28,6 +28,7 @@ import argparse
 import contextlib
 
 from runtime_log import _log
+from runtime_quiet import _display_quiet_image
 from runtime_state import RuntimeState
 from runtime_theme import resolve_effective_theme
 
@@ -75,8 +76,7 @@ def action_skip(args: argparse.Namespace, state: RuntimeState, *, label: str = "
                 previous = state.last_quote_id
             if previous is not None:
                 # Ban the currently-shown quote so the next pick filters it out for the week.
-                with state.ledger_lock:
-                    run_clock.pick_quote_module.append_history(history_path, previous[0], previous[1])
+                run_clock._append_history_after_render(state, history_path, previous)
                 with state.lock:
                     # Remember what we just banned so A long-press / web unskip can reverse it.
                     state.last_skipped = previous
@@ -86,8 +86,7 @@ def action_skip(args: argparse.Namespace, state: RuntimeState, *, label: str = "
             )
             run_clock._render_unlocked(args, state, time_str, history_path, quote_id=quote_id)
             if quote_id is not None:
-                with state.ledger_lock:
-                    run_clock.pick_quote_module.append_history(history_path, quote_id[0], quote_id[1])
+                run_clock._append_history_after_render(state, history_path, quote_id)
             return {"ok": True, "new_quote_id": list(quote_id) if quote_id else None}
         except Exception as exc:
             _log(f"{label} skip failed: {exc!r}", err=True)
@@ -129,8 +128,7 @@ def action_unskip(args: argparse.Namespace, state: RuntimeState, *, label: str =
             )
             run_clock._render_unlocked(args, state, time_str, history_path, quote_id=quote_id)
             if quote_id is not None:
-                with state.ledger_lock:
-                    run_clock.pick_quote_module.append_history(history_path, quote_id[0], quote_id[1])
+                run_clock._append_history_after_render(state, history_path, quote_id)
             return {"ok": True, "restored": list(target)}
         except Exception as exc:
             _log(f"{label} un-skip failed: {exc!r}", err=True)
@@ -191,7 +189,7 @@ def action_quiet(args: argparse.Namespace, state: RuntimeState, *, label: str = 
                 quiet_now = state.manual_quiet
             _log(f"{label}: manual quiet -> {quiet_now}")
             if quiet_now and args.quiet_image:
-                run_clock._display_quiet_image(args.quiet_image, args.output, args.display_script)
+                _display_quiet_image(args.quiet_image, args.output, args.display_script)
             elif not quiet_now:
                 # Wake to the current time so the user sees something immediately.
                 time_str = run_clock.current_time_str()
@@ -225,8 +223,7 @@ def action_rerender(args: argparse.Namespace, state: RuntimeState, *, label: str
             )
             run_clock._render_unlocked(args, state, time_str, history_path, bucket=bucket, quote_id=quote_id)
             if quote_id is not None:
-                with state.ledger_lock:
-                    run_clock.pick_quote_module.append_history(history_path, quote_id[0], quote_id[1])
+                run_clock._append_history_after_render(state, history_path, quote_id)
             _log(f"{label}: rerender bucket={bucket}")
             return {"ok": True, "bucket": bucket, "quote_id": list(quote_id) if quote_id else None}
         except Exception as exc:

--- a/runtime_actions.py
+++ b/runtime_actions.py
@@ -17,10 +17,13 @@ Extracted from :mod:`run_clock`; the original names are re-exported from
 ``run_clock.action_*``). Implementation detail: each action does a local
 ``import run_clock`` and routes calls to helpers like ``peek_quote_id``,
 ``_render_unlocked``, ``current_time_str``, ``current_bucket``,
-``_display_quiet_image``, ``save_runtime_state``, ``append_telemetry``, and
-``pick_quote_module`` through ``run_clock.X`` so tests that patch those names
-on ``run_clock`` affect the action's call path (same pattern ``web_server``
-uses to dodge circular imports at module load).
+``save_runtime_state``, ``append_telemetry``, ``_append_history_after_render``,
+and ``pick_quote_module`` through ``run_clock.X`` so tests that patch those
+names on ``run_clock`` affect the action's call path (same pattern
+``web_server`` uses to dodge circular imports at module load).
+``_display_quiet_image`` is imported *directly* from :mod:`runtime_quiet` —
+the through-``run_clock`` indirection earned no coupling benefit for a leaf
+helper, and the direct import makes the ownership obvious.
 """
 from __future__ import annotations
 

--- a/runtime_state.py
+++ b/runtime_state.py
@@ -59,3 +59,20 @@ class RuntimeState:
 
     def snapshot_for_persistence(self) -> dict:
         return {"manual_theme": self.manual_theme, "manual_quiet": self.manual_quiet}
+
+    def commit_render_result(
+        self, bucket: str, effective_theme: str, quote_id: tuple | None,
+    ) -> None:
+        """Record the identity of the frame we just pushed to the panel.
+
+        ``last_bucket``, ``last_effective_theme``, and ``last_quote_id`` form an
+        atomic group — the skip-if-unchanged check at the top of every tick
+        compares all three, so writing them separately risks a stale pair. This
+        method is the single entry point; ``quote_id`` is left untouched when
+        ``None`` (theme-only repaints reuse the previous quote).
+        """
+        with self.lock:
+            self.last_bucket = bucket
+            self.last_effective_theme = effective_theme
+            if quote_id is not None:
+                self.last_quote_id = quote_id

--- a/runtime_store.py
+++ b/runtime_store.py
@@ -45,21 +45,9 @@ def load_runtime_state(state_path: str | None) -> dict:
     return parsed
 
 
-def _atomic_write_text(path: Path, payload: str) -> None:
-    """Durably write ``payload`` to ``path``.
-
-    Thin shim around :func:`atomic_io.atomic_write_text` so every caller that
-    imports ``run_clock._atomic_write_text`` keeps the same contract while the
-    implementation lives in one place (see ``atomic_io`` for the tmp → fsync →
-    replace → dir-fsync details). Shared by ``save_runtime_state`` and the web
-    UI's override writer.
-    """
-    atomic_io.atomic_write_text(path, payload)
-
-
 def save_runtime_state(state_path: str | None, state: dict) -> None:
     """Persist runtime state atomically. No-op when disabled."""
     path = _resolve_state_path(state_path)
     if path is None:
         return
-    _atomic_write_text(path, json.dumps(state, ensure_ascii=False, indent=2))
+    atomic_io.atomic_write_text(path, json.dumps(state, ensure_ascii=False, indent=2))

--- a/tests/test_run_clock.py
+++ b/tests/test_run_clock.py
@@ -1365,7 +1365,9 @@ class TestButtonHandlers:
         args = self._args(tmp_path, quiet_image=str(quiet))
         state = run_clock.RuntimeState("default")
         state.manual_quiet = False
-        with patch("run_clock._display_quiet_image") as mock_display:
+        # action_quiet calls runtime_quiet._display_quiet_image directly (not through
+        # run_clock), so the patch target is the action module's binding.
+        with patch("runtime_actions._display_quiet_image") as mock_display:
             short_handlers, _hold_handlers = run_clock._build_button_handlers(args, state)
             short_handlers["D"]()
         assert state.manual_quiet is True

--- a/web_server.py
+++ b/web_server.py
@@ -30,7 +30,6 @@ import datetime as dt
 import hmac
 import json
 import re
-import sys
 import threading
 import urllib.parse
 from http import HTTPStatus
@@ -40,6 +39,7 @@ from pathlib import Path
 import atomic_io
 import pick_quote as pick_quote_module
 from buckets import bucket_for_time
+from runtime_log import _log
 
 BASE_DIR = Path(__file__).resolve().parent
 WEB_ROOT = BASE_DIR / "web"
@@ -176,9 +176,7 @@ def write_overrides_atomic(path: Path, payload: dict) -> None:
 
     Routes through :mod:`atomic_io` so the on-disk overrides file inherits the
     same tmp → fsync → replace → dir-fsync durability contract as persisted
-    runtime state and the attributed corpus. Previously this imported
-    ``run_clock._atomic_write_text`` lazily to dodge circular imports; the
-    shared module eliminates that concern entirely.
+    runtime state and the attributed corpus.
     """
     atomic_io.atomic_write_text(path, json.dumps(payload, ensure_ascii=False, indent=2) + "\n")
 
@@ -471,16 +469,6 @@ def _status_from_result(result: dict) -> int:
     if result.get("error") == "busy":
         return HTTPStatus.CONFLICT  # 409 — render already in flight
     return HTTPStatus.INTERNAL_SERVER_ERROR
-
-
-def _log(msg: str, *, err: bool = False) -> None:
-    """Tiny local logger so web_server doesn't import run_clock at module load.
-
-    Mirrors ``run_clock._log`` formatting (timestamped, flushed) so the two
-    streams interleave cleanly in journald.
-    """
-    stream = sys.stderr if err else sys.stdout
-    print(f"[{dt.datetime.now().isoformat(timespec='seconds')}] {msg}", file=stream, flush=True)
 
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
Consolidate the post-refactor seams so each runtime_* module owns one
concern, implicit cross-module contracts become explicit, and the
through-run_clock coupling drops to exactly the places it earns.

- Add RuntimeState.commit_render_result so (last_bucket,
  last_effective_theme, last_quote_id) are always written together under
  state.lock; callers stop hand-rolling the triple.
- Add run_clock._append_history_after_render as the single seam for
  post-render ledger appends; the main loop and action_skip /
  action_unskip / action_rerender all route through it.
- runtime_actions.action_quiet now imports _display_quiet_image from
  runtime_quiet directly instead of reaching through run_clock; the
  test that patched through run_clock moves to the correct target.
- Delete runtime_store._atomic_write_text compatibility shim and call
  atomic_io.atomic_write_text directly.
- Replace the web_server local _log duplicate with an import from
  runtime_log.
- Trim run_clock.py re-exports down to the set that tests actually patch
  plus the names used internally. Dropped: _atomic_write_text,
  _resolve_state_path, _TELEMETRY_DATE_RE, AUTO_DARK_{START,END}_HOUR.
- Document the whole architecture in CLAUDE.md under a new "Runtime
  Module Architecture" subsection: module ownership table, three-lock
  hierarchy, thread ownership, lazy import run_clock contract, and a
  one-tick call graph.

https://claude.ai/code/session_01BRkVywCHGmFCqPUZzC9jMz