### PR TITLE
Document test suite duration in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ Every stage is a standalone Python 3 CLI script that reads/writes JSONL. The min
 ### Testing & linting
 
 ```bash
-# Run the full test suite
+# Run the full test suite (2254 tests, ~3 minutes)
 pytest
 
 # Run tests with coverage report


### PR DESCRIPTION
Added note that the full test suite includes 2254 tests and takes approximately 3 minutes to run.

https://claude.ai/code/session_01MhfBfwtTYxUjm6kR6gk91L