### PR TITLE
Close the packaging boundary: fix py-modules, guard against optional-dep leakage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,20 @@ jobs:
           COVERAGE_CORE: sysmon
         run: pytest -n auto --dist loadscope --ignore=tests/test_render_golden.py --cov=. --cov-report=term-missing --cov-report=xml
 
+      - name: End-to-end --once smoke (verifies rendered PNG decodes)
+        # One Python version is enough — the existing test job already exercises
+        # ``run_clock --once`` via subprocess; this step adds an
+        # ``Image.verify()`` check so a truncated / partially-snapped PNG
+        # surfaces immediately instead of waiting for someone to look at the
+        # appliance. ``--skip-preflight`` is required because the CI runner
+        # has no display script on the configured path.
+        if: matrix.python-version == '3.12'
+        run: |
+          python run_clock.py --once --skip-preflight --buttons-off --quiet-off \
+            --history-path "" --state-path "" --pidfile "" --telemetry-path "" \
+            --mode production
+          python -c "from PIL import Image; im = Image.open('output/current.png'); im.verify(); im.close(); print('PNG OK')"
+
       - name: Upload coverage report
         if: matrix.python-version == '3.12'
         uses: actions/upload-artifact@v7
@@ -104,3 +118,77 @@ jobs:
 
       - name: Run golden render tests
         run: pytest tests/test_render_golden.py -n auto --dist worksteal
+
+  package-build:
+    # Builds a wheel + sdist from pyproject.toml and installs the wheel into
+    # a fresh venv with NO extras (no ``[dev]``, no ``[pi]``). Then imports
+    # every production module from the installed wheel and runs
+    # ``python -m run_clock --help`` as a canonical entrypoint smoke. This
+    # catches three install-time failure modes that the rest of CI (which
+    # uses ``pip install -e .``) cannot see:
+    #
+    #   1. Modules missing from ``[tool.setuptools] py-modules`` — the wheel
+    #      ships only what's listed there. A missing entry produces a wheel
+    #      that crashes on first ``import``.
+    #   2. Optional-dep leakage at module import time — if any module hoists
+    #      an ``import gpiozero`` / ``import inky`` from a function body to
+    #      the top of the file, the wheel becomes unusable on non-Pi hosts.
+    #   3. Broken ``__main__`` wiring — ``python -m run_clock`` only resolves
+    #      against installed top-level modules, not the source checkout.
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Build wheel and sdist
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build
+
+      - name: Install built wheel into clean venv (no extras)
+        run: |
+          python -m venv /tmp/whlcheck
+          /tmp/whlcheck/bin/pip install --upgrade pip
+          /tmp/whlcheck/bin/pip install dist/*.whl
+
+      - name: Import every production module from the installed wheel
+        run: |
+          /tmp/whlcheck/bin/python - <<'PY'
+          import importlib
+          import sys
+
+          MODULES = [
+              "apply_content_overrides", "atomic_io", "bake_quote_database",
+              "bucket_coverage", "buckets", "clean_display_quotes",
+              "contact_sheet", "display_inky", "enrich_metadata",
+              "fix_legacy_buckets", "fix_substring_time_matches",
+              "gutenberg_time_miner", "import_targeted_hits", "inky_buttons",
+              "jsonl_io", "litclock_health", "merge_candidates", "pick_quote",
+              "pidfile", "probe_buttons", "quality_filter", "render_quote",
+              "run_clock", "runtime_actions", "runtime_config", "runtime_log",
+              "runtime_quiet", "runtime_state", "runtime_store",
+              "runtime_telemetry", "runtime_theme", "sd_notify",
+              "target_sparse_buckets", "web_server",
+          ]
+          for name in MODULES:
+              importlib.import_module(name)
+
+          forbidden = ("gpiozero", "inky", "RPi")
+          leaked = sorted(m for m in sys.modules if m.split(".", 1)[0] in forbidden)
+          assert leaked == [], f"hardware deps leaked into sys.modules: {leaked}"
+          print(f"OK: {len(MODULES)} modules importable from installed wheel; no leakage")
+          PY
+
+      - name: Smoke-test installed entrypoint
+        # ``python -m run_clock --help`` resolves only against installed
+        # top-level modules, so this fails loudly if the wheel is missing
+        # anything that ``run_clock``'s import chain needs.
+        run: /tmp/whlcheck/bin/python -m run_clock --help

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,12 @@ jobs:
           /tmp/whlcheck/bin/pip install dist/*.whl
 
       - name: Import every production module from the installed wheel
+        # Run from /tmp, not the repo root: when Python starts, ``sys.path[0]``
+        # is the CWD, so a step run from the checkout would resolve
+        # ``import run_clock`` to ``./run_clock.py`` BEFORE the installed
+        # wheel — defeating the whole point of this job. ``cd /tmp`` forces
+        # imports to come from site-packages.
+        working-directory: /tmp
         run: |
           /tmp/whlcheck/bin/python - <<'PY'
           import importlib
@@ -178,8 +184,16 @@ jobs:
               "runtime_telemetry", "runtime_theme", "sd_notify",
               "target_sparse_buckets", "web_server",
           ]
+          site_packages = "/tmp/whlcheck/lib"
           for name in MODULES:
-              importlib.import_module(name)
+              mod = importlib.import_module(name)
+              # Defence in depth: confirm the import resolved to the installed
+              # wheel, not a stray copy on sys.path. If this assertion ever
+              # fires the working-directory above is wrong.
+              assert mod.__file__ and mod.__file__.startswith(site_packages), (
+                  f"{name!r} resolved to {mod.__file__!r}, "
+                  f"expected something under {site_packages!r}"
+              )
 
           forbidden = ("gpiozero", "inky", "RPi")
           leaked = sorted(m for m in sys.modules if m.split(".", 1)[0] in forbidden)
@@ -188,7 +202,8 @@ jobs:
           PY
 
       - name: Smoke-test installed entrypoint
-        # ``python -m run_clock --help`` resolves only against installed
-        # top-level modules, so this fails loudly if the wheel is missing
-        # anything that ``run_clock``'s import chain needs.
+        # Same ``working-directory`` reasoning as above — without it,
+        # ``python -m run_clock`` would resolve against the source checkout
+        # instead of the wheel.
+        working-directory: /tmp
         run: /tmp/whlcheck/bin/python -m run_clock --help

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,12 +17,21 @@ dev = ["pytest", "pytest-cov", "pytest-xdist", "ruff"]
 pi = ["inky", "gpiozero"]
 
 [tool.setuptools]
+# Keep this list in sync with the top-level *.py files in the repo root.
+# tests/test_packaging.py::test_py_modules_covers_top_level_modules enforces
+# the invariant — a module that exists on disk but is missing here will
+# silently break ``pip install .`` (the installed wheel won't contain it).
 py-modules = [
-    "buckets",
+    "apply_content_overrides",
+    "atomic_io",
+    "bake_quote_database",
     "bucket_coverage",
+    "buckets",
     "clean_display_quotes",
+    "contact_sheet",
     "display_inky",
     "enrich_metadata",
+    "fix_legacy_buckets",
     "fix_substring_time_matches",
     "gutenberg_time_miner",
     "import_targeted_hits",
@@ -31,9 +40,20 @@ py-modules = [
     "litclock_health",
     "merge_candidates",
     "pick_quote",
+    "pidfile",
+    "probe_buttons",
     "quality_filter",
     "render_quote",
     "run_clock",
+    "runtime_actions",
+    "runtime_config",
+    "runtime_log",
+    "runtime_quiet",
+    "runtime_state",
+    "runtime_store",
+    "runtime_telemetry",
+    "runtime_theme",
+    "sd_notify",
     "target_sparse_buckets",
     "web_server",
 ]

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,0 +1,124 @@
+"""Packaging-boundary tests.
+
+These guard two install-time invariants that are otherwise invisible to a
+``pip install -e .`` developer setup (which puts the repo on ``sys.path``
+regardless of what's listed in ``[tool.setuptools] py-modules``):
+
+1. **Every top-level production ``*.py`` module is listed in ``py-modules``.**
+   Setuptools ships exactly what ``py-modules`` lists into the wheel — a
+   module that exists on disk but is missing from the list silently breaks
+   the installed wheel (and the appliance won't start). Caught here at
+   ``pytest`` time instead of at deploy time.
+
+2. **Importing any production module never pulls hardware deps**
+   (``gpiozero`` / ``inky`` / ``RPi.GPIO``) **into ``sys.modules``.** Today
+   every such import is locally scoped inside a function body. A refactor
+   that hoists one to module level would silently break ``pip install`` on
+   non-Pi hosts (and the import-time of every pipeline script). Subprocess
+   isolation is required because once any test in the same interpreter
+   imports ``run_clock``, in-process ``sys.modules`` is already populated.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# Top-level files that exist on disk but are deliberately not Python modules
+# to ship in the wheel. Keep this list short and explicit — anything not
+# listed here must appear in ``py-modules``.
+EXCLUDED_TOP_LEVEL = frozenset({
+    # Test helpers / packaging — never imported as a runtime module.
+    "setup",  # if anyone ever adds a vestigial setup.py
+    "conftest",  # pytest discovers these implicitly under ``tests/``
+})
+
+# Hardware-dep namespaces that must NEVER appear in ``sys.modules`` after
+# importing any LitClock production module on a non-Pi host.
+FORBIDDEN_HARDWARE_NAMESPACES = ("gpiozero", "inky", "RPi")
+
+
+def _pyproject_py_modules() -> list[str]:
+    pyproject = REPO_ROOT / "pyproject.toml"
+    data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+    return list(data["tool"]["setuptools"]["py-modules"])
+
+
+def _top_level_modules_on_disk() -> set[str]:
+    return {
+        path.stem
+        for path in REPO_ROOT.glob("*.py")
+        if path.stem not in EXCLUDED_TOP_LEVEL
+    }
+
+
+class TestPyModulesList:
+    """Guard the ``[tool.setuptools] py-modules`` list against drift."""
+
+    def test_py_modules_covers_top_level_modules(self):
+        on_disk = _top_level_modules_on_disk()
+        listed = set(_pyproject_py_modules())
+
+        missing = sorted(on_disk - listed)
+        extra = sorted(listed - on_disk)
+
+        assert not missing and not extra, (
+            "pyproject.toml [tool.setuptools] py-modules is out of sync with "
+            "top-level *.py files in the repo root.\n"
+            f"  Missing from py-modules (will not ship in the wheel): {missing}\n"
+            f"  Listed but not on disk (will fail wheel build):       {extra}"
+        )
+
+    def test_py_modules_list_is_sorted_and_deduped(self):
+        listed = _pyproject_py_modules()
+        assert listed == sorted(listed), (
+            "py-modules should be alphabetically sorted so diffs stay small "
+            "when modules are added; got "
+            f"{listed!r}"
+        )
+        assert len(listed) == len(set(listed)), "py-modules contains duplicates"
+
+
+class TestNoOptionalDepLeakage:
+    """Importing a production module on a non-Pi host must not pull hardware
+    deps into sys.modules. Each module is imported in a fresh subprocess so
+    the assertion is independent of test ordering."""
+
+    @pytest.mark.parametrize("module_name", sorted(_top_level_modules_on_disk()))
+    def test_module_import_does_not_pull_hardware_deps(self, module_name):
+        # Run the import in a subprocess with the repo root on PYTHONPATH so
+        # the module resolves the same way it will inside the installed wheel
+        # (top-level, no package qualifier).
+        probe = (
+            f"import {module_name}; "
+            "import json, sys; "
+            f"forbidden = {FORBIDDEN_HARDWARE_NAMESPACES!r}; "
+            "leaked = sorted(m for m in sys.modules if m.split('.', 1)[0] in forbidden); "
+            "print(json.dumps(leaked))"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", probe],
+            cwd=str(REPO_ROOT),
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        assert result.returncode == 0, (
+            f"importing {module_name!r} in a fresh subprocess failed:\n"
+            f"--- stdout ---\n{result.stdout}\n"
+            f"--- stderr ---\n{result.stderr}"
+        )
+
+        leaked = json.loads(result.stdout.strip() or "[]")
+        assert leaked == [], (
+            f"importing {module_name!r} pulled hardware deps into sys.modules: "
+            f"{leaked}. All gpiozero/inky/RPi imports must stay inside function "
+            "bodies so non-Pi installs work."
+        )


### PR DESCRIPTION
`pyproject.toml`'s `[tool.setuptools] py-modules` list was missing 16 of
the 34 top-level production modules — including `atomic_io`, `pidfile`,
`sd_notify`, and every `runtime_*` sibling. Because every CI job uses
`pip install -e .` (which puts the source dir on `sys.path`), this
latent install-time bug was invisible: the moment anyone tried to
`pip install` a built wheel, `import run_clock` would crash on a
`ModuleNotFoundError` for `atomic_io`.

Three changes, all aimed at confidence-per-line of test code:

1. `pyproject.toml`: add the 16 missing modules to `py-modules`,
   alphabetised.

2. `tests/test_packaging.py` (new):
   - `test_py_modules_covers_top_level_modules` — globs `*.py` at repo
     root and asserts the `py-modules` list matches, with a clear diff
     message so future module-additions get a pointer to the fix.
   - `test_no_optional_dep_leakage_on_module_import` — parametrised
     across all 34 modules, spawns a subprocess for each (so test
     ordering can't pollute `sys.modules`) and asserts that `gpiozero`,
     `inky`, and `RPi.GPIO` never appear after import. Today every
     hardware import is locally scoped inside a function body; this
     test pins that invariant so a refactor that hoists one to module
     scope fails CI immediately rather than at Pi deploy time.

3. `.github/workflows/ci.yml`:
   - New `package-build` job: `python -m build`, install the wheel into
     a fresh venv with NO extras, import every production module from
     the installed wheel, assert no hardware-dep leakage, and run
     `python -m run_clock --help` as a canonical entrypoint smoke.
     Catches missing `py-modules` entries, optional-dep leakage at
     import time, and broken `__main__` wiring on a real installed
     wheel — failure modes the existing `pip install -e .` jobs cannot
     observe.
   - New end-to-end `--once` smoke step on the `test` job (3.12 only):
     runs `run_clock --once --skip-preflight` and verifies the produced
     PNG decodes via `Image.verify()`. The existing
     `test_cli_main_smoke.py::test_once_renders_a_frame` only checks
     `st_size > 0`, so a truncated / partially-snapped output would
     silently pass.

Deliberately not added: a mypy job (low ROI for stdlib + Pillow code),
hash-based snapshot rework (the existing palette-snapped goldens are
already more durable than HomeDashboard's Pillow-pinned hash approach),
hardware-mock state-transition assertions (would couple tests to
gpiozero internals without catching real bugs), 3.13 matrix entry.

Verified locally: `python -m pytest -n 4 --ignore=tests/test_render_golden.py`
2270/2270 pass; goldens 20/20 pass; `ruff check .` clean;
`python -m build` produces a wheel that installs cleanly into a fresh
venv, all 34 modules importable, `python -m run_clock --help` works.

https://claude.ai/code/session_01EkPTHP3yorgt5s6xpUhurY