### PR TITLE
Appliance hardening phase 4: observability for operator actions

### DIFF
--- a/litclock_health.py
+++ b/litclock_health.py
@@ -56,6 +56,16 @@ def parse_args() -> argparse.Namespace:
             "Default: disabled."
         ),
     )
+    parser.add_argument(
+        "--actions-only",
+        action="store_true",
+        help=(
+            "Emit an operator-centric 'what did the user do?' report instead of the full "
+            "health summary: action counts by type (skip/theme/quiet/...), press-dropped "
+            "count, web_auth_fail count, quiet-window count, and last action timestamp. "
+            "Combine with --json for machine-readable output."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -152,6 +162,16 @@ def summarise(entries: list[dict]) -> dict:
     # doesn't look like "0 renders, 0 errors" when it's actually fine.
     heartbeats = [e for e in entries if e.get("type") == "heartbeat"]
     non_heartbeats = [e for e in entries if e.get("type") != "heartbeat"]
+    # Operator-activity entries emitted by runtime_actions / _button_render_gate
+    # / web_server. Tracked separately so a burst of button presses doesn't
+    # inflate render_count and so "what did the user do?" queries have a
+    # single source of truth.
+    actions = [e for e in non_heartbeats if e.get("mode") == "action"]
+    press_dropped = [e for e in non_heartbeats if e.get("mode") == "press_dropped"]
+    web_auth_fails = [e for e in non_heartbeats if e.get("mode") == "web_auth_fail"]
+    web_errors = [e for e in non_heartbeats if e.get("mode") == "web_error"]
+    quiet_enters = [e for e in non_heartbeats if e.get("mode") == "quiet_enter"]
+    quiet_exits = [e for e in non_heartbeats if e.get("mode") == "quiet_exit"]
     # Positively identify renders by the ``render_ms`` field — only set by
     # ``run_clock.render_now`` on a successful render subprocess. Defining
     # renders as "anything without an error" miscategorises modes like
@@ -159,7 +179,15 @@ def summarise(entries: list[dict]) -> dict:
     # field) as successful renders, which would let a wedged appliance
     # report healthy as long as it was tripping the backoff threshold.
     renders = [e for e in non_heartbeats if isinstance(e.get("render_ms"), int)]
-    errors = [e for e in non_heartbeats if "error" in e]
+    # Exclude structured action / web / quiet markers from the generic
+    # error tally even if they carry an ``error`` field — they have their
+    # own dedicated counts below and a failed skip action doesn't mean the
+    # render pipeline itself is unhealthy.
+    error_modes_excluded = {"action", "web_error", "web_auth_fail"}
+    errors = [
+        e for e in non_heartbeats
+        if "error" in e and e.get("mode") not in error_modes_excluded
+    ]
     render_latencies = sorted(e["render_ms"] for e in renders)
     display_latencies = sorted(
         e["display_ms"] for e in renders if isinstance(e.get("display_ms"), int)
@@ -170,6 +198,13 @@ def summarise(entries: list[dict]) -> dict:
         # order since ``append_telemetry`` always appends. The final entry's ts
         # is the most recent heartbeat.
         last_heartbeat_ts = heartbeats[-1].get("ts")
+    # Break actions down by verb so the summary reads as
+    # "5 theme toggles, 2 skips" instead of a bare "7 actions".
+    actions_by_type: dict[str, int] = {}
+    for entry in actions:
+        name = str(entry.get("action", "unknown"))
+        actions_by_type[name] = actions_by_type.get(name, 0) + 1
+    last_action_ts = actions[-1].get("ts") if actions else None
     return {
         "render_count": len(renders),
         "error_count": len(errors),
@@ -180,6 +215,14 @@ def summarise(entries: list[dict]) -> dict:
         "display_p50_ms": _percentile(display_latencies, 50),
         "display_p95_ms": _percentile(display_latencies, 95),
         "last_error": errors[-1].get("error") if errors else None,
+        "action_count": len(actions),
+        "actions_by_type": actions_by_type,
+        "last_action_ts": last_action_ts,
+        "press_dropped_count": len(press_dropped),
+        "web_auth_fail_count": len(web_auth_fails),
+        "web_error_count": len(web_errors),
+        "quiet_enter_count": len(quiet_enters),
+        "quiet_exit_count": len(quiet_exits),
     }
 
 
@@ -198,11 +241,56 @@ def format_summary(summary: dict, hours: int) -> str:
         parts.append(
             f"display latency p50 {summary['display_p50_ms']}ms / p95 {summary['display_p95_ms']}ms"
         )
+    # Action breakdown: always show the header when any operator activity
+    # occurred so silent windows (0 actions) don't pad the summary.
+    if summary.get("action_count"):
+        actions_by_type = summary.get("actions_by_type") or {}
+        breakdown = ", ".join(
+            f"{name} {count}" for name, count in sorted(actions_by_type.items())
+        ) or "—"
+        last_action = summary.get("last_action_ts") or "?"
+        parts.append(f"{summary['action_count']} actions ({breakdown}; last {last_action})")
+    if summary.get("press_dropped_count"):
+        parts.append(f"{summary['press_dropped_count']} presses dropped (render in flight)")
+    if summary.get("web_auth_fail_count"):
+        parts.append(f"{summary['web_auth_fail_count']} web auth failures")
+    if summary.get("web_error_count"):
+        parts.append(f"{summary['web_error_count']} web POST errors")
+    if summary.get("quiet_enter_count") or summary.get("quiet_exit_count"):
+        parts.append(
+            f"quiet hours: {summary.get('quiet_enter_count', 0)} enters, "
+            f"{summary.get('quiet_exit_count', 0)} exits"
+        )
     if summary["last_error"]:
         parts.append(f"last error: {summary['last_error']}")
     if summary.get("stale_heartbeat"):
         parts.append("WARNING: heartbeat is stale — loop may be wedged")
     return "\n".join(parts)
+
+
+def format_actions_summary(summary: dict, hours: int) -> str:
+    """Render the ``--actions-only`` view.
+
+    Operator-centric "what did the user do?" report. Omits render / latency
+    fields, which are covered by the default summary. Always prints every
+    counter (including zeros) so cron / grep output is shape-stable.
+    """
+    actions_by_type = summary.get("actions_by_type") or {}
+    breakdown = (
+        ", ".join(f"{name} {count}" for name, count in sorted(actions_by_type.items()))
+        if actions_by_type else "none"
+    )
+    last_action = summary.get("last_action_ts") or "never"
+    return "\n".join([
+        f"Last {hours}h — operator activity:",
+        f"  actions: {summary.get('action_count', 0)} ({breakdown})",
+        f"  last action: {last_action}",
+        f"  presses dropped: {summary.get('press_dropped_count', 0)}",
+        f"  web auth failures: {summary.get('web_auth_fail_count', 0)}",
+        f"  web POST errors: {summary.get('web_error_count', 0)}",
+        f"  quiet hours: {summary.get('quiet_enter_count', 0)} enters / "
+        f"{summary.get('quiet_exit_count', 0)} exits",
+    ])
 
 
 def is_heartbeat_stale(summary: dict, max_age_minutes: int, now: dt.datetime | None = None) -> bool:
@@ -267,7 +355,12 @@ def main() -> int:
     if args.max_heartbeat_age_minutes is not None:
         summary["stale_heartbeat"] = is_heartbeat_stale(summary, args.max_heartbeat_age_minutes)
     if args.json:
+        # --actions-only is a human-readability concern; the JSON already
+        # contains every field either view consumes, so keep the payload
+        # shape stable for scripts regardless of the flag.
         print(json.dumps({"hours": args.hours, **summary}))
+    elif args.actions_only:
+        print(format_actions_summary(summary, args.hours))
     else:
         print(format_summary(summary, args.hours))
     return evaluate_health(

--- a/litclock_health.py
+++ b/litclock_health.py
@@ -199,10 +199,13 @@ def summarise(entries: list[dict]) -> dict:
         # is the most recent heartbeat.
         last_heartbeat_ts = heartbeats[-1].get("ts")
     # Break actions down by verb so the summary reads as
-    # "5 theme toggles, 2 skips" instead of a bare "7 actions".
+    # "5 theme toggles, 2 skips" instead of a bare "7 actions". Use
+    # ``or "unknown"`` so both a missing key and a null value fall into
+    # the same bucket (a malformed entry with ``"action": null`` would
+    # otherwise produce an ``"None"`` column).
     actions_by_type: dict[str, int] = {}
     for entry in actions:
-        name = str(entry.get("action", "unknown"))
+        name = str(entry.get("action") or "unknown")
         actions_by_type[name] = actions_by_type.get(name, 0) + 1
     last_action_ts = actions[-1].get("ts") if actions else None
     return {

--- a/run_clock.py
+++ b/run_clock.py
@@ -561,7 +561,7 @@ def _build_button_handlers(
         # same title/author/id through ``GET /api/current`` without occupying
         # the panel for 5s). Kept inline because the timer-driven restore
         # doesn't fit the action_* return-dict contract cleanly.
-        with _button_render_gate(state, "button C (card)") as acquired:
+        with _button_render_gate(state, "button C", "card", telemetry_path=telemetry_path) as acquired:
             if not acquired:
                 return
             _log("button C: source card")
@@ -631,7 +631,7 @@ def _build_button_handlers(
         if not cmd:
             _log("button D held: --shutdown-command is empty, skipping system shutdown")
             return
-        with _button_render_gate(state, "button D (shutdown)") as acquired:
+        with _button_render_gate(state, "button D", "shutdown", telemetry_path=telemetry_path) as acquired:
             if not acquired:
                 return
             _log("button D held: shutdown")
@@ -1206,6 +1206,11 @@ def main() -> int:
             if state.was_quiet:
                 _log("quiet hours end, resuming normal render cycle")
                 exit_quiet(state)
+                # Falling-edge marker paired with the enter_quiet emission so
+                # litclock_health can count balanced quiet windows (and an
+                # operator can spot "we stopped rendering because we entered
+                # quiet" vs "we stopped rendering because we wedged").
+                append_telemetry(telemetry_path, {"mode": "quiet_exit"})
                 state.was_quiet = False
 
             bucket = current_bucket()

--- a/runtime_actions.py
+++ b/runtime_actions.py
@@ -37,27 +37,58 @@ from runtime_theme import resolve_effective_theme
 
 
 @contextlib.contextmanager
-def _button_render_gate(state: RuntimeState, name: str):
+def _button_render_gate(
+    state: RuntimeState,
+    label: str,
+    action: str,
+    *,
+    telemetry_path: str | None = None,
+):
     """Try-acquire ``state.render_lock`` for a button or web handler.
 
     Yields ``True`` if the lock was acquired (caller does its work; the gate
     releases on exit) or ``False`` if a render is already in flight, in which
-    case the press is logged and dropped. This coalesces a rapid tap-tap-tap
-    down to "first wins, rest are no-ops" — without it, gpiozero queues
-    subsequent events behind the slow eInk refresh and the user sees
-    unpredictable multi-second delays.
+    case the press is logged, telemetrised as ``mode="press_dropped"``, and
+    dropped. This coalesces a rapid tap-tap-tap down to "first wins, rest are
+    no-ops" — without it, gpiozero queues subsequent events behind the slow
+    eInk refresh and the user sees unpredictable multi-second delays.
 
-    ``name`` is the full caller label (e.g. ``"button A (skip)"`` or
-    ``"web (skip)"``) so the log message correctly attributes a dropped press.
+    ``label`` is the source (``"button A"``, ``"web"``) and ``action`` is the
+    verb (``"skip"``, ``"theme"``…); they appear together in the log line and
+    as separate fields in the telemetry entry so a health summary can break
+    drops down by both source and action.
     """
+    name = f"{label} ({action})"
     if not state.render_lock.acquire(blocking=False):
         _log(f"{name}: busy (render in flight), press ignored")
+        # Structured drop marker so operators can see "I mashed during a 20 s
+        # refresh and nothing happened" in the telemetry sidecar — the log
+        # line alone is easy to miss in journald under load.
+        import run_clock  # lazy import matches the action-body pattern below
+        run_clock.append_telemetry(
+            telemetry_path,
+            {"mode": "press_dropped", "label": label, "action": action, "reason": "render_in_flight"},
+        )
         yield False
         return
     try:
         yield True
     finally:
         state.render_lock.release()
+
+
+def _emit_action(telemetry_path: str | None, action: str, label: str, *, ok: bool, error: str | None = None) -> None:
+    """Write one structured ``mode="action"`` telemetry entry.
+
+    Extracted so each ``action_*`` body has a single call site for success /
+    failure emission (the busy-drop case is handled by ``_button_render_gate``
+    and records ``mode="press_dropped"`` instead, so the two never double-count).
+    """
+    import run_clock  # lazy: keeps test patches on run_clock.append_telemetry effective
+    payload: dict = {"mode": "action", "action": action, "label": label, "ok": ok}
+    if error is not None:
+        payload["error"] = error
+    run_clock.append_telemetry(telemetry_path, payload)
 
 
 def action_skip(args: argparse.Namespace, state: RuntimeState, *, label: str = "web") -> dict:
@@ -70,7 +101,7 @@ def action_skip(args: argparse.Namespace, state: RuntimeState, *, label: str = "
     import run_clock
     history_path = args.history_path or None
     telemetry_path = args.telemetry_path or None
-    with _button_render_gate(state, f"{label} (skip)") as acquired:
+    with _button_render_gate(state, label, "skip", telemetry_path=telemetry_path) as acquired:
         if not acquired:
             return {"ok": False, "error": "busy"}
         _log(f"{label}: skip")
@@ -90,12 +121,11 @@ def action_skip(args: argparse.Namespace, state: RuntimeState, *, label: str = "
             run_clock._render_unlocked(args, state, time_str, history_path, quote_id=quote_id)
             if quote_id is not None:
                 run_clock._append_history_after_render(state, history_path, quote_id)
+            _emit_action(telemetry_path, "skip", label, ok=True)
             return {"ok": True, "new_quote_id": list(quote_id) if quote_id else None}
         except Exception as exc:
             _log(f"{label} skip failed: {exc!r}", err=True)
-            run_clock.append_telemetry(
-                telemetry_path, {"bucket": run_clock.current_bucket(), "error": repr(exc), "mode": "skip"},
-            )
+            _emit_action(telemetry_path, "skip", label, ok=False, error=repr(exc))
             return {"ok": False, "error": repr(exc)}
 
 
@@ -109,7 +139,7 @@ def action_unskip(args: argparse.Namespace, state: RuntimeState, *, label: str =
     import run_clock
     history_path = args.history_path or None
     telemetry_path = args.telemetry_path or None
-    with _button_render_gate(state, f"{label} (unskip)") as acquired:
+    with _button_render_gate(state, label, "unskip", telemetry_path=telemetry_path) as acquired:
         if not acquired:
             return {"ok": False, "error": "busy"}
         _log(f"{label}: un-skip")
@@ -119,6 +149,7 @@ def action_unskip(args: argparse.Namespace, state: RuntimeState, *, label: str =
                 state.last_skipped = None
             if target is None:
                 _log("un-skip: no recently-skipped quote recorded")
+                _emit_action(telemetry_path, "unskip", label, ok=True)
                 return {"ok": True, "restored": None}
             with state.ledger_lock:
                 removed = run_clock.pick_quote_module.remove_last_history_entry(
@@ -132,12 +163,11 @@ def action_unskip(args: argparse.Namespace, state: RuntimeState, *, label: str =
             run_clock._render_unlocked(args, state, time_str, history_path, quote_id=quote_id)
             if quote_id is not None:
                 run_clock._append_history_after_render(state, history_path, quote_id)
+            _emit_action(telemetry_path, "unskip", label, ok=True)
             return {"ok": True, "restored": list(target)}
         except Exception as exc:
             _log(f"{label} un-skip failed: {exc!r}", err=True)
-            run_clock.append_telemetry(
-                telemetry_path, {"bucket": run_clock.current_bucket(), "error": repr(exc), "mode": "unskip"},
-            )
+            _emit_action(telemetry_path, "unskip", label, ok=False, error=repr(exc))
             return {"ok": False, "error": repr(exc)}
 
 
@@ -146,7 +176,7 @@ def action_theme(args: argparse.Namespace, state: RuntimeState, *, label: str = 
     import run_clock
     history_path = args.history_path or None
     telemetry_path = args.telemetry_path or None
-    with _button_render_gate(state, f"{label} (theme)") as acquired:
+    with _button_render_gate(state, label, "theme", telemetry_path=telemetry_path) as acquired:
         if not acquired:
             return {"ok": False, "error": "busy"}
         try:
@@ -161,12 +191,11 @@ def action_theme(args: argparse.Namespace, state: RuntimeState, *, label: str = 
                 quote_id = state.last_quote_id
             _log(f"{label}: theme -> {new_theme}")
             run_clock._render_unlocked(args, state, time_str, history_path, quote_id=quote_id)
+            _emit_action(telemetry_path, "theme", label, ok=True)
             return {"ok": True, "theme": new_theme}
         except Exception as exc:
             _log(f"{label} theme toggle failed: {exc!r}", err=True)
-            run_clock.append_telemetry(
-                telemetry_path, {"bucket": run_clock.current_bucket(), "error": repr(exc), "mode": "theme"},
-            )
+            _emit_action(telemetry_path, "theme", label, ok=False, error=repr(exc))
             return {"ok": False, "error": repr(exc)}
 
 
@@ -178,7 +207,7 @@ def action_quiet(args: argparse.Namespace, state: RuntimeState, *, label: str = 
     import run_clock
     history_path = args.history_path or None
     telemetry_path = args.telemetry_path or None
-    with _button_render_gate(state, f"{label} (quiet)") as acquired:
+    with _button_render_gate(state, label, "quiet", telemetry_path=telemetry_path) as acquired:
         if not acquired:
             return {"ok": False, "error": "busy"}
         try:
@@ -204,12 +233,11 @@ def action_quiet(args: argparse.Namespace, state: RuntimeState, *, label: str = 
                     time_str, history_path=history_path, history_days=args.history_days,
                 )
                 run_clock._render_unlocked(args, state, time_str, history_path, quote_id=quote_id)
+            _emit_action(telemetry_path, "quiet", label, ok=True)
             return {"ok": True, "manual_quiet": quiet_now}
         except Exception as exc:
             _log(f"{label} quiet toggle failed: {exc!r}", err=True)
-            run_clock.append_telemetry(
-                telemetry_path, {"bucket": run_clock.current_bucket(), "error": repr(exc), "mode": "quiet"},
-            )
+            _emit_action(telemetry_path, "quiet", label, ok=False, error=repr(exc))
             return {"ok": False, "error": repr(exc)}
 
 
@@ -219,7 +247,7 @@ def action_rerender(args: argparse.Namespace, state: RuntimeState, *, label: str
     from buckets import bucket_for_time
     history_path = args.history_path or None
     telemetry_path = args.telemetry_path or None
-    with _button_render_gate(state, f"{label} (rerender)") as acquired:
+    with _button_render_gate(state, label, "rerender", telemetry_path=telemetry_path) as acquired:
         if not acquired:
             return {"ok": False, "error": "busy"}
         try:
@@ -232,10 +260,9 @@ def action_rerender(args: argparse.Namespace, state: RuntimeState, *, label: str
             if quote_id is not None:
                 run_clock._append_history_after_render(state, history_path, quote_id)
             _log(f"{label}: rerender bucket={bucket}")
+            _emit_action(telemetry_path, "rerender", label, ok=True)
             return {"ok": True, "bucket": bucket, "quote_id": list(quote_id) if quote_id else None}
         except Exception as exc:
             _log(f"{label} rerender failed: {exc!r}", err=True)
-            run_clock.append_telemetry(
-                telemetry_path, {"bucket": run_clock.current_bucket(), "error": repr(exc), "mode": "rerender"},
-            )
+            _emit_action(telemetry_path, "rerender", label, ok=False, error=repr(exc))
             return {"ok": False, "error": repr(exc)}

--- a/runtime_quiet.py
+++ b/runtime_quiet.py
@@ -158,6 +158,12 @@ def enter_quiet(
     quiet_bucket = bucket_for_time(time_str)
     trigger = "manual" if manual_only else f"{args.quiet_start}–{args.quiet_end}"
     _log(f"quiet hours start ({trigger})")
+    # Structured rising-edge marker so litclock_health can tell
+    # "silent window because quiet" apart from "silent window because wedged";
+    # the falling-edge marker is emitted by the main loop after exit_quiet.
+    run_clock.append_telemetry(
+        telemetry_path, {"mode": "quiet_enter", "manual": manual_only, "bucket": quiet_bucket},
+    )
     try:
         if args.quiet_image:
             with state.render_lock:

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -63,13 +63,13 @@ class TestRenderGateDropsConcurrentPresses:
         observed = []
 
         def slow_first():
-            with run_clock._button_render_gate(state, "first") as acquired:
+            with run_clock._button_render_gate(state, "test", "first") as acquired:
                 observed.append(("first", acquired))
                 first_entered.set()
                 release_first.wait(timeout=2)
 
         def immediate_second():
-            with run_clock._button_render_gate(state, "second") as acquired:
+            with run_clock._button_render_gate(state, "test", "second") as acquired:
                 observed.append(("second", acquired))
 
         t1 = threading.Thread(target=slow_first)
@@ -171,14 +171,14 @@ class TestRenderGateFairness:
         count_lock = threading.Lock()
 
         def slow_holder():
-            with run_clock._button_render_gate(state, "holder") as acquired:
+            with run_clock._button_render_gate(state, "test", "holder") as acquired:
                 assert acquired
                 running.set()
                 release.wait(timeout=5)
 
         def taps():
             nonlocal acquired_count, dropped_count
-            with run_clock._button_render_gate(state, "tap") as acquired:
+            with run_clock._button_render_gate(state, "test", "tap") as acquired:
                 with count_lock:
                     if acquired:
                         acquired_count += 1

--- a/tests/test_litclock_health.py
+++ b/tests/test_litclock_health.py
@@ -427,3 +427,157 @@ class TestBackoffNotCountedAsRender:
         summary = litclock_health.summarise(entries)
         assert summary["render_count"] == 0
         assert summary["error_count"] == 2
+
+
+class TestActionSummarisation:
+    """Phase 4 observability — operator actions, press-drops, web auth
+    failures, and quiet-window transitions surface as counters in the
+    summary. See github.com/gkoch02/litclock issue #55.
+    """
+
+    def test_actions_broken_down_by_type(self):
+        entries = [
+            {"ts": _ts(5), "mode": "action", "action": "skip", "label": "button A", "ok": True},
+            {"ts": _ts(4), "mode": "action", "action": "skip", "label": "web", "ok": True},
+            {"ts": _ts(3), "mode": "action", "action": "theme", "label": "button B", "ok": True},
+            {"ts": _ts(2), "mode": "action", "action": "theme", "label": "web", "ok": False, "error": "X"},
+        ]
+        summary = litclock_health.summarise(entries)
+        assert summary["action_count"] == 4
+        assert summary["actions_by_type"] == {"skip": 2, "theme": 2}
+        # last action is the most recent one in the list order
+        assert summary["last_action_ts"] == entries[-1]["ts"]
+
+    def test_action_errors_do_not_inflate_error_count(self):
+        """A failed skip action has ``ok=False, error=...`` but the render
+        pipeline itself is unaffected — it belongs in action_count, not
+        error_count, so a spurious web call doesn't light up health
+        monitoring."""
+        entries = [
+            {"ts": _ts(5), "mode": "action", "action": "skip", "ok": False, "error": "boom"},
+            {"ts": _ts(4), "render_ms": 100},
+        ]
+        summary = litclock_health.summarise(entries)
+        assert summary["render_count"] == 1
+        assert summary["error_count"] == 0
+        assert summary["action_count"] == 1
+
+    def test_press_dropped_counted(self):
+        entries = [
+            {"ts": _ts(5), "mode": "press_dropped", "label": "button A", "action": "skip", "reason": "render_in_flight"},
+            {"ts": _ts(4), "mode": "press_dropped", "label": "web", "action": "theme", "reason": "render_in_flight"},
+        ]
+        summary = litclock_health.summarise(entries)
+        assert summary["press_dropped_count"] == 2
+
+    def test_web_auth_fail_counted(self):
+        entries = [
+            {"ts": _ts(5), "mode": "web_auth_fail", "remote": "10.0.0.2", "path": "/api/action/theme"},
+        ]
+        summary = litclock_health.summarise(entries)
+        assert summary["web_auth_fail_count"] == 1
+        # web_auth_fail has no error field, so it shouldn't influence error_count either way.
+        assert summary["error_count"] == 0
+
+    def test_web_error_counted_not_as_generic_error(self):
+        """``web_error`` entries carry an ``error`` field but represent HTTP
+        4xx/5xx responses, not render-pipeline failures. They get their own
+        counter, not the generic error_count."""
+        entries = [
+            {"ts": _ts(5), "mode": "web_error", "status": 400, "path": "/api/overrides", "error": "invalid bucket"},
+            {"ts": _ts(4), "mode": "web_error", "status": 500, "path": "/api/action/theme", "error": "RuntimeError()"},
+        ]
+        summary = litclock_health.summarise(entries)
+        assert summary["web_error_count"] == 2
+        assert summary["error_count"] == 0
+
+    def test_quiet_enter_and_exit_counted(self):
+        entries = [
+            {"ts": _ts(30), "mode": "quiet_enter", "manual": False},
+            {"ts": _ts(20), "mode": "quiet_exit"},
+            {"ts": _ts(10), "mode": "quiet_enter", "manual": True},
+        ]
+        summary = litclock_health.summarise(entries)
+        assert summary["quiet_enter_count"] == 2
+        assert summary["quiet_exit_count"] == 1
+
+    def test_summary_fields_all_present_on_empty(self):
+        """Zero entries still produce every counter so downstream consumers
+        don't need ``summary.get(..., 0)`` guards."""
+        summary = litclock_health.summarise([])
+        for key in (
+            "action_count", "press_dropped_count", "web_auth_fail_count",
+            "web_error_count", "quiet_enter_count", "quiet_exit_count",
+        ):
+            assert summary[key] == 0, key
+        assert summary["actions_by_type"] == {}
+        assert summary["last_action_ts"] is None
+
+
+class TestActionsOnlyView:
+    def test_actions_only_text_output(self, tmp_path, capsys):
+        path = _ledger(tmp_path, [
+            {"ts": _ts(5), "mode": "action", "action": "skip", "label": "button A", "ok": True},
+            {"ts": _ts(4), "mode": "action", "action": "theme", "label": "web", "ok": True},
+            {"ts": _ts(3), "mode": "press_dropped", "label": "button A", "action": "skip", "reason": "render_in_flight"},
+            {"ts": _ts(2), "mode": "web_auth_fail", "remote": "1.2.3.4", "path": "/api/action/theme"},
+            {"ts": _ts(1), "mode": "quiet_enter", "manual": False},
+        ])
+        argv = [
+            "litclock_health.py",
+            "--telemetry-path", str(path),
+            "--hours", "1",
+            "--actions-only",
+        ]
+        with patch("sys.argv", argv):
+            rc = litclock_health.main()
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "operator activity" in out
+        assert "actions: 2" in out
+        assert "skip 1" in out
+        assert "theme 1" in out
+        assert "presses dropped: 1" in out
+        assert "web auth failures: 1" in out
+        assert "1 enters" in out
+
+    def test_actions_only_stable_shape_on_empty_window(self, tmp_path, capsys):
+        """Every counter prints even when zero so grep-based cron workflows
+        don't silently break when the window is quiet."""
+        path = _ledger(tmp_path, [
+            {"ts": _ts(5), "render_ms": 100},  # no action traffic, but a render exists so we don't exit 1
+        ])
+        argv = [
+            "litclock_health.py",
+            "--telemetry-path", str(path),
+            "--hours", "1",
+            "--actions-only",
+        ]
+        with patch("sys.argv", argv):
+            rc = litclock_health.main()
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "actions: 0" in out
+        assert "presses dropped: 0" in out
+        assert "web auth failures: 0" in out
+        assert "last action: never" in out
+
+    def test_actions_only_ignored_by_json_flag(self, tmp_path, capsys):
+        """--json keeps its machine-readable shape regardless of --actions-only."""
+        path = _ledger(tmp_path, [
+            {"ts": _ts(5), "mode": "action", "action": "skip", "label": "web", "ok": True},
+            {"ts": _ts(4), "mode": "press_dropped", "label": "web", "action": "skip", "reason": "render_in_flight"},
+        ])
+        argv = [
+            "litclock_health.py",
+            "--telemetry-path", str(path),
+            "--hours", "1",
+            "--actions-only", "--json",
+        ]
+        with patch("sys.argv", argv):
+            rc = litclock_health.main()
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out.strip())
+        assert data["action_count"] == 1
+        assert data["press_dropped_count"] == 1
+        assert data["actions_by_type"] == {"skip": 1}

--- a/tests/test_run_clock.py
+++ b/tests/test_run_clock.py
@@ -2223,7 +2223,13 @@ class TestActionExceptionBranches:
         assert result["ok"] is False
         assert "panel disconnected" in result["error"]
         entries = self._read_telemetry(tmp_path)
-        assert any(e.get("mode") == "skip" and "panel disconnected" in e.get("error", "") for e in entries)
+        assert any(
+            e.get("mode") == "action"
+            and e.get("action") == "skip"
+            and e.get("ok") is False
+            and "panel disconnected" in e.get("error", "")
+            for e in entries
+        )
 
     def test_unskip_remove_entry_failure_returns_error_dict(self, tmp_path):
         args = self._args(tmp_path)
@@ -2236,7 +2242,10 @@ class TestActionExceptionBranches:
         assert result["ok"] is False
         assert "disk full" in result["error"]
         entries = self._read_telemetry(tmp_path)
-        assert any(e.get("mode") == "unskip" for e in entries)
+        assert any(
+            e.get("mode") == "action" and e.get("action") == "unskip" and e.get("ok") is False
+            for e in entries
+        )
 
     def test_theme_render_failure_returns_error_dict(self, tmp_path):
         args = self._args(tmp_path)
@@ -2275,7 +2284,10 @@ class TestActionExceptionBranches:
         assert result["ok"] is False
         assert "pick failed" in result["error"]
         entries = self._read_telemetry(tmp_path)
-        assert any(e.get("mode") == "rerender" for e in entries)
+        assert any(
+            e.get("mode") == "action" and e.get("action") == "rerender" and e.get("ok") is False
+            for e in entries
+        )
 
     def test_all_actions_return_busy_when_render_lock_held(self, tmp_path):
         """Non-blocking acquire must return {'ok': False, 'error': 'busy'}
@@ -2302,6 +2314,252 @@ class TestActionExceptionBranches:
         state.last_skipped = None
         result = run_clock.action_unskip(args, state, label="web")
         assert result == {"ok": True, "restored": None}
+
+
+class TestActionSuccessTelemetry:
+    """Each ``action_*`` emits a structured ``mode="action"`` entry on
+    success. Failures emit the same shape with ``ok=False`` (covered in
+    ``TestActionExceptionBranches``); busy-drops emit ``mode="press_dropped"``
+    from ``_button_render_gate`` (covered in ``TestPressDroppedTelemetry``)
+    so there is exactly one operator-visible marker per press.
+    """
+
+    def _args(self, tmp_path, **overrides):
+        defaults = dict(
+            render_script="render_quote.py",
+            output=str(tmp_path / "current.png"),
+            width=800,
+            height=480,
+            display_script=None,
+            mode="debug",
+            theme="default",
+            history_path=str(tmp_path / "history.jsonl"),
+            history_days=7,
+            telemetry_path=str(tmp_path / "telemetry.jsonl"),
+            state_path=str(tmp_path / "state.json"),
+            quiet_image="",
+            shutdown_command="",
+        )
+        defaults.update(overrides)
+        return argparse.Namespace(**defaults)
+
+    def _read_telemetry(self, tmp_path) -> list[dict]:
+        entries = []
+        for path in tmp_path.glob("telemetry-*.jsonl"):
+            for line in path.read_text(encoding="utf-8").splitlines():
+                if line.strip():
+                    entries.append(json.loads(line))
+        return entries
+
+    def test_skip_success_emits_action_entry(self, tmp_path):
+        args = self._args(tmp_path)
+        state = run_clock.RuntimeState("default")
+        with patch("run_clock.peek_quote_id", return_value=("src", 1, "q", "mt")), \
+             patch("run_clock._render_unlocked"), \
+             patch("run_clock.current_time_str", return_value="10:00"):
+            result = run_clock.action_skip(args, state, label="button A")
+        assert result["ok"] is True
+        entries = self._read_telemetry(tmp_path)
+        matching = [e for e in entries if e.get("mode") == "action" and e.get("action") == "skip"]
+        assert matching, entries
+        assert matching[0]["label"] == "button A"
+        assert matching[0]["ok"] is True
+        assert "error" not in matching[0]
+
+    def test_theme_success_emits_action_entry(self, tmp_path):
+        args = self._args(tmp_path)
+        state = run_clock.RuntimeState("default")
+        state.last_effective_theme = "default"
+        with patch("run_clock._render_unlocked"), \
+             patch("run_clock.current_time_str", return_value="10:00"):
+            result = run_clock.action_theme(args, state, label="web")
+        assert result["ok"] is True
+        entries = self._read_telemetry(tmp_path)
+        matching = [e for e in entries if e.get("mode") == "action" and e.get("action") == "theme"]
+        assert matching
+        assert matching[0]["label"] == "web"
+        assert matching[0]["ok"] is True
+
+    def test_quiet_success_emits_action_entry(self, tmp_path):
+        args = self._args(tmp_path, quiet_image="")
+        state = run_clock.RuntimeState("default")
+        state.manual_quiet = True
+        with patch("run_clock._render_unlocked"), \
+             patch("run_clock.peek_quote_id", return_value=("src", 1, "q", "mt")), \
+             patch("run_clock.current_time_str", return_value="10:00"):
+            result = run_clock.action_quiet(args, state, label="button D")
+        assert result["ok"] is True
+        entries = self._read_telemetry(tmp_path)
+        matching = [e for e in entries if e.get("mode") == "action" and e.get("action") == "quiet"]
+        assert matching
+        assert matching[0]["label"] == "button D"
+
+    def test_rerender_success_emits_action_entry(self, tmp_path):
+        args = self._args(tmp_path)
+        state = run_clock.RuntimeState("default")
+        with patch("run_clock._render_unlocked"), \
+             patch("run_clock.peek_quote_id", return_value=("src", 1, "q", "mt")), \
+             patch("run_clock.current_time_str", return_value="10:00"):
+            result = run_clock.action_rerender(args, state, label="web")
+        assert result["ok"] is True
+        entries = self._read_telemetry(tmp_path)
+        matching = [e for e in entries if e.get("mode") == "action" and e.get("action") == "rerender"]
+        assert matching
+
+    def test_unskip_noop_still_emits_action_entry(self, tmp_path):
+        """An un-skip with nothing to restore is a successful no-op — still
+        emits ``mode="action"`` so the summary counts the operator press."""
+        args = self._args(tmp_path)
+        state = run_clock.RuntimeState("default")
+        state.last_skipped = None
+        run_clock.action_unskip(args, state, label="button A")
+        entries = self._read_telemetry(tmp_path)
+        matching = [e for e in entries if e.get("mode") == "action" and e.get("action") == "unskip"]
+        assert matching
+        assert matching[0]["ok"] is True
+
+
+class TestPressDroppedTelemetry:
+    """``_button_render_gate`` emits a ``mode="press_dropped"`` entry when
+    the non-blocking ``render_lock.acquire`` fails. One entry per dropped
+    press, never paired with an action entry.
+    """
+
+    def _args(self, tmp_path, **overrides):
+        defaults = dict(
+            render_script="render_quote.py",
+            output=str(tmp_path / "current.png"),
+            width=800,
+            height=480,
+            display_script=None,
+            mode="debug",
+            theme="default",
+            history_path=str(tmp_path / "history.jsonl"),
+            history_days=7,
+            telemetry_path=str(tmp_path / "telemetry.jsonl"),
+            state_path=str(tmp_path / "state.json"),
+            quiet_image="",
+            shutdown_command="",
+        )
+        defaults.update(overrides)
+        return argparse.Namespace(**defaults)
+
+    def _read_telemetry(self, tmp_path) -> list[dict]:
+        entries = []
+        for path in tmp_path.glob("telemetry-*.jsonl"):
+            for line in path.read_text(encoding="utf-8").splitlines():
+                if line.strip():
+                    entries.append(json.loads(line))
+        return entries
+
+    def test_busy_skip_emits_press_dropped_not_action(self, tmp_path):
+        """Acceptance criterion from issue #55: a press during an in-flight
+        render shows up as ``press_dropped``, and NOT as an ``action`` entry."""
+        args = self._args(tmp_path)
+        state = run_clock.RuntimeState("default")
+        state.render_lock.acquire()
+        try:
+            result = run_clock.action_skip(args, state, label="button A")
+        finally:
+            state.render_lock.release()
+        assert result == {"ok": False, "error": "busy"}
+        entries = self._read_telemetry(tmp_path)
+        dropped = [e for e in entries if e.get("mode") == "press_dropped"]
+        actions = [e for e in entries if e.get("mode") == "action"]
+        assert len(dropped) == 1
+        assert actions == []  # busy path must not double-count
+        assert dropped[0]["label"] == "button A"
+        assert dropped[0]["action"] == "skip"
+        assert dropped[0]["reason"] == "render_in_flight"
+
+    def test_spam_ten_presses_yields_one_success_and_nine_dropped(self, tmp_path):
+        """Acceptance criterion from issue #55: 10 presses during a slow
+        render ⇒ 1 success + 9 dropped. We simulate this by holding the
+        render lock for 9 of the 10 presses, then releasing for the 10th."""
+        args = self._args(tmp_path)
+        state = run_clock.RuntimeState("default")
+        with patch("run_clock._render_unlocked"), \
+             patch("run_clock.peek_quote_id", return_value=("src", 1, "q", "mt")), \
+             patch("run_clock.current_time_str", return_value="10:00"):
+            state.render_lock.acquire()
+            try:
+                for _ in range(9):
+                    run_clock.action_theme(args, state, label="button B")
+            finally:
+                state.render_lock.release()
+            # The 10th press succeeds.
+            run_clock.action_theme(args, state, label="button B")
+        entries = self._read_telemetry(tmp_path)
+        dropped = [e for e in entries if e.get("mode") == "press_dropped"]
+        actions = [e for e in entries if e.get("mode") == "action" and e.get("ok") is True]
+        assert len(dropped) == 9
+        assert len(actions) == 1
+
+
+class TestQuietHoursTelemetry:
+    """``enter_quiet`` emits ``mode="quiet_enter"`` (scheduled or manual);
+    the main loop's scheduled-exit branch emits ``mode="quiet_exit"`` after
+    calling ``exit_quiet``. Manual-quiet toggles are tracked via the
+    ``action`` telemetry instead, so they don't double-count here.
+    """
+
+    def test_enter_quiet_emits_telemetry(self, tmp_path):
+        import runtime_quiet
+        args = argparse.Namespace(
+            history_path="",
+            telemetry_path=str(tmp_path / "telemetry.jsonl"),
+            quiet_start="22:00",
+            quiet_end="06:00",
+            quiet_image="",
+            output=str(tmp_path / "out.png"),
+            display_script=None,
+            render_script="render_quote.py",
+            width=800,
+            height=480,
+            mode="debug",
+            history_days=7,
+        )
+        state = run_clock.RuntimeState("default")
+        with patch("run_clock.render_now"), \
+             patch("run_clock._display_quiet_image"):
+            runtime_quiet.enter_quiet(args, state, "22:30", manual_only=False)
+        entries = []
+        for path in tmp_path.glob("telemetry-*.jsonl"):
+            for line in path.read_text(encoding="utf-8").splitlines():
+                if line.strip():
+                    entries.append(json.loads(line))
+        matching = [e for e in entries if e.get("mode") == "quiet_enter"]
+        assert matching, entries
+        assert matching[0]["manual"] is False
+
+    def test_manual_quiet_enter_records_manual_true(self, tmp_path):
+        import runtime_quiet
+        args = argparse.Namespace(
+            history_path="",
+            telemetry_path=str(tmp_path / "telemetry.jsonl"),
+            quiet_start="22:00",
+            quiet_end="06:00",
+            quiet_image="",
+            output=str(tmp_path / "out.png"),
+            display_script=None,
+            render_script="render_quote.py",
+            width=800,
+            height=480,
+            mode="debug",
+            history_days=7,
+        )
+        state = run_clock.RuntimeState("default")
+        with patch("run_clock.render_now"), \
+             patch("run_clock._display_quiet_image"):
+            runtime_quiet.enter_quiet(args, state, "12:00", manual_only=True)
+        entries = []
+        for path in tmp_path.glob("telemetry-*.jsonl"):
+            for line in path.read_text(encoding="utf-8").splitlines():
+                if line.strip():
+                    entries.append(json.loads(line))
+        matching = [e for e in entries if e.get("mode") == "quiet_enter"]
+        assert matching
+        assert matching[0]["manual"] is True
 
 
 class TestParseArgsBasic:

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -850,6 +850,31 @@ class TestWebAuthFailTelemetry:
         entries = _read_web_telemetry(tmp_path)
         assert any(e.get("mode") == "web_auth_fail" for e in entries)
 
+    def test_auth_fail_strips_query_string_from_path(self, tmp_path):
+        """Security: a fat-finger client putting a token in the URL (instead of
+        the X-LitClock-Token header) would otherwise plant the secret in the
+        telemetry sidecar. ``log_message`` is silenced for the same reason."""
+        args = _make_args(tmp_path, web_bind="0.0.0.0:0")
+        state = run_clock.RuntimeState(args.theme)
+        server, thread = web_server.start_web_server(args, state, token="secret")
+        try:
+            # Deliberately embed a "secret" in the query to simulate misuse.
+            conn = _client(server)
+            conn.request("POST", "/api/action/theme?token=leaked", body=b"",
+                         headers={"Content-Length": "0"})
+            resp = conn.getresponse()
+            resp.read()
+            conn.close()
+            assert resp.status == 401
+        finally:
+            run_clock.stop_web_server((server, thread))
+        entries = _read_web_telemetry(tmp_path)
+        matching = [e for e in entries if e.get("mode") == "web_auth_fail"]
+        assert matching
+        # Path must be just the route, without the query — no "leaked" token.
+        assert matching[0]["path"] == "/api/action/theme"
+        assert "leaked" not in json.dumps(matching[0])
+
     def test_successful_post_does_not_emit_auth_fail(self, tmp_path):
         args = _make_args(tmp_path, web_bind="0.0.0.0:0")
         state = run_clock.RuntimeState(args.theme)

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -800,3 +800,96 @@ class TestErrorBranches:
         status, body = _get(server, "/api/bucket/h3_exact?top=notanumber")
         assert status == 400
         assert "top" in _json_body(body)["error"]
+
+
+# ============================================================================
+# Phase 4 observability — structured web telemetry
+# (github.com/gkoch02/litclock issue #55)
+# ============================================================================
+
+
+def _read_web_telemetry(tmp_path: Path) -> list[dict]:
+    """Read all date-rotated telemetry siblings written by the web server."""
+    entries = []
+    for path in tmp_path.glob("telemetry-*.jsonl"):
+        for line in path.read_text(encoding="utf-8").splitlines():
+            if line.strip():
+                entries.append(json.loads(line))
+    return entries
+
+
+class TestWebAuthFailTelemetry:
+    def test_bad_token_post_emits_web_auth_fail(self, tmp_path):
+        """A 401 on a POST lays down a ``mode="web_auth_fail"`` entry so an
+        operator can see "was the web UI hammered with bad tokens yesterday?"
+        without scraping journald."""
+        args = _make_args(tmp_path, web_bind="0.0.0.0:0")
+        state = run_clock.RuntimeState(args.theme)
+        server, thread = web_server.start_web_server(args, state, token="secret")
+        try:
+            status, _ = _post(server, "/api/action/theme", headers={"X-LitClock-Token": "wrong"})
+            assert status == 401
+        finally:
+            run_clock.stop_web_server((server, thread))
+        entries = _read_web_telemetry(tmp_path)
+        matching = [e for e in entries if e.get("mode") == "web_auth_fail"]
+        assert matching, entries
+        assert matching[0]["path"] == "/api/action/theme"
+        # remote is present (127.0.0.1 in the test loopback)
+        assert "remote" in matching[0]
+
+    def test_missing_token_header_emits_web_auth_fail(self, tmp_path):
+        args = _make_args(tmp_path, web_bind="0.0.0.0:0")
+        state = run_clock.RuntimeState(args.theme)
+        server, thread = web_server.start_web_server(args, state, token="secret")
+        try:
+            status, _ = _post(server, "/api/action/theme")
+            assert status == 401
+        finally:
+            run_clock.stop_web_server((server, thread))
+        entries = _read_web_telemetry(tmp_path)
+        assert any(e.get("mode") == "web_auth_fail" for e in entries)
+
+    def test_successful_post_does_not_emit_auth_fail(self, tmp_path):
+        args = _make_args(tmp_path, web_bind="0.0.0.0:0")
+        state = run_clock.RuntimeState(args.theme)
+        server, thread = web_server.start_web_server(args, state, token="secret")
+        try:
+            with patch("run_clock._render_unlocked"), \
+                 patch("run_clock.peek_quote_id", return_value=("141", 1, "q", "m")):
+                status, _ = _post(
+                    server, "/api/action/theme",
+                    headers={"X-LitClock-Token": "secret"},
+                )
+            assert status == 200
+        finally:
+            run_clock.stop_web_server((server, thread))
+        entries = _read_web_telemetry(tmp_path)
+        assert not any(e.get("mode") == "web_auth_fail" for e in entries)
+
+
+class TestWebErrorTelemetry:
+    def test_bad_post_body_emits_web_error(self, live_server):
+        """A malformed overrides payload returns 400 and emits a structured
+        ``mode="web_error"`` entry with the status and error string."""
+        server, _, args = live_server
+        status, _ = _post(server, "/api/overrides", {"preferred_buckets": {"h13_exact": "141"}})
+        assert status == 400
+        entries = _read_web_telemetry(Path(args.telemetry_path).parent)
+        matching = [e for e in entries if e.get("mode") == "web_error"]
+        assert matching, entries
+        assert matching[0]["status"] == 400
+        assert matching[0]["path"] == "/api/overrides"
+
+    def test_exception_in_handler_emits_web_error_500(self, live_server, monkeypatch):
+        server, _, args = live_server
+        monkeypatch.setattr(
+            run_clock, "action_rerender",
+            lambda *a, **kw: (_ for _ in ()).throw(RuntimeError("explode")),
+        )
+        status, _ = _post(server, "/api/action/rerender", {})
+        assert status == 500
+        entries = _read_web_telemetry(Path(args.telemetry_path).parent)
+        matching = [e for e in entries if e.get("mode") == "web_error" and e.get("status") == 500]
+        assert matching
+        assert "explode" in matching[0]["error"]

--- a/web_server.py
+++ b/web_server.py
@@ -244,11 +244,14 @@ class CuratorHandler(BaseHTTPRequestHandler):
             # Structured auth-failure marker so an operator can grep for
             # "was the web UI hammered with bad tokens?" without scraping
             # journald; remote+path are sufficient to distinguish a fat-
-            # finger from a scanner sweep.
+            # finger from a scanner sweep. Strip the query string for the
+            # same reason ``log_message`` is silenced — a fat-finger client
+            # putting the token in the URL would otherwise plant the secret
+            # in the telemetry sidecar.
             self._emit_web_telemetry({
                 "mode": "web_auth_fail",
                 "remote": self.client_address[0] if self.client_address else "",
-                "path": self.path,
+                "path": urllib.parse.urlparse(self.path).path,
             })
             self._json(HTTPStatus.UNAUTHORIZED, {"error": "token required"})
             return False

--- a/web_server.py
+++ b/web_server.py
@@ -241,9 +241,32 @@ class CuratorHandler(BaseHTTPRequestHandler):
             return True
         supplied = self.headers.get(TOKEN_HEADER, "")
         if not supplied or not hmac.compare_digest(supplied, ctx.token):
+            # Structured auth-failure marker so an operator can grep for
+            # "was the web UI hammered with bad tokens?" without scraping
+            # journald; remote+path are sufficient to distinguish a fat-
+            # finger from a scanner sweep.
+            self._emit_web_telemetry({
+                "mode": "web_auth_fail",
+                "remote": self.client_address[0] if self.client_address else "",
+                "path": self.path,
+            })
             self._json(HTTPStatus.UNAUTHORIZED, {"error": "token required"})
             return False
         return True
+
+    def _emit_web_telemetry(self, payload: dict) -> None:
+        """Emit one structured web-activity entry via the run_clock telemetry sink.
+
+        Lazy import keeps the module-import graph acyclic (``run_clock``
+        imports from ``web_server``-adjacent runtime modules, not vice
+        versa at load time) and routes through ``run_clock.append_telemetry``
+        so tests can patch the sink in one place.
+        """
+        ctx = self._ctx()
+        if not ctx.telemetry_path:
+            return
+        import run_clock
+        run_clock.append_telemetry(ctx.telemetry_path, payload)
 
     def _read_json_body(self) -> dict:
         length = int(self.headers.get("Content-Length", "0") or 0)
@@ -311,9 +334,17 @@ class CuratorHandler(BaseHTTPRequestHandler):
         try:
             return handler()
         except ValueError as exc:
+            # Body/payload validation failure — structured 400 marker so an
+            # operator can tell a curl-it-wrong from a real 5xx blow-up.
+            self._emit_web_telemetry({
+                "mode": "web_error", "status": 400, "path": path, "error": str(exc),
+            })
             return self._json(HTTPStatus.BAD_REQUEST, {"error": str(exc)})
         except Exception as exc:  # noqa: BLE001
             _log(f"web POST {path}: {exc!r}", err=True)
+            self._emit_web_telemetry({
+                "mode": "web_error", "status": 500, "path": path, "error": repr(exc),
+            })
             return self._json(HTTPStatus.INTERNAL_SERVER_ERROR, {"error": repr(exc)})
 
     # -- GET endpoints --------------------------------------------------------


### PR DESCRIPTION
Telemetry previously covered renders, errors, backoff, heartbeats, and
subprocess timeouts. Silent drops — successful button presses, busy-drop
coalescing, web auth failures, and quiet-hours transitions — were only
visible in journald, so litclock_health.py summaries couldn't answer
"what did the user do?" or tell "silent because quiet" apart from
"silent because wedged."

Closes #55.

Actions (runtime_actions.py)
  - Each action_* now emits {"mode": "action", "action": ..., "label":
    "button A"|"web", "ok": true/false, "error"?: ...} on success and
    failure. The per-mode error entries ("skip"/"theme"/...) are gone —
    unified under mode="action".
  - _button_render_gate gains (label, action, *, telemetry_path=) and
    emits {"mode": "press_dropped", "label": ..., "action": ...,
    "reason": "render_in_flight"} when the non-blocking render_lock
    acquire fails. A busy press never double-counts as both action and
    press_dropped.

Web server (web_server.py)
  - 401 auth failures emit {"mode": "web_auth_fail", "remote": ...,
    "path": ...}. 4xx/5xx POST responses emit {"mode": "web_error",
    "status": ..., "path": ..., "error": ...}. Telemetry routed via
    a new _emit_web_telemetry helper that honors ctx.telemetry_path.

Quiet hours (runtime_quiet.py, run_clock.py)
  - enter_quiet emits {"mode": "quiet_enter", "manual": bool, "bucket":
    ...} at the rising edge (scheduled or manual). The main loop's
    scheduled-exit branch emits {"mode": "quiet_exit"} at the falling
    edge. Manual-quiet toggles surface as action entries; the state
    machine re-triggers enter/exit on the next tick, so the counts
    stay balanced.

Health summariser (litclock_health.py)
  - summarise() adds action_count, actions_by_type, last_action_ts,
    press_dropped_count, web_auth_fail_count, web_error_count,
    quiet_enter_count, quiet_exit_count. Action-errors and web-errors
    are deliberately excluded from error_count (render pipeline ≠
    operator action pipeline).
  - format_summary prints compact breakdowns when nonzero.
  - New --actions-only flag renders an operator-centric "what did the
    user do?" view (shape-stable even on empty windows for grep-based
    cron). --json output shape is unchanged regardless of flag.

Tests (24 new tests across test_run_clock, test_litclock_health,
test_web_server) cover: every action's success telemetry; the 10-press
spam case from the issue's acceptance criteria (1 success + 9
press_dropped, zero action entries); web_auth_fail on bad/missing
token; web_error on bad payload and 500 exceptions; quiet_enter with
manual=True/False; summariser breakdowns; --actions-only text and
empty-window stability.

https://claude.ai/code/session_012TArCFJSFK85s6jveEFx29