### PR TITLE
Add importable GitHub ruleset for main branch protection

### DIFF
--- a/.github/rulesets/main-branch.json
+++ b/.github/rulesets/main-branch.json
@@ -1,0 +1,28 @@
+{
+  "name": "Protect main",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["~DEFAULT_BRANCH"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {"type": "deletion"},
+    {"type": "non_fast_forward"},
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": false,
+        "do_not_enforce_on_create": false,
+        "required_status_checks": [
+          {"context": "lint"},
+          {"context": "test (3.11)"},
+          {"context": "test (3.12)"}
+        ]
+      }
+    }
+  ],
+  "bypass_actors": []
+}


### PR DESCRIPTION
Blocks force-push and deletion, requires the existing CI checks
(lint, test (3.11), test (3.12)) to pass before merges to main.
Import via Settings -> Rules -> Rulesets -> New ruleset -> Import a ruleset.