### PR TITLE
Parallelize CI tests and split golden renders

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
           pip install -e ".[dev]"
 
       - name: Run tests with coverage
-        run: pytest -n 4 --dist worksteal --ignore=tests/test_render_golden.py --cov=. --cov-report=term-missing --cov-report=xml -v
+        run: pytest -n 4 --dist worksteal --ignore=tests/test_render_golden.py --cov=. --cov-report=term-missing --cov-report=xml -v --dist loadscope
 
       - name: Upload coverage report
         uses: actions/upload-artifact@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
           pip install -e ".[dev]"
 
       - name: Run tests with coverage
-        run: pytest --cov=. --cov-report=term-missing --cov-report=xml -v
+        run: pytest -n 4 --dist worksteal --ignore=tests/test_render_golden.py --cov=. --cov-report=term-missing --cov-report=xml -v
 
       - name: Upload coverage report
         uses: actions/upload-artifact@v7
@@ -66,3 +66,25 @@ jobs:
           name: coverage-${{ matrix.python-version }}
           path: coverage.xml
           if-no-files-found: error
+
+  golden-render:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Run golden render tests
+        run: pytest tests/test_render_golden.py -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest", "pytest-cov", "ruff"]
+dev = ["pytest", "pytest-cov", "pytest-xdist", "ruff"]
 pi = ["inky", "gpiozero"]
 
 [tool.setuptools]


### PR DESCRIPTION
## Summary
- add  to dev dependencies and run the main test matrix with 4 parallel workers
- exclude golden render tests from the main matrix so normal failures surface faster
- add a dedicated  CI job on Python 3.12 for 

## Verification
- inspected the existing CI workflow and dev dependency setup
- updated the workflow so normal tests and golden render tests now run as separate concerns