### PR TITLE
Appliance hardening phase 5: unbounded growth + drift cleanup (#56)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,7 +206,7 @@ assets/quote_database.jsonl           ← pick_quote.py default --database
   ↓ pick_quote.py
 JSON quote for requested time
   ↓ render_quote.py (imports pick_quote in-process)
-render-HHMM.png  or  output/current.png
+output/current.png  (overwritten per render — stable filename)
   ↓ display_inky.py (optional, Pi-only)
 Inky Impression eInk panel
   ↑ run_clock.py orchestrates the render→display loop
@@ -440,7 +440,7 @@ Imports `pick_quote` in-process (`pick_quote_module.select_quote`) and lays out 
 - **Fit loop.** `fit_quote` shrinks the quote font in 2pt steps from the layout's `font_max` down to `font_min` until all lines fit within `quote_height`.
 - **Justification.** Non-last lines are fully justified by distributing leftover slack across inter-word spaces — but only when slack is ≤25% of the layout's `max_width`. Loose lines fall back to ragged-right because wide forced gaps look worse than uneven right edges.
 - **Modes.** `--mode debug` (default) draws a top-right `DEBUG MODE` banner (rendered in sans-bold to match the footer strip, in the theme's accent color) plus a centered bottom strip (`HH:MM · bucket[ → resolved] · layout X · quality N · id source:Lline`) separated from the quote block by a dotted horizontal rule. `--mode production` hides all of that for a clean appliance look.
-- **Outputs.** `--output` defaults to `output/render-HHMM.png`; `run_clock.py` overrides this to `output/current.png` so the Inky bridge has a stable filename. The PNG is encoded to a `BytesIO` and written via `atomic_io.atomic_write_bytes` so a power cut mid-save can't leave a truncated frame for the next tick (and for `display_inky.py`) to read. The underlying PIL `Image` is explicitly `close()`d after encoding to release the file handle — important over months of continuous operation.
+- **Outputs.** `--output` defaults to `output/current.png` (the same stable filename `run_clock.py` passes explicitly), so repeated ad-hoc CLI invocations overwrite one file instead of leaking up to 1440 `render-HHMM.png` siblings across a day. Pass an explicit path when you want a persistent per-time artifact. The PNG is encoded to a `BytesIO` and written via `atomic_io.atomic_write_bytes` so a power cut mid-save can't leave a truncated frame for the next tick (and for `display_inky.py`) to read. The underlying PIL `Image` is explicitly `close()`d after encoding to release the file handle — important over months of continuous operation.
 
 ### Runtime Loop (`run_clock.py`)
 

--- a/pick_quote.py
+++ b/pick_quote.py
@@ -431,6 +431,57 @@ def append_history(history_path: str | None, source_id, line_number) -> None:
         os.fsync(handle.fileno())
 
 
+def compact_history(history_path: str | None, days: int) -> int:
+    """Drop ledger entries older than ``2 × days``. Returns the number of lines dropped.
+
+    The anti-repeat filter only consults entries within the configured window
+    (``--history-days``), so anything older than that is dead weight that still
+    gets streamed through :func:`load_recent_history` on every pick. A long-
+    lived appliance accumulates ~288 entries per week; over years the linear
+    scan is cheap but the file grows into tens of KB of expired rows.
+
+    We keep ``2 × days`` of slack so a short clock drift or an operator
+    bumping ``--history-days`` up a day or two doesn't immediately evict rows
+    that are about to be re-consulted. No-op if the path is empty, the file
+    doesn't exist, ``days <= 0``, or every entry is still fresh (the common
+    case — avoids a pointless rewrite). Routes the rewrite through
+    :mod:`atomic_io` so a crash mid-compact leaves the original ledger intact.
+
+    Malformed lines are preserved as-is rather than silently dropped: the
+    compact pass is about bounded growth, not corruption repair — callers who
+    need the warn-and-skip behaviour should rely on :func:`load_recent_history`.
+    """
+    if not history_path or days <= 0:
+        return 0
+    path = Path(history_path).expanduser()
+    if not path.exists():
+        return 0
+    cutoff = dt.datetime.now(dt.timezone.utc) - dt.timedelta(days=2 * days)
+    original = path.read_text(encoding="utf-8").splitlines()
+    kept: list[str] = []
+    dropped = 0
+    for line in original:
+        if not line.strip():
+            continue
+        try:
+            entry = json.loads(line)
+            ts = dt.datetime.fromisoformat(entry["ts"])
+        except (ValueError, KeyError, json.JSONDecodeError):
+            kept.append(line)
+            continue
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=dt.timezone.utc)
+        if ts < cutoff:
+            dropped += 1
+            continue
+        kept.append(line)
+    if dropped == 0:
+        return 0
+    payload = ("\n".join(kept) + "\n") if kept else ""
+    atomic_io.atomic_write_text(path, payload)
+    return dropped
+
+
 def remove_last_history_entry(history_path: str | None, source_id, line_number) -> bool:
     """Remove the most recent ledger entry matching ``(source_id, line_number)``.
 

--- a/render_quote.py
+++ b/render_quote.py
@@ -149,7 +149,17 @@ LAYOUTS = {
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Render a literary clock quote for a given time.")
     parser.add_argument("--time", required=True, help="Time in HH:MM 24-hour format")
-    parser.add_argument("--output", default=None, help="Output PNG path. Defaults to output/render-HHMM.png")
+    parser.add_argument(
+        "--output",
+        default=None,
+        help=(
+            "Output PNG path. Defaults to output/current.png (overwritten on every "
+            "run) so repeated ad-hoc invocations don't leak one file per HH:MM into "
+            "output/. Pass an explicit path when you want a persistent per-time "
+            "artifact. run_clock.py always passes --output explicitly, so the "
+            "runtime loop is unaffected by this default."
+        ),
+    )
     parser.add_argument("--width", type=int, default=DEFAULT_WIDTH)
     parser.add_argument("--height", type=int, default=DEFAULT_HEIGHT)
     parser.add_argument(
@@ -680,7 +690,7 @@ def render(time_str: str, quote_row: dict, width: int, height: int, mode: str = 
 def main() -> int:
     args = parse_args()
     quote_row = pick_quote(args.time, history_path=args.history_path, history_days=args.history_days)
-    output_path = Path(args.output) if args.output else Path(f"output/render-{args.time.replace(':', '')}.png")
+    output_path = Path(args.output) if args.output else Path("output/current.png")
     if not output_path.is_absolute():
         output_path = BASE_DIR / output_path
     output_path.parent.mkdir(parents=True, exist_ok=True)

--- a/run_clock.py
+++ b/run_clock.py
@@ -744,12 +744,16 @@ def _check_button_liveness(state: RuntimeState, telemetry_path: str | None) -> N
 
 
 def _resolve_web_token(args: argparse.Namespace) -> str:
-    """Resolve the web token from --web-token, --web-token-file, or empty (disabled).
+    """Resolve the web token from --web-token or --web-token-file for startup logging.
 
     Prefers the file over the inline flag when both are set so rotating the
     token is a single file edit. A missing/unreadable token file is logged and
     falls back to the inline flag (or empty), keeping the server startable even
     if the file has a transient permission hiccup.
+
+    Note: this is the *startup* read; the live auth check uses
+    :meth:`WebContext.current_token` which re-reads the file on every request
+    when the mtime changes, so rotating the token doesn't need a restart.
     """
     if args.web_token_file:
         try:
@@ -777,7 +781,9 @@ def _maybe_start_web_server(args: argparse.Namespace, state: RuntimeState):
         return None
     try:
         token = _resolve_web_token(args)
-        handle = web_server.start_web_server(args, state, token=token)
+        handle = web_server.start_web_server(
+            args, state, token=token, token_file=args.web_token_file or None,
+        )
     except Exception as exc:
         _log(f"web UI failed to start on {args.web_bind!r}: {exc!r}", err=True)
         traceback.print_exc(file=sys.stderr)
@@ -825,6 +831,35 @@ def _maybe_prune_telemetry(args: argparse.Namespace, state: RuntimeState, teleme
     removed = prune_telemetry(telemetry_path, args.telemetry_retain_days, today=today)
     if removed:
         _log(f"telemetry retention: dropped {removed} file(s) older than {args.telemetry_retain_days}d")
+
+
+def _maybe_compact_history(args: argparse.Namespace, state: RuntimeState) -> None:
+    """Compact the anti-repeat history ledger once per local-date rollover.
+
+    Gated on ``state.last_compacted_date`` so the compact sweep runs at most
+    once per calendar day — the ledger is a ~288-entries-per-week
+    append-only file, so a per-tick compact would re-parse it needlessly.
+    Serialised against button A's ``remove_last_history_entry`` rewrite via
+    ``state.ledger_lock`` to avoid stepping on a concurrent un-skip.
+    Best-effort: a disk hiccup here must not bubble into the render path and
+    trip the outer-loop backoff counter.
+    """
+    history_path = args.history_path or None
+    if not history_path or args.history_days <= 0:
+        return
+    today = dt.date.today()
+    with state.lock:
+        if state.last_compacted_date == today:
+            return
+        state.last_compacted_date = today
+    try:
+        with state.ledger_lock:
+            dropped = pick_quote_module.compact_history(history_path, args.history_days)
+    except Exception as exc:
+        _log(f"history compact failed: {exc!r}", err=True)
+        return
+    if dropped:
+        _log(f"history compact: dropped {dropped} entr{'y' if dropped == 1 else 'ies'} older than {2 * args.history_days}d")
 
 
 def _record_render_failure(state: RuntimeState, telemetry_path: str | None, bucket: str | None) -> None:
@@ -1180,6 +1215,7 @@ def main() -> int:
             _maybe_reset_manual_theme_at_midnight(args, state)
             _check_button_liveness(state, telemetry_path)
             _maybe_prune_telemetry(args, state, telemetry_path)
+            _maybe_compact_history(args, state)
             _maybe_emit_heartbeat(state, telemetry_path)
 
             # If the render path has failed repeatedly, skip the render
@@ -1247,9 +1283,24 @@ def main() -> int:
                     # Keep the loop alive so a transient failure (pick_quote crash, Inky I/O,
                     # missing corpus row, etc.) does not kill the appliance. last_bucket stays
                     # stale so the next tick retries.
-                    _log(f"render/display failed for bucket {bucket}: {exc!r}", err=True)
-                    traceback.print_exc(file=sys.stderr)
-                    append_telemetry(telemetry_path, {"bucket": bucket, "error": repr(exc), "mode": args.mode})
+                    #
+                    # Error-log dedup latch: when the same ``repr(exc)`` repeats
+                    # back-to-back (the outer-loop backoff window is retrying
+                    # the same hardware fault), drop the stderr+traceback
+                    # emission so journald doesn't fill with identical
+                    # tracebacks. The structured telemetry entry is still
+                    # written every time so ``litclock_health.py`` sees the
+                    # full failure count. The latch clears on the next success
+                    # via ``commit_render_result``, so a genuinely new error
+                    # after a recovery still logs loudly.
+                    error_repr = repr(exc)
+                    with state.lock:
+                        is_repeat = state.last_logged_error == error_repr
+                        state.last_logged_error = error_repr
+                    if not is_repeat:
+                        _log(f"render/display failed for bucket {bucket}: {error_repr}", err=True)
+                        traceback.print_exc(file=sys.stderr)
+                    append_telemetry(telemetry_path, {"bucket": bucket, "error": error_repr, "mode": args.mode})
                     _record_render_failure(state, telemetry_path, bucket)
             elif state.last_effective_theme is None:
                 with state.lock:

--- a/run_clock.py
+++ b/run_clock.py
@@ -843,6 +843,13 @@ def _maybe_compact_history(args: argparse.Namespace, state: RuntimeState) -> Non
     ``state.ledger_lock`` to avoid stepping on a concurrent un-skip.
     Best-effort: a disk hiccup here must not bubble into the render path and
     trip the outer-loop backoff counter.
+
+    Failure-retry policy: we set ``last_compacted_date`` *before* running the
+    compact, so a disk error leaves the flag set and the sweep doesn't retry
+    until tomorrow. This is intentional — retrying every tick on a persistent
+    fault (readonly fs, full disk) would just spam the log. The next day's
+    rollover retries naturally; if compaction is truly wedged, the ledger's
+    linear scan stays cheap for months before the bloat is user-visible.
     """
     history_path = args.history_path or None
     if not history_path or args.history_days <= 0:

--- a/runtime_actions.py
+++ b/runtime_actions.py
@@ -172,37 +172,58 @@ def action_unskip(args: argparse.Namespace, state: RuntimeState, *, label: str =
 
 
 def action_theme(args: argparse.Namespace, state: RuntimeState, *, label: str = "web") -> dict:
-    """Toggle default ↔ dark, persist to ``--state-path``, re-render. Mirrors button B."""
+    """Toggle default ↔ dark, re-render, persist to ``--state-path`` on success.
+
+    Mirrors button B. Order-of-operations matters: we flip the in-memory
+    ``manual_theme`` so the render reads the new value, push the display, and
+    only *then* persist — if the render raises (missing font file, subprocess
+    timeout, Inky disconnect), we roll the flip back so ``state.json`` and
+    the panel stay in sync. The alternative "persist first, then display"
+    leaves ``state.json`` claiming a theme the panel doesn't show after a
+    transient I/O failure.
+    """
     import run_clock
     history_path = args.history_path or None
     telemetry_path = args.telemetry_path or None
     with _button_render_gate(state, label, "theme", telemetry_path=telemetry_path) as acquired:
         if not acquired:
             return {"ok": False, "error": "busy"}
-        try:
+        rolled_back = False
+        with state.lock:
+            previous_theme = state.manual_theme
             time_str = run_clock.current_time_str()
-            with state.lock:
-                current = state.last_effective_theme or resolve_effective_theme(
-                    state.theme_arg, time_str, state.manual_theme,
-                )
-                state.manual_theme = "dark" if current == "default" else "default"
-                run_clock.save_runtime_state(args.state_path, state.snapshot_for_persistence())
-                new_theme = state.manual_theme
-                quote_id = state.last_quote_id
+            current = state.last_effective_theme or resolve_effective_theme(
+                state.theme_arg, time_str, previous_theme,
+            )
+            state.manual_theme = "dark" if current == "default" else "default"
+            new_theme = state.manual_theme
+            quote_id = state.last_quote_id
+        try:
             _log(f"{label}: theme -> {new_theme}")
             run_clock._render_unlocked(args, state, time_str, history_path, quote_id=quote_id)
+            # Persist only after the display push succeeded so ``state.json``
+            # cannot drift ahead of the panel on a transient render failure.
+            with state.lock:
+                run_clock.save_runtime_state(args.state_path, state.snapshot_for_persistence())
             _emit_action(telemetry_path, "theme", label, ok=True)
             return {"ok": True, "theme": new_theme}
         except Exception as exc:
-            _log(f"{label} theme toggle failed: {exc!r}", err=True)
+            with state.lock:
+                state.manual_theme = previous_theme
+            rolled_back = True
+            _log(f"{label} theme toggle failed: {exc!r} (rolled back to {previous_theme!r})", err=True)
             _emit_action(telemetry_path, "theme", label, ok=False, error=repr(exc))
-            return {"ok": False, "error": repr(exc)}
+            return {"ok": False, "error": repr(exc), "rolled_back": rolled_back}
 
 
 def action_quiet(args: argparse.Namespace, state: RuntimeState, *, label: str = "web") -> dict:
-    """Toggle the manual quiet override, persist, display goodnight-or-wake frame.
+    """Toggle the manual quiet override, display goodnight-or-wake frame, persist on success.
 
-    Mirrors button D short-press.
+    Mirrors button D short-press. See :func:`action_theme` for the ordering
+    rationale: the flip happens in RAM first, then we push the display (quiet
+    image going in, fresh render coming out), then persist. A raise during the
+    display push rolls the flip back so ``state.json`` cannot claim "quiet"
+    while the panel still shows a quote (or vice versa).
     """
     import run_clock
     history_path = args.history_path or None
@@ -210,17 +231,15 @@ def action_quiet(args: argparse.Namespace, state: RuntimeState, *, label: str = 
     with _button_render_gate(state, label, "quiet", telemetry_path=telemetry_path) as acquired:
         if not acquired:
             return {"ok": False, "error": "busy"}
+        with state.lock:
+            previous_quiet = state.manual_quiet
+            state.manual_quiet = not previous_quiet
+            quiet_now = state.manual_quiet
+        # Shared with the main loop's scheduled-exit path: clear render-dedup
+        # state so the next tick repaints in whichever direction we flipped.
+        exit_quiet(state)
+        _log(f"{label}: manual quiet -> {quiet_now}")
         try:
-            with state.lock:
-                state.manual_quiet = not state.manual_quiet
-                run_clock.save_runtime_state(args.state_path, state.snapshot_for_persistence())
-                # Snapshot inside the lock so a concurrent toggle can't flip the
-                # branch we take below.
-                quiet_now = state.manual_quiet
-            # Shared with the main loop's scheduled-exit path: clear render-dedup
-            # state so the next tick repaints in whichever direction we flipped.
-            exit_quiet(state)
-            _log(f"{label}: manual quiet -> {quiet_now}")
             if quiet_now and args.quiet_image:
                 _display_quiet_image(
                     args.quiet_image, args.output, args.display_script,
@@ -233,12 +252,16 @@ def action_quiet(args: argparse.Namespace, state: RuntimeState, *, label: str = 
                     time_str, history_path=history_path, history_days=args.history_days,
                 )
                 run_clock._render_unlocked(args, state, time_str, history_path, quote_id=quote_id)
+            with state.lock:
+                run_clock.save_runtime_state(args.state_path, state.snapshot_for_persistence())
             _emit_action(telemetry_path, "quiet", label, ok=True)
             return {"ok": True, "manual_quiet": quiet_now}
         except Exception as exc:
-            _log(f"{label} quiet toggle failed: {exc!r}", err=True)
+            with state.lock:
+                state.manual_quiet = previous_quiet
+            _log(f"{label} quiet toggle failed: {exc!r} (rolled back to {previous_quiet!r})", err=True)
             _emit_action(telemetry_path, "quiet", label, ok=False, error=repr(exc))
-            return {"ok": False, "error": repr(exc)}
+            return {"ok": False, "error": repr(exc), "rolled_back": True}
 
 
 def action_rerender(args: argparse.Namespace, state: RuntimeState, *, label: str = "web") -> dict:

--- a/runtime_actions.py
+++ b/runtime_actions.py
@@ -181,6 +181,13 @@ def action_theme(args: argparse.Namespace, state: RuntimeState, *, label: str = 
     the panel stay in sync. The alternative "persist first, then display"
     leaves ``state.json`` claiming a theme the panel doesn't show after a
     transient I/O failure.
+
+    Persist failures AFTER a successful render are NOT grounds for rollback:
+    the panel already shows the new theme, so reverting in-memory state would
+    just cause the next loop tick to undo the user's action. We log and keep
+    running (same pattern as ``_persist_state_after_render`` for the main
+    loop); the in-memory theme will be re-persisted on the next successful
+    render commit.
     """
     import run_clock
     history_path = args.history_path or None
@@ -188,7 +195,6 @@ def action_theme(args: argparse.Namespace, state: RuntimeState, *, label: str = 
     with _button_render_gate(state, label, "theme", telemetry_path=telemetry_path) as acquired:
         if not acquired:
             return {"ok": False, "error": "busy"}
-        rolled_back = False
         with state.lock:
             previous_theme = state.manual_theme
             time_str = run_clock.current_time_str()
@@ -198,22 +204,25 @@ def action_theme(args: argparse.Namespace, state: RuntimeState, *, label: str = 
             state.manual_theme = "dark" if current == "default" else "default"
             new_theme = state.manual_theme
             quote_id = state.last_quote_id
+        _log(f"{label}: theme -> {new_theme}")
         try:
-            _log(f"{label}: theme -> {new_theme}")
             run_clock._render_unlocked(args, state, time_str, history_path, quote_id=quote_id)
-            # Persist only after the display push succeeded so ``state.json``
-            # cannot drift ahead of the panel on a transient render failure.
-            with state.lock:
-                run_clock.save_runtime_state(args.state_path, state.snapshot_for_persistence())
-            _emit_action(telemetry_path, "theme", label, ok=True)
-            return {"ok": True, "theme": new_theme}
         except Exception as exc:
             with state.lock:
                 state.manual_theme = previous_theme
-            rolled_back = True
             _log(f"{label} theme toggle failed: {exc!r} (rolled back to {previous_theme!r})", err=True)
             _emit_action(telemetry_path, "theme", label, ok=False, error=repr(exc))
-            return {"ok": False, "error": repr(exc), "rolled_back": rolled_back}
+            return {"ok": False, "error": repr(exc), "rolled_back": True}
+        # Render succeeded; the panel is now authoritative. A persist failure
+        # from here on must NOT roll back — the in-memory flip matches what
+        # the operator sees.
+        try:
+            with state.lock:
+                run_clock.save_runtime_state(args.state_path, state.snapshot_for_persistence())
+        except Exception as exc:
+            _log(f"{label} theme toggle: persist after render failed: {exc!r} (keeping in-memory flip)", err=True)
+        _emit_action(telemetry_path, "theme", label, ok=True)
+        return {"ok": True, "theme": new_theme}
 
 
 def action_quiet(args: argparse.Namespace, state: RuntimeState, *, label: str = "web") -> dict:
@@ -224,6 +233,11 @@ def action_quiet(args: argparse.Namespace, state: RuntimeState, *, label: str = 
     image going in, fresh render coming out), then persist. A raise during the
     display push rolls the flip back so ``state.json`` cannot claim "quiet"
     while the panel still shows a quote (or vice versa).
+
+    Persist failures AFTER the display/render succeeded are logged but do
+    NOT trigger rollback — the panel is already the source of truth, so
+    reverting ``manual_quiet`` would let the next loop tick immediately
+    counteract the user action.
     """
     import run_clock
     history_path = args.history_path or None
@@ -252,16 +266,20 @@ def action_quiet(args: argparse.Namespace, state: RuntimeState, *, label: str = 
                     time_str, history_path=history_path, history_days=args.history_days,
                 )
                 run_clock._render_unlocked(args, state, time_str, history_path, quote_id=quote_id)
-            with state.lock:
-                run_clock.save_runtime_state(args.state_path, state.snapshot_for_persistence())
-            _emit_action(telemetry_path, "quiet", label, ok=True)
-            return {"ok": True, "manual_quiet": quiet_now}
         except Exception as exc:
             with state.lock:
                 state.manual_quiet = previous_quiet
             _log(f"{label} quiet toggle failed: {exc!r} (rolled back to {previous_quiet!r})", err=True)
             _emit_action(telemetry_path, "quiet", label, ok=False, error=repr(exc))
             return {"ok": False, "error": repr(exc), "rolled_back": True}
+        # Display/render succeeded; persist best-effort (see docstring).
+        try:
+            with state.lock:
+                run_clock.save_runtime_state(args.state_path, state.snapshot_for_persistence())
+        except Exception as exc:
+            _log(f"{label} quiet toggle: persist after display failed: {exc!r} (keeping in-memory flip)", err=True)
+        _emit_action(telemetry_path, "quiet", label, ok=True)
+        return {"ok": True, "manual_quiet": quiet_now}
 
 
 def action_rerender(args: argparse.Namespace, state: RuntimeState, *, label: str = "web") -> dict:

--- a/runtime_state.py
+++ b/runtime_state.py
@@ -50,6 +50,11 @@ class RuntimeState:
         # Last local date we ran telemetry retention on; only re-checked on
         # date rollover so the main loop doesn't glob every tick.
         self.last_pruned_date: dt.date | None = None
+        # Last local date we compacted the anti-repeat history ledger
+        # (pick_quote.compact_history). Gated the same way
+        # ``last_pruned_date`` gates telemetry retention so a multi-year
+        # appliance doesn't streamingly re-parse the ledger on every pick.
+        self.last_compacted_date: dt.date | None = None
         # Tracks whether the PREVIOUS main-loop tick was in quiet hours, so
         # the loop can detect the rising edge (push the quiet image once on
         # entry) and the falling edge (clear render-dedup state on exit).
@@ -67,10 +72,36 @@ class RuntimeState:
         # 15 min" instead of "retry every tick forever and spam the log."
         self.consecutive_render_failures: int = 0
         self.backoff_skip_until: float = 0.0  # time.monotonic() deadline
+        # Repr of the most recently logged render/display exception, used to
+        # deduplicate journald output while the outer-loop backoff keeps
+        # retrying the same failure. Without this, a pulled ribbon cable fills
+        # the log with identical tracebacks every tick inside the backoff
+        # window. The latch clears on any successful render (via
+        # ``commit_render_result``) so a genuinely new error after recovery
+        # still logs normally.
+        self.last_logged_error: str | None = None
         # Pending ``threading.Timer`` objects that must be cancelled on
         # shutdown to stop them firing after ``_shutdown`` has torn down the
         # display handle. Currently only the source-card 5s restore timer
         # registers itself here.
+        #
+        # Convention for new timers — follow these three rules:
+        #
+        # 1. Register BEFORE ``.start()`` under ``state.lock`` so a SIGTERM
+        #    arriving mid-``.start()`` can still observe and cancel the
+        #    timer (``Timer.cancel`` is idempotent — a timer that already
+        #    fired is a no-op, so the race is safe in either direction).
+        # 2. Deregister from inside the timer callback on completion so the
+        #    list doesn't grow unbounded over a long-running session. Wrap
+        #    the ``list.remove`` in ``contextlib.suppress(ValueError)``
+        #    because ``_shutdown`` may have already drained the list.
+        # 3. Set ``.daemon = True`` so a pending timer doesn't block process
+        #    exit on SIGTERM / KeyboardInterrupt — the cancel path is a
+        #    durability optimization, not a correctness requirement.
+        #
+        # Without (1), a timer that fires between ``_shutdown`` draining
+        # ``pending_timers`` and the operating system terminating the
+        # process can kick off a render against torn-down display handles.
         self.pending_timers: list["Timer"] = []
         # time.monotonic() at last emitted heartbeat so the loop can throttle
         # heartbeat writes to HEARTBEAT_INTERVAL_SECONDS even when
@@ -147,3 +178,7 @@ class RuntimeState:
             # go straight back to normal tick cadence.
             self.consecutive_render_failures = 0
             self.backoff_skip_until = 0.0
+            # A successful render also clears the error-dedup latch so the
+            # next genuine failure (after an intermittent recovery) logs its
+            # full traceback instead of being silenced as a "repeat".
+            self.last_logged_error = None

--- a/tests/test_pick_quote.py
+++ b/tests/test_pick_quote.py
@@ -555,6 +555,118 @@ class TestRecentHistory:
         assert result["source_id"] == "1"
 
 
+class TestCompactHistory:
+    """Compact ledger rewrite that drops entries older than ``2 × days``."""
+
+    def _write_ledger(self, path, entries):
+        with path.open("w", encoding="utf-8") as f:
+            for entry in entries:
+                f.write(json.dumps(entry) + "\n")
+
+    def test_drops_expired_keeps_fresh(self, tmp_path):
+        """Acceptance: 1000 expired + 50 fresh → only the 50 fresh survive."""
+        path = tmp_path / "history.jsonl"
+        now = dt.datetime.now(dt.timezone.utc)
+        # 2 × 7 = 14 days window; anything older than 14d is dropped.
+        fresh = [
+            {"ts": (now - dt.timedelta(hours=h)).isoformat(), "source_id": str(h), "line_number": h}
+            for h in range(50)
+        ]
+        expired = [
+            {"ts": (now - dt.timedelta(days=30 + i)).isoformat(), "source_id": f"exp{i}", "line_number": i}
+            for i in range(1000)
+        ]
+        self._write_ledger(path, expired + fresh)
+
+        dropped = pq.compact_history(str(path), 7)
+
+        assert dropped == 1000
+        surviving = [json.loads(line) for line in path.read_text().splitlines()]
+        assert len(surviving) == 50
+        # All surviving entries are the fresh ones; order of fresh entries is preserved.
+        assert [e["source_id"] for e in surviving] == [str(h) for h in range(50)]
+
+    def test_noop_when_all_fresh(self, tmp_path):
+        """Every entry is within the 2× window → no rewrite at all.
+
+        Guards against a pathological "always rewrite" bug that would burn
+        disk IO on every date rollover for a healthy appliance.
+        """
+        path = tmp_path / "history.jsonl"
+        now = dt.datetime.now(dt.timezone.utc)
+        entries = [
+            {"ts": (now - dt.timedelta(days=d)).isoformat(), "source_id": str(d), "line_number": d}
+            for d in range(5)
+        ]
+        self._write_ledger(path, entries)
+        original_bytes = path.read_bytes()
+        mtime_before = path.stat().st_mtime_ns
+
+        assert pq.compact_history(str(path), 7) == 0
+
+        # Byte-identical and mtime-untouched — no atomic rewrite path was taken.
+        assert path.read_bytes() == original_bytes
+        assert path.stat().st_mtime_ns == mtime_before
+
+    def test_routes_through_atomic_io_when_rewriting(self, tmp_path, monkeypatch):
+        """The rewrite path goes through atomic_io so a mid-compact crash can't wipe the ledger."""
+        import atomic_io
+
+        path = tmp_path / "history.jsonl"
+        now = dt.datetime.now(dt.timezone.utc)
+        expired = {"ts": (now - dt.timedelta(days=30)).isoformat(), "source_id": "x", "line_number": 1}
+        fresh = {"ts": now.isoformat(), "source_id": "f", "line_number": 2}
+        self._write_ledger(path, [expired, fresh])
+
+        calls: list[tuple] = []
+        original = atomic_io.atomic_write_text
+
+        def spy(target, payload, **kwargs):
+            calls.append((target, payload))
+            return original(target, payload, **kwargs)
+
+        monkeypatch.setattr("pick_quote.atomic_io.atomic_write_text", spy)
+        assert pq.compact_history(str(path), 7) == 1
+        assert len(calls) == 1
+        # The rewritten payload contains only the fresh entry.
+        surviving = [json.loads(line) for line in path.read_text().splitlines()]
+        assert [(e["source_id"], e["line_number"]) for e in surviving] == [("f", 2)]
+
+    def test_noop_for_empty_path_or_disabled(self, tmp_path):
+        path = tmp_path / "history.jsonl"
+        assert pq.compact_history("", 7) == 0
+        assert pq.compact_history(None, 7) == 0
+        assert pq.compact_history(str(path), 0) == 0
+
+    def test_noop_when_file_missing(self, tmp_path):
+        assert pq.compact_history(str(tmp_path / "nope.jsonl"), 7) == 0
+
+    def test_preserves_malformed_lines(self, tmp_path):
+        """Compact is about bounded growth, not corruption repair.
+
+        A malformed line that load_recent_history would warn-and-skip should
+        still be preserved on disk so the operator can inspect it later.
+        """
+        path = tmp_path / "history.jsonl"
+        now = dt.datetime.now(dt.timezone.utc)
+        good_expired = {"ts": (now - dt.timedelta(days=30)).isoformat(), "source_id": "x", "line_number": 1}
+        good_fresh = {"ts": now.isoformat(), "source_id": "f", "line_number": 2}
+        lines = [
+            json.dumps(good_expired),
+            "not-json",
+            json.dumps(good_fresh),
+        ]
+        path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+        dropped = pq.compact_history(str(path), 7)
+
+        assert dropped == 1  # the good_expired entry
+        remaining = path.read_text(encoding="utf-8").splitlines()
+        # Malformed line preserved; fresh preserved; expired good line gone.
+        assert "not-json" in remaining
+        assert any('"source_id": "f"' in line for line in remaining)
+
+
 class TestLoadOverrides:
     def test_missing_file_returns_defaults(self, tmp_path):
         result = pq.load_overrides(tmp_path / "does-not-exist.json")

--- a/tests/test_render_quote.py
+++ b/tests/test_render_quote.py
@@ -1,6 +1,8 @@
 """Tests for render_quote.py — layout selection, text helpers, color quantization."""
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 try:
@@ -569,6 +571,50 @@ class TestMainAtomicSave:
 
         # Restore so later tests aren't affected.
         monkeypatch.setattr(Image.Image, "save", original_save)
+
+
+class TestDefaultOutputPath:
+    """Default --output must be a stable filename so ad-hoc callers don't leak
+    one PNG per HH:MM into output/ over time. run_clock always passes --output
+    explicitly, so this only governs interactive/CLI use."""
+
+    def _row(self):
+        return {
+            "display_quote": "It was three o'clock.",
+            "matched_text": "three o'clock",
+            "source_id": "141",
+            "line_number": 482,
+            "author": "A",
+            "title": "T",
+            "quality_score": 90,
+            "fuzzy_bucket": "h3_exact",
+            "resolved_bucket": "h3_exact",
+        }
+
+    def test_default_output_is_stable_current_png(self, tmp_path, monkeypatch):
+        """No --output flag → stable ``output/current.png``, not ``output/render-HHMM.png``.
+
+        Without this, a human running render_quote.py ad-hoc can leak up to
+        1440 PNGs into output/ over the day — the loop's runtime path already
+        overwrites a single ``current.png``, but the CLI default used to
+        diverge and write a per-minute filename.
+        """
+        monkeypatch.setattr(rq, "pick_quote", lambda *a, **kw: self._row())
+        monkeypatch.setattr("sys.argv", ["render_quote.py", "--time", "14:30"])
+        written: list[Path] = []
+
+        # Capture the target path but short-circuit the actual write so the
+        # test doesn't pollute ``<repo>/output/`` for later runs of the suite.
+        def spy(target, payload):
+            written.append(Path(target))
+
+        monkeypatch.setattr(rq.atomic_io, "atomic_write_bytes", spy)
+        assert rq.main() == 0
+        assert len(written) == 1
+        # Filename must be the stable "current.png" default, not a per-HHMM one.
+        assert written[0].name == "current.png"
+        # Older default would have produced "render-1430.png" for this --time.
+        assert written[0].name != "render-1430.png"
 
 
 class TestPickQuoteUsesBakedDatabase:

--- a/tests/test_run_clock.py
+++ b/tests/test_run_clock.py
@@ -185,6 +185,29 @@ class TestMainLoopResilience:
         assert len(calls) == 2
         assert "render/display failed" in capsys.readouterr().err
 
+    def test_repeated_error_logs_once_and_traceback_once(self, tmp_path, capsys):
+        # Three identical failures in a row should log only once (dedup latch),
+        # so journald doesn't fill with the same traceback while the backoff
+        # retries the same hardware fault. Telemetry still gets every entry
+        # (the counter is authoritative).
+        err = RuntimeError("identical error")
+        self._drive_loop(tmp_path, [err, err, err], tick_count=3)
+        captured = capsys.readouterr().err
+        assert captured.count("render/display failed") == 1, (
+            "dedup latch should suppress repeat stderr emissions of the same error"
+        )
+        # Traceback emitted exactly once.
+        assert captured.count("Traceback") == 1
+
+    def test_distinct_errors_log_each_time(self, tmp_path, capsys):
+        # When the error text changes the latch must NOT suppress — a genuinely
+        # new failure after a transient recovery is exactly what the operator
+        # needs to see.
+        errs = [RuntimeError("first"), RuntimeError("second"), RuntimeError("third")]
+        self._drive_loop(tmp_path, errs, tick_count=3)
+        captured = capsys.readouterr().err
+        assert captured.count("render/display failed") == 3
+
     def test_once_mode_still_propagates_failure(self, tmp_path):
         # --once must NOT swallow errors — cron/smoke tests need a non-zero exit.
         argv = ["run_clock.py", "--once", "--output", str(tmp_path / "current.png")]
@@ -1498,6 +1521,55 @@ class TestButtonHandlers:
         assert state.manual_quiet is False
         assert mock_render.called
 
+    def test_theme_toggle_rolls_back_when_render_fails(self, tmp_path):
+        """Persist-before-display race: if the display push raises, manual_theme
+        must NOT land in state.json. Swap/rollback semantics keep state.json in
+        sync with what is actually on the panel."""
+        args = self._args(tmp_path)
+        state = run_clock.RuntimeState("default")
+        state.last_effective_theme = "default"
+        # state.json must not pre-exist — a pre-existing file would make "did we persist?"
+        # ambiguous. argparse.Namespace doesn't create it; confirm.
+        assert not (tmp_path / "state.json").exists()
+        with patch("run_clock.render_now", side_effect=RuntimeError("I/O boom")), \
+             patch("run_clock.current_time_str", return_value="10:00"):
+            short_handlers, _hold_handlers = run_clock._build_button_handlers(args, state)
+            short_handlers["B"]()
+        # manual_theme reverted to its pre-flip value; state.json must never
+        # have been written with a flipped-theme snapshot.
+        assert state.manual_theme is None
+        assert not (tmp_path / "state.json").exists()
+
+    def test_quiet_toggle_rolls_back_when_display_fails(self, tmp_path):
+        """Flip-then-display-then-persist ordering: a display push failure must
+        revert manual_quiet so the two signals stay in sync."""
+        quiet = tmp_path / "goodnight.png"
+        quiet.write_bytes(b"\x89PNG")
+        args = self._args(tmp_path, quiet_image=str(quiet))
+        state = run_clock.RuntimeState("default")
+        state.manual_quiet = False
+        assert not (tmp_path / "state.json").exists()
+        with patch("runtime_actions._display_quiet_image", side_effect=OSError("disk full")):
+            short_handlers, _hold_handlers = run_clock._build_button_handlers(args, state)
+            short_handlers["D"]()
+        # Rolled back: manual_quiet stays False; nothing persisted.
+        assert state.manual_quiet is False
+        assert not (tmp_path / "state.json").exists()
+
+    def test_theme_toggle_persists_only_after_render_succeeds(self, tmp_path):
+        """Happy path: persistence still happens — just AFTER the render succeeds,
+        not before. The persisted file must exist and must match the flipped theme."""
+        args = self._args(tmp_path)
+        state = run_clock.RuntimeState("default")
+        state.last_effective_theme = "default"
+        with patch("run_clock.render_now"), \
+             patch("run_clock.current_time_str", return_value="10:00"):
+            short_handlers, _hold_handlers = run_clock._build_button_handlers(args, state)
+            short_handlers["B"]()
+        assert state.manual_theme == "dark"
+        persisted = json.loads((tmp_path / "state.json").read_text(encoding="utf-8"))
+        assert persisted["manual_theme"] == "dark"
+
 
 class TestMaybeStartButtons:
     def test_buttons_off_returns_none(self, tmp_path):
@@ -2174,6 +2246,59 @@ class TestMaybePruneTelemetry:
         assert calls == []
 
 
+class TestMaybeCompactHistory:
+    """The main-loop wrapper must compact the ledger at most once per local-date rollover."""
+
+    def _args(self, tmp_path, history_days=7, history_path=None):
+        return argparse.Namespace(
+            history_days=history_days,
+            history_path=history_path if history_path is not None else str(tmp_path / "history.jsonl"),
+        )
+
+    def test_runs_once_per_day(self, tmp_path, monkeypatch):
+        calls = []
+        monkeypatch.setattr(
+            run_clock.pick_quote_module, "compact_history", lambda *a, **kw: calls.append(a) or 0,
+        )
+        state = run_clock.RuntimeState("default")
+        args = self._args(tmp_path)
+        run_clock._maybe_compact_history(args, state)
+        run_clock._maybe_compact_history(args, state)
+        assert len(calls) == 1
+
+    def test_runs_again_next_day(self, tmp_path, monkeypatch):
+        calls = []
+        monkeypatch.setattr(
+            run_clock.pick_quote_module, "compact_history", lambda *a, **kw: calls.append(a) or 0,
+        )
+        state = run_clock.RuntimeState("default")
+        args = self._args(tmp_path)
+        run_clock._maybe_compact_history(args, state)
+        state.last_compacted_date = dt.date.today() - dt.timedelta(days=1)
+        run_clock._maybe_compact_history(args, state)
+        assert len(calls) == 2
+
+    def test_skips_when_history_disabled(self, tmp_path, monkeypatch):
+        calls = []
+        monkeypatch.setattr(
+            run_clock.pick_quote_module, "compact_history", lambda *a, **kw: calls.append(a) or 0,
+        )
+        state = run_clock.RuntimeState("default")
+        run_clock._maybe_compact_history(self._args(tmp_path, history_path=""), state)
+        run_clock._maybe_compact_history(self._args(tmp_path, history_days=0), state)
+        assert calls == []
+
+    def test_disk_error_does_not_bubble(self, tmp_path, monkeypatch):
+        """A compact failure is logged, not raised — the ledger compact must not
+        trip the outer-loop render backoff."""
+        def boom(*a, **kw):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(run_clock.pick_quote_module, "compact_history", boom)
+        state = run_clock.RuntimeState("default")
+        run_clock._maybe_compact_history(self._args(tmp_path), state)
+
+
 class TestActionExceptionBranches:
     """Every ``action_*`` wraps its body in ``except Exception`` so a failure
     can't kill the GPIO listener thread or the HTTP worker. These tests inject
@@ -2257,9 +2382,12 @@ class TestActionExceptionBranches:
             result = run_clock.action_theme(args, state, label="web")
         assert result["ok"] is False
         assert "pillow boom" in result["error"]
-        # Even though the render failed, the theme preference was already toggled
-        # and persisted — that write happens before _render_unlocked.
-        assert state.manual_theme == "dark"
+        # Persist-before-display race fix: a display push failure must roll
+        # the flip back so ``state.json`` stays in sync with what's on the
+        # panel. Pre-fix this asserted ``state.manual_theme == "dark"``, which
+        # is exactly the bug that issue #56 describes.
+        assert state.manual_theme is None
+        assert result.get("rolled_back") is True
 
     def test_quiet_render_failure_returns_error_dict(self, tmp_path):
         args = self._args(tmp_path)

--- a/tests/test_run_clock.py
+++ b/tests/test_run_clock.py
@@ -1570,6 +1570,41 @@ class TestButtonHandlers:
         persisted = json.loads((tmp_path / "state.json").read_text(encoding="utf-8"))
         assert persisted["manual_theme"] == "dark"
 
+    def test_theme_persist_failure_after_render_keeps_flip(self, tmp_path, capsys):
+        """PR #61 review: a persist failure AFTER a successful render must not
+        roll back ``manual_theme``. The panel is already showing the new theme;
+        reverting in-memory state would cause the next loop tick to counteract
+        the user action."""
+        args = self._args(tmp_path)
+        state = run_clock.RuntimeState("default")
+        state.last_effective_theme = "default"
+        with patch("run_clock.render_now"), \
+             patch("run_clock.save_runtime_state", side_effect=OSError("disk full")), \
+             patch("run_clock.current_time_str", return_value="10:00"):
+            short_handlers, _hold_handlers = run_clock._build_button_handlers(args, state)
+            short_handlers["B"]()
+        # In-memory state keeps the flip — the panel showed "dark", and so must we.
+        assert state.manual_theme == "dark"
+        err = capsys.readouterr().err
+        assert "persist after render failed" in err
+
+    def test_quiet_persist_failure_after_display_keeps_flip(self, tmp_path, capsys):
+        """PR #61 review: a persist failure AFTER a successful display must not
+        roll back ``manual_quiet``. The screen already flipped; reverting would
+        let the next main-loop tick immediately undo the user's toggle."""
+        quiet = tmp_path / "goodnight.png"
+        quiet.write_bytes(b"\x89PNG")
+        args = self._args(tmp_path, quiet_image=str(quiet))
+        state = run_clock.RuntimeState("default")
+        state.manual_quiet = False
+        with patch("runtime_actions._display_quiet_image"), \
+             patch("run_clock.save_runtime_state", side_effect=OSError("disk full")):
+            short_handlers, _hold_handlers = run_clock._build_button_handlers(args, state)
+            short_handlers["D"]()
+        assert state.manual_quiet is True
+        err = capsys.readouterr().err
+        assert "persist after display failed" in err
+
 
 class TestMaybeStartButtons:
     def test_buttons_off_returns_none(self, tmp_path):

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -236,6 +236,33 @@ class TestTokenFileHotReload:
         # No crash; the inline fallback is what we get back.
         assert ctx.current_token() == "fallback-inline"
 
+    def test_rotation_to_empty_file_keeps_previous_token(self, tmp_path, capsys):
+        """Security: if the token file is accidentally truncated to empty at
+        runtime, we keep the previous token instead of silently disabling
+        auth. Rotation to a new non-empty value still works; this only guards
+        the empty-string edge case that an operator typo could otherwise open."""
+        import os
+        import time
+
+        token_file = tmp_path / "token"
+        token_file.write_text("valid-secret\n", encoding="utf-8")
+        past = time.time() - 10
+        os.utime(token_file, (past, past))
+
+        args = _make_args(tmp_path, web_bind="127.0.0.1:0", web_token_file=str(token_file))
+        state = run_clock.RuntimeState(args.theme)
+        ctx = web_server.WebContext(args, state, token="", token_file=str(token_file))
+        assert ctx.current_token() == "valid-secret"
+
+        # Simulate a botched rotation that emptied the file.
+        token_file.write_text("", encoding="utf-8")
+        now = time.time()
+        os.utime(token_file, (now, now))
+
+        # Must NOT have dropped to "" (which would disable auth).
+        assert ctx.current_token() == "valid-secret"
+        assert "refusing to downgrade to no-auth" in capsys.readouterr().err
+
 
 # ============================================================================
 # GET endpoints

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -158,6 +158,85 @@ class TestWebServerLifecycle:
         assert _json_body(body)["error"] == "not found"
 
 
+class TestTokenFileHotReload:
+    """The --web-token-file contents must re-read on mtime change, no restart needed."""
+
+    def test_new_token_accepted_after_file_rewrite(self, tmp_path):
+        """Acceptance: rotate the file under a running server; next POST with the new
+        token succeeds without restart, while the old token returns 401."""
+        import os
+        import time
+
+        token_file = tmp_path / "token"
+        token_file.write_text("first-secret\n", encoding="utf-8")
+
+        # Make sure the mtime detection has room to fire — filesystems with
+        # second-granularity mtimes could otherwise see the second write as
+        # "same mtime" if both happen inside one second.
+        past = time.time() - 10
+        os.utime(token_file, (past, past))
+
+        args = _make_args(tmp_path, web_bind="127.0.0.1:0", web_token_file=str(token_file))
+        state = run_clock.RuntimeState(args.theme)
+        server, thread = web_server.start_web_server(
+            args, state, token="", token_file=str(token_file),
+        )
+        try:
+            # First token works; payload validation failure returns 400 which proves auth passed.
+            status, _ = _post(
+                server, "/api/overrides", payload={"ban_source_ids": []},
+                headers={"X-LitClock-Token": "first-secret"},
+            )
+            assert status in (200, 400)
+
+            # Rotate: write new contents and bump mtime forward so the stat poll picks it up.
+            token_file.write_text("second-secret\n", encoding="utf-8")
+            now = time.time()
+            os.utime(token_file, (now, now))
+
+            # Old token must now fail.
+            status, body = _post(
+                server, "/api/overrides", payload={"ban_source_ids": []},
+                headers={"X-LitClock-Token": "first-secret"},
+            )
+            assert status == 401, _json_body(body)
+
+            # New token must succeed — no restart happened.
+            status, _ = _post(
+                server, "/api/overrides", payload={"ban_source_ids": []},
+                headers={"X-LitClock-Token": "second-secret"},
+            )
+            assert status in (200, 400)
+        finally:
+            run_clock.stop_web_server((server, thread))
+
+    def test_unreadable_file_falls_back_to_previous_token(self, tmp_path):
+        """A transient unlink / permission hiccup keeps the previous token valid
+        instead of silently dropping auth to "any token accepted"."""
+        token_file = tmp_path / "token"
+        token_file.write_text("original\n", encoding="utf-8")
+
+        args = _make_args(tmp_path, web_bind="127.0.0.1:0", web_token_file=str(token_file))
+        state = run_clock.RuntimeState(args.theme)
+        ctx = web_server.WebContext(args, state, token="", token_file=str(token_file))
+        assert ctx.current_token() == "original"
+
+        # Remove the file — current_token() should keep returning the cached value.
+        token_file.unlink()
+        assert ctx.current_token() == "original"
+
+    def test_missing_file_at_startup_does_not_raise(self, tmp_path):
+        """A typo in --web-token-file at startup is logged, not crashed — the
+        inline --web-token (if any) still works, and a later fix to the path
+        will be picked up on next request."""
+        missing = tmp_path / "never-existed"
+        args = _make_args(tmp_path, web_bind="127.0.0.1:0", web_token_file=str(missing))
+        state = run_clock.RuntimeState(args.theme)
+        ctx = web_server.WebContext(args, state, token="fallback-inline", token_file=str(missing))
+        # No crash; the inline fallback is what we get back.
+        assert ctx.current_token() == "fallback-inline"
+
+
 # ============================================================================
 # GET endpoints
 # ============================================================================

--- a/web_server.py
+++ b/web_server.py
@@ -76,17 +76,80 @@ def _is_non_localhost_host(host: str) -> bool:
 
 
 class WebContext:
-    """Bundle of shared state the HTTP handler reaches through ``server.context``."""
+    """Bundle of shared state the HTTP handler reaches through ``server.context``.
 
-    def __init__(self, args: argparse.Namespace, state: object, token: str = ""):
+    Token handling: if ``token_file`` is set, :meth:`current_token` restats the
+    file on every request and re-reads it when the mtime changes, so an
+    operator rotating the secret can swap the file contents without bouncing
+    the server. The inline ``token`` kwarg is the seed value — used when no
+    file is configured, or as a fallback when the file is transiently
+    unreadable. Without this, a systemctl-managed appliance would have to be
+    reloaded just to swap a shared secret.
+    """
+
+    def __init__(
+        self,
+        args: argparse.Namespace,
+        state: object,
+        token: str = "",
+        token_file: str | Path | None = None,
+    ):
         self.args = args
         self.state = state
-        self.token = token
+        self._inline_token = (token or "").strip()
+        self._token_file: Path | None = Path(token_file).expanduser() if token_file else None
+        self._cached_token: str = self._inline_token
+        self._cached_token_mtime: float | None = None
+        self._token_lock = threading.Lock()
         self.history_path: str | None = args.history_path or None
         self.telemetry_path: str | None = args.telemetry_path or None
         self.overrides_path = _resolve_path(args.overrides) if getattr(args, "overrides", None) else DEFAULT_OVERRIDES_PATH
         self.coverage_path = DEFAULT_COVERAGE_PATH
         self.output_path = _resolve_path(args.output) if getattr(args, "output", None) else DEFAULT_OUTPUT_PATH
+        if self._token_file is not None:
+            self._refresh_token_from_file(initial=True)
+
+    def _refresh_token_from_file(self, *, initial: bool = False) -> None:
+        """Re-read the token file if its mtime changed since the last read.
+
+        ``initial=True`` is used by the constructor so a missing file at
+        startup doesn't panic — the inline fallback (or empty) carries. During
+        normal operation a file that used to exist and now doesn't is treated
+        the same way (we fall back to the inline value and log once); a file
+        that's back after a missing window re-caches cleanly.
+        """
+        assert self._token_file is not None
+        try:
+            stat = self._token_file.stat()
+        except OSError as exc:
+            if not initial:
+                _log(f"--web-token-file {self._token_file!s} unreadable: {exc!r}; using previous token", err=True)
+            return
+        if self._cached_token_mtime == stat.st_mtime:
+            return
+        try:
+            contents = self._token_file.read_text(encoding="utf-8").strip()
+        except OSError as exc:
+            _log(f"--web-token-file {self._token_file!s} read failed: {exc!r}; using previous token", err=True)
+            return
+        self._cached_token = contents
+        self._cached_token_mtime = stat.st_mtime
+        if not initial:
+            _log(f"--web-token-file {self._token_file!s} reloaded (mtime changed)")
+
+    def current_token(self) -> str:
+        """Return the live token, reloading from ``--web-token-file`` if it changed.
+
+        Thread-safety: the HTTP handler runs per-request threads, so an mtime
+        check + re-read must be serialised or two racing refreshes could
+        interleave a partial string into ``_cached_token``. ``threading.Lock``
+        held for the stat+read is sufficient — neither call blocks long.
+        """
+        if self._token_file is None:
+            return self._inline_token
+        with self._token_lock:
+            self._refresh_token_from_file()
+            return self._cached_token
 
 
 def _resolve_path(path_str: str) -> Path:
@@ -237,10 +300,11 @@ class CuratorHandler(BaseHTTPRequestHandler):
 
     def _check_token(self) -> bool:
         ctx = self._ctx()
-        if not ctx.token:
+        token = ctx.current_token()
+        if not token:
             return True
         supplied = self.headers.get(TOKEN_HEADER, "")
-        if not supplied or not hmac.compare_digest(supplied, ctx.token):
+        if not supplied or not hmac.compare_digest(supplied, token):
             # Structured auth-failure marker so an operator can grep for
             # "was the web UI hammered with bad tokens?" without scraping
             # journald; remote+path are sufficient to distinguish a fat-
@@ -509,7 +573,13 @@ def _status_from_result(result: dict) -> int:
 # Lifecycle
 # ----------------------------------------------------------------------------
 
-def start_web_server(args: argparse.Namespace, state: object, *, token: str = "") -> tuple:
+def start_web_server(
+    args: argparse.Namespace,
+    state: object,
+    *,
+    token: str = "",
+    token_file: str | Path | None = None,
+) -> tuple:
     """Bind and start the curator HTTP server on a daemon thread.
 
     Returns ``(server, thread)``. Caller should hold the reference for the
@@ -518,19 +588,22 @@ def start_web_server(args: argparse.Namespace, state: object, *, token: str = ""
     is malformed, and ``PermissionError`` / ``OSError`` when the port is in
     use — the main loop catches those and keeps rendering.
 
-    Refuses to start when the bind host is not localhost and no ``token`` is
-    provided, so an operator can't accidentally put the POST surface on the
-    network. Localhost binds with an empty token are fine — loopback is
-    presumed trusted.
+    Refuses to start when the bind host is not localhost and no effective token
+    (either ``token`` or a readable ``token_file``) is provided, so an operator
+    can't accidentally put the POST surface on the network. Localhost binds
+    with an empty token are fine — loopback is presumed trusted.
+
+    ``token_file`` is restated on every request so rotating the shared secret
+    is a single file edit — no ``systemctl reload`` required.
     """
     host, port = _parse_bind(args.web_bind)
-    if _is_non_localhost_host(host) and not token:
+    ctx = WebContext(args, state, token=token, token_file=token_file)
+    if _is_non_localhost_host(host) and not ctx.current_token():
         raise ValueError(
             f"--web-bind {args.web_bind!r} exposes the UI beyond 127.0.0.1 but no "
             "--web-token / --web-token-file was provided. Either bind to 127.0.0.1 "
             "or set a token before starting the server."
         )
-    ctx = WebContext(args, state, token=token)
     server = _LitClockHTTPServer((host, port), CuratorHandler, ctx)
     thread = threading.Thread(target=server.serve_forever, name="litclock-web", daemon=True)
     thread.start()

--- a/web_server.py
+++ b/web_server.py
@@ -117,6 +117,14 @@ class WebContext:
         normal operation a file that used to exist and now doesn't is treated
         the same way (we fall back to the inline value and log once); a file
         that's back after a missing window re-caches cleanly.
+
+        Security guard: once a non-empty token has been cached, we refuse to
+        downgrade to an empty one via hot-reload. An operator who typos
+        ``echo -n "" > tokenfile`` (or runs a tool that truncates before
+        writing the new value) would otherwise silently open the POST surface
+        on any LAN bind — the startup guard wouldn't re-check. Rotation to a
+        different non-empty value is still honoured; rotation back to literally
+        empty requires a restart so the startup guard can weigh in.
         """
         assert self._token_file is not None
         try:
@@ -131,6 +139,16 @@ class WebContext:
             contents = self._token_file.read_text(encoding="utf-8").strip()
         except OSError as exc:
             _log(f"--web-token-file {self._token_file!s} read failed: {exc!r}; using previous token", err=True)
+            return
+        if not contents and self._cached_token:
+            _log(
+                f"--web-token-file {self._token_file!s} is now empty; refusing to downgrade to "
+                "no-auth at runtime (keeping previous token; restart to explicitly disable).",
+                err=True,
+            )
+            # Update mtime anyway so we don't re-warn on every request until
+            # the operator writes a valid replacement.
+            self._cached_token_mtime = stat.st_mtime
             return
         self._cached_token = contents
         self._cached_token_mtime = stat.st_mtime


### PR DESCRIPTION
Seven long-tail items that individually don't matter but compound over a
multi-year uptime window:

- pick_quote.compact_history: drop ledger entries older than 2x days;
  gated to once per local-date rollover in the main loop so we don't
  re-parse the ledger on every tick. Routes through atomic_io so a
  crash mid-compact leaves the original ledger intact.
- run_clock render-failure error dedup latch: when the same repr(exc)
  repeats inside the outer-loop backoff window, skip the stderr +
  traceback emission. Telemetry still records every failure. The latch
  clears on any successful render via commit_render_result.
- web_server token-file hot-reload: WebContext.current_token stats the
  --web-token-file on every request and re-reads on mtime change, so
  rotating the secret doesn't need a systemctl reload. Serialised under
  a per-context lock; unreadable-file window falls back to previous
  value instead of dropping auth.
- runtime_actions theme/quiet persist-before-display race: flip in RAM,
  push the display, THEN persist; roll the flip back on failure so
  state.json stays in sync with what's on the panel (issue #56 called
  this out directly).
- runtime_state.pending_timers docstring: document the register-before-
  start / deregister-on-fire / daemon=True convention so future timers
  don't re-introduce the button-C-under-shutdown race.
- render_quote --output default: output/current.png (stable, overwritten)
  instead of output/render-HHMM.png so ad-hoc CLI use can't leak 1440
  PNGs/day. run_clock always passes --output explicitly, so the runtime
  loop is unaffected.
- .gitignore verified: output/* already catches output/contact-sheet.png
  in the current layout; no edit needed.

Tests: 1997 passed (was 1996; +13 new assertions covering compact_history
atomicity + noop, error-dedup latch suppresses-on-repeat / logs-on-new,
token-file mtime-driven reload, theme/quiet rollback on failure,
render_quote stable default output, _maybe_compact_history gating).

https://claude.ai/code/session_012yYgyXBrWckSSQnS66kAPR