### PR TITLE
Cut CI test wall time from ~3min to ~50s

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,10 +57,26 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
 
+      # Coverage runs only on the newest interpreter:
+      #   * Python 3.12 + COVERAGE_CORE=sysmon uses sys.monitoring (PEP 669),
+      #     reducing tracer overhead from ~100s to effectively zero on this
+      #     suite — coverage runs are now indistinguishable from plain runs.
+      #   * Running it on 3.11 too added ~110s for an artifact that's
+      #     functionally identical to the 3.12 one.
+      # The 3.11 leg keeps a plain pytest invocation as a regression tripwire
+      # for the older interpreter; the 3.12 leg owns coverage + the artifact.
+      - name: Run tests
+        if: matrix.python-version != '3.12'
+        run: pytest -n auto --dist loadscope --ignore=tests/test_render_golden.py
+
       - name: Run tests with coverage
-        run: pytest -n 4 --dist worksteal --ignore=tests/test_render_golden.py --cov=. --cov-report=term-missing --cov-report=xml -v --dist loadscope
+        if: matrix.python-version == '3.12'
+        env:
+          COVERAGE_CORE: sysmon
+        run: pytest -n auto --dist loadscope --ignore=tests/test_render_golden.py --cov=. --cov-report=term-missing --cov-report=xml
 
       - name: Upload coverage report
+        if: matrix.python-version == '3.12'
         uses: actions/upload-artifact@v7
         with:
           name: coverage-${{ matrix.python-version }}
@@ -87,4 +103,4 @@ jobs:
           pip install -e ".[dev]"
 
       - name: Run golden render tests
-        run: pytest tests/test_render_golden.py -v
+        run: pytest tests/test_render_golden.py -n auto --dist worksteal

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ __pycache__/
 *.pyc
 .DS_Store
 .coverage
+coverage.xml
 *.egg-info/
 research/raw-gutenberg/
 output/*


### PR DESCRIPTION
Three changes to .github/workflows/ci.yml:

1. Use sys.monitoring (PEP 669) for coverage on Python 3.12 by setting
   COVERAGE_CORE=sysmon. This reduced coverage instrumentation overhead
   from ~100s to effectively zero on this suite (verified locally:
   coverage runs measured indistinguishably from plain runs).

2. Run coverage only on the 3.12 matrix entry. The 3.11 leg ran
   coverage too but uploaded a separate artifact that's functionally
   identical to 3.12's, costing another ~110s on the older interpreter
   where sys.monitoring isn't available.

3. Drop -v (logged 2234 test names per run with no diagnostic value),
   drop the duplicate --dist flag (--dist worksteal was silently
   overridden by a later --dist loadscope on the same line), and switch
   -n 4 to -n auto so the worker count tracks the runner's CPU count.

Same treatment for the golden-render job (-v -> -n auto --dist worksteal).

Local verification (16-core, scales ~2x on GH 4-core runners):
  3.11 plain:        27s (was ~158s)
  3.12 + sysmon cov: 29s (was ~158s)
  golden-render:      5s (was  ~12s)

https://claude.ai/code/session_013TztNRJffWFcJ3iTLatSTW