### PR TITLE
Add LICENSE (MIT) and SECURITY.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,21 @@
+# Code of Conduct
+
+This project adopts the **Contributor Covenant, version 2.1** as its code of
+conduct. The full text is maintained upstream:
+
+- https://www.contributor-covenant.org/version/2/1/code_of_conduct/
+
+Short version: be respectful, assume good faith, and help keep this a
+welcoming project to contribute to.
+
+## Reporting
+
+To report a concern, open a private report via GitHub:
+
+- https://github.com/gkoch02/litclock/security/advisories/new
+
+(Using the security advisory channel keeps reports out of public issues; the
+same inbox handles both conduct and security reports for this small project.)
+
+Reports are handled by the project maintainer. Expect an acknowledgement
+within 7 days.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,184 @@
+# Contributing to LitClock
+
+Thanks for considering a contribution. LitClock is a small hobby project, so
+process is deliberately light — the goal is to make it easy for someone who
+just wants to fix a typo, improve a quote, or add a pipeline stage.
+
+This doc covers the dev environment, how the pipeline fits together, and what
+to do when contributing each kind of change. The deep architecture reference
+lives in [`CLAUDE.md`](CLAUDE.md) — if you're modifying the runtime or
+pipeline, skim that first.
+
+By participating you agree to follow the [Code of Conduct](CODE_OF_CONDUCT.md).
+Security issues go through the reporting process in [`SECURITY.md`](SECURITY.md),
+not public issues.
+
+## Dev setup
+
+Python 3.11 or 3.12. The runtime is pure stdlib + Pillow; the Pi deployment
+additionally needs `inky` and `gpiozero`.
+
+```bash
+git clone https://github.com/gkoch02/litclock.git
+cd litclock
+python3 -m venv .venv && source .venv/bin/activate
+pip install -e ".[dev]"
+```
+
+Verify:
+
+```bash
+pytest
+ruff check .
+python3 run_clock.py --once --buttons-off     # one-shot render to output/current.png
+```
+
+`pip install -e ".[dev]"` is the single source of truth for dev deps; CI
+installs the same way. Don't hardcode `pytest pytest-cov ruff Pillow` in new
+workflow files — they'll drift.
+
+## Before you open a PR
+
+- **Run the tests.** `pytest` should pass locally. The suite is fast (seconds,
+  not minutes).
+- **Run the linter.** `ruff check .` — rules `E`, `W`, `F`, `I`; line length
+  130; `E501` ignored. `ruff check --fix .` handles import ordering.
+- **Don't commit generated artifacts you didn't mean to.** `output/` is
+  gitignored except for `.gitkeep`. `data/gutenberg/` is gitignored entirely.
+- **Keep commits focused.** One logical change per commit makes bisect useful
+  later.
+
+## What kind of change are you making?
+
+### Runtime code (`run_clock.py`, `runtime_*.py`, `render_quote.py`, `pick_quote.py`, `web_server.py`, …)
+
+The runtime is a thin orchestrator (`run_clock.py`) that delegates to seven
+`runtime_*` siblings. The module boundary, lock discipline, and thread
+ownership rules are documented in the "Runtime Module Architecture" section of
+`CLAUDE.md` — please read that section before restructuring any of those
+modules. Highlights:
+
+- Three locks: `render_lock` (coarse, serialises panel pushes),
+  `state.lock` (fine, guards `RuntimeState` fields), and `ledger_lock` (file
+  I/O for `history.jsonl`). Nesting is allowed **only** in the documented
+  direction.
+- Button and web handlers route through the same `action_*` functions via
+  `_button_render_gate`. Don't add a parallel "web render path" — convergence
+  on one path is the point of the refactor.
+- Any new file the next tick reads needs to go through
+  `atomic_io.atomic_write_*`. Don't reintroduce naive `open("w")`.
+
+### Corpus / quote content
+
+Two different files depending on the kind of change:
+
+| You want to… | Edit this | Effect |
+|---|---|---|
+| Fix the wording of a specific quote (bad excerpt boundary, typo, wrong author) | `assets/content_overrides.json` | Re-applied every time the pipeline re-bakes; durable |
+| Ban a source, boost a source, pin a source to a bucket | `assets/selection_overrides.json` | Runtime, also editable via the curator UI |
+
+**Never edit `assets/quote_database.jsonl` or `assets/candidates-attributed.jsonl`
+by hand.** They're derived artifacts; your edit will be clobbered on the next
+pipeline re-run. If you find yourself wanting to override more than a handful
+of rows for the same reason, that's a signal that a pipeline stage has a bug —
+push the fix into the miner / cleaner / quality filter rather than
+accumulating per-row patches.
+
+After editing `content_overrides.json`, re-run the tail of the pipeline:
+
+```bash
+python3 apply_content_overrides.py assets/candidates-attributed.jsonl
+python3 bake_quote_database.py assets/candidates-attributed.jsonl
+```
+
+Commit the updated `assets/quote_database.jsonl` alongside your override
+change — a raw-corpus commit with no matching bake means your fix is
+invisible to the appliance.
+
+### Adding quotes from a new Gutenberg book
+
+There's a one-shot driver:
+
+```bash
+# Add the ID to gutenberg_dawn_expansion_ids.txt, then:
+bash run_dawn_expansion.sh
+```
+
+That drives the full pipeline and commits the updated
+`candidates-attributed.jsonl`, `quote_database.jsonl`, and coverage snapshot
+together. Safe to re-run (downloads cache, merge dedupes).
+
+### Pipeline stages
+
+If you're touching a pipeline script, the flow (also in `CLAUDE.md`) is:
+
+```
+gutenberg_time_miner → merge_candidates → clean_display_quotes →
+  quality_filter → enrich_metadata → apply_content_overrides →
+  bake_quote_database
+```
+
+- `buckets.py` is the single source of truth for the fuzzy-bucket rounding
+  rule. Don't reintroduce a second copy of the state table in a new script.
+- JSONL rows accumulate fields as they flow through — preserve the existing
+  schema, add new fields rather than renaming.
+- The baked DB's scoring components are cross-checked between
+  `bake_quote_database.py` and `pick_quote.py` via `BAKED_SCORE_COMPONENTS`.
+  Bump `BAKED_SCORE_SCHEMA_VERSION` if you change order, length, or
+  semantics.
+
+### Rendering / typography
+
+`render_quote.py` is designed around the Inky Impression 7.3 Spectra 6 (800×480,
+6-colour palette). Any colour change goes through `snap_image_to_palette`.
+The `THEMES` dict has two presets (`default`, `dark`); add a third by also
+wiring it into `display_inky.THEME_SATURATION` and the `--theme` argparse
+choices in `run_clock.py` and `render_quote.py`.
+
+Test visually on both themes with the contact sheet:
+
+```bash
+python3 contact_sheet.py --theme default --output output/contact-default.png
+python3 contact_sheet.py --theme dark    --output output/contact-dark.png
+```
+
+## Testing
+
+- One `tests/test_<script>.py` per main script, class-based. Use the
+  `make_row` / `sample_row` / `tmp_jsonl` fixtures from `tests/conftest.py`
+  rather than building rows inline.
+- The autouse `_isolate_home` fixture points `$HOME` at a per-test tmp dir,
+  so tests can safely use default `--state-path` / `--history-path` /
+  `--telemetry-path` / `--pidfile` values.
+- Hardware-touching modules (`display_inky.py`, `inky_buttons.py`) are tested
+  with the hardware call mocked; new hardware code should follow the same
+  pattern (local import inside a function, Pillow/GPIO stubbed in the test).
+
+## Commit messages and PRs
+
+- Commit subjects: present tense, under ~70 characters
+  ("Add quiet-hours manual toggle", not "Added …"). Body explains the *why*
+  if it's not obvious from the diff.
+- PRs: short summary of what changed and any intentional trade-offs. Link
+  relevant issues. If the change is corpus-only, the PR body is fine at one
+  line.
+- CI runs on every push to `main` and every PR (lint + pytest matrix on
+  Python 3.11/3.12). Green CI is a prerequisite for merge.
+
+## Reporting bugs
+
+Open a GitHub issue with:
+
+- what you expected to happen,
+- what actually happened,
+- reproduction steps (command-line flags, time of day if relevant — some
+  bugs only surface in specific buckets),
+- relevant log lines from `journalctl -u litclock` or the terminal.
+
+For the appliance specifically, `python3 litclock_health.py --hours 24`
+output is usually the fastest way to share state.
+
+## License
+
+By contributing, you agree that your contributions are licensed under the
+[MIT License](LICENSE) that covers the rest of the project.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,35 @@
+MIT License
+
+Copyright (c) 2026 Greg Koch
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
+Third-party content:
+
+- The corpus in `assets/candidates-attributed.jsonl` and
+  `assets/quote_database.jsonl` is excerpted from works sourced via Project
+  Gutenberg (https://www.gutenberg.org/). Individual works are in the public
+  domain in the United States; other jurisdictions may vary. The compilation
+  and scoring of those excerpts is covered by the MIT license above.
+
+- Playfair Display fonts bundled under `fonts/` are distributed under the SIL
+  Open Font License, Version 1.1. See the font files' accompanying OFL.txt
+  (upstream: https://github.com/clauseggers/Playfair-Display).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,94 @@
+# Security Policy
+
+LitClock is a small, single-operator home appliance. It is not a hosted
+service, has no accounts or user data, and the canonical deployment is a
+Raspberry Pi pushing an eInk frame once per fuzzy-minute bucket. The surface
+area below is what exists; anything outside it is not in scope.
+
+## Supported versions
+
+Only the current `main` branch is supported. Security fixes land on `main`;
+there are no long-lived release branches.
+
+## Reporting a vulnerability
+
+**Please do not open a public GitHub issue for security reports.**
+
+Use GitHub's private vulnerability reporting to file a report against
+`gkoch02/litclock`:
+
+- https://github.com/gkoch02/litclock/security/advisories/new
+
+Include:
+
+- a short description of the issue and its impact,
+- the affected file / endpoint / flag,
+- reproduction steps or a proof of concept,
+- any suggested remediation.
+
+You can expect an acknowledgement within **7 days** and a triage decision
+within **30 days**. Because this is a volunteer-maintained hobby project,
+fixes may take longer than that; the goal is to be honest about status, not
+to commit to an SLA I can't meet.
+
+Coordinated disclosure is appreciated — please give me a reasonable window to
+ship a fix before publishing details.
+
+## What's in scope
+
+These are the surfaces where a security bug would matter:
+
+- **Curator web UI (`web_server.py`, `web/`).** Off by default. Loopback binds
+  (`127.0.0.1:*`, `localhost:*`, `::1:*`) run without authentication on the
+  assumption that the OS-level trust boundary is sufficient; non-loopback
+  binds **require** `--web-token` or `--web-token-file`, and `start_web_server`
+  refuses to bind `0.0.0.0` without one. Token checks use
+  `hmac.compare_digest` against the `X-LitClock-Token` header only. Report
+  anything that lets an unauthenticated caller mutate state, read tokens from
+  logs, or bypass the bind check.
+- **Mutating endpoints (`POST /api/overrides`, `POST /api/action/*`).** These
+  rewrite `assets/selection_overrides.json` and trigger renders / theme
+  changes / shutdown. Report auth bypass, path traversal, injection, or
+  writes outside the intended paths.
+- **Button-D long-press shutdown.** Default command is
+  `sudo -n shutdown -h now` and requires passwordless sudo. Report anything
+  that lets a non-operator trigger shutdown, or any way the
+  `--shutdown-command` override could be abused to run arbitrary commands
+  from an untrusted input.
+- **Runtime file writes** (`state.json`, `history.jsonl`, telemetry sidecar,
+  rendered PNGs, ledger/corpus rewrites via `atomic_io`). Report path
+  escape, TOCTOU, or corruption that survives the atomic-write primitive.
+- **Corpus pipeline (`gutenberg_time_miner.py` → `bake_quote_database.py`).**
+  Fetches from `www.gutenberg.org` and reads local text. Report anything
+  that lets a malicious text file cause code execution, path traversal, or
+  resource exhaustion in a pipeline operator's environment.
+
+## What's out of scope
+
+- Denial-of-service against the render loop by burning CPU on a developer
+  machine. The appliance is single-user; there is no rate limit.
+- Vulnerabilities in upstream dependencies (Pillow, Pimoroni `inky`,
+  `gpiozero`). Please report those to their upstream projects. Mitigations
+  we can apply (pinning, sandboxing, workarounds) are in scope.
+- Vulnerabilities in Project Gutenberg itself or in cached texts under
+  `data/gutenberg/`. Out of scope as a LitClock issue; in scope only if our
+  handling of untrusted input is what creates the risk.
+- Issues that require physical access to the Pi (GPIO, SD card, serial
+  console) — if you can touch the device, you can already reboot it.
+- Corpus-content complaints (a quote you dislike, a misattribution).
+  Open a normal issue / PR with a `content_overrides.json` patch — see
+  `CONTRIBUTING.md`.
+
+## Hardening defaults worth knowing
+
+- The example systemd unit (`litclock.service.example`) runs with
+  `NoNewPrivileges=yes`, `ProtectSystem=strict`, `ProtectHome=read-only`,
+  `PrivateTmp=yes`, and a scoped `StateDirectory=litclock`. The Button-D
+  shutdown default (`sudo -n shutdown`) is **incompatible** with
+  `NoNewPrivileges=yes`; swap it for `systemctl poweroff` under the sandbox.
+- `--web-token-file` is preferred over `--web-token` in production so the
+  secret isn't visible in `ps` output or journald. The file is hot-reloaded
+  on `st_mtime` change, so rotating the token is a plain file replace.
+- `atomic_io.atomic_write_*` is the single durability primitive for every
+  file the next tick reads. If you're adding a new write path, route through
+  it — don't reintroduce naive `open("w")`.


### PR DESCRIPTION
Drops in the two project docs that were straightforward:

- LICENSE: MIT, with a note carving out the Project Gutenberg excerpts
  (public-domain source) and the bundled Playfair Display fonts (SIL OFL 1.1)
  so the reader isn't misled into thinking the compilation relicenses them.
- SECURITY.md: scoped to what actually exists — curator web UI auth model,
  button-D shutdown, atomic-write runtime files, corpus pipeline — and
  points reports at GitHub private vulnerability reporting.

CODE_OF_CONDUCT.md and CONTRIBUTING.md deferred: the Contributor Covenant
text tripped the API output content filter mid-generation, so the next
commit will either link to the upstream covenant or ship a shorter
custom version.