### PR TITLE
Improve render hot path, telemetry durability, and shared helpers

### DIFF
--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -15,16 +15,6 @@ is something the codebase is fine without but would be cleaner with.
   issue applies to `--startup-image`. Low priority — the existing
   behaviour is consistent, just not theme-aware.
 
-- **Three near-duplicate lazy-import helpers.**
-  `runtime_state._known_theme_names`,
-  `runtime_theme._registered_themes`, and
-  `runtime_actions._theme_cycle` all do the same
-  `from render_quote import ...` dance with a legacy fallback. The
-  fallbacks are even different types (`frozenset` vs `tuple`). Worth
-  consolidating into a single PIL-free `theme_names.py` module (or
-  dropping the fallback entirely — if `render_quote` can't be imported
-  the appliance is broken in ways the fallback can't paper over).
-
 - **`--theme auto` is binary (default/dark only).** The eight operator
   themes (`scholar`, `newsprint`, `nightvision`, `blueprint`,
   `illuminated`, `bauhaus`, `risograph`, `comic`) can't be
@@ -33,9 +23,3 @@ is something the codebase is fine without but would be cleaner with.
   table — likely gated on a new `--auto-day-theme` / `--auto-night-theme`
   flag pair. Deliberately punted from PR #72 because the current
   binary contract is well-understood.
-
-- **`subtle` theme field is unused.** Every theme populates
-  `subtle` but `render_quote` never references it (confirmed by
-  grep). Either wire it into an existing element (subheading, maybe?)
-  or remove from the theme contract and the `TestThemes` field-count
-  invariant.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ py-modules = [
     "runtime_theme",
     "sd_notify",
     "target_sparse_buckets",
+    "theme_names",
     "web_server",
 ]
 

--- a/render_quote.py
+++ b/render_quote.py
@@ -618,8 +618,19 @@ def pick_quote(time_str: str, history_path: str | None = None, history_days: int
     )
 
 
+_FONT_CACHE: dict[tuple, "ImageFont.FreeTypeFont"] = {}
+
+
+def _normalize_candidates(candidates) -> tuple:
+    """Normalize the load_font candidates list into a hashable cache key.
+
+    Plain string entries become ``(path, None)``; tuple entries pass through.
+    """
+    return tuple((c, None) if not isinstance(c, tuple) else tuple(c) for c in candidates)
+
+
 def load_font(candidates: list, size: int):
-    """Load the first reachable TrueType font in ``candidates``.
+    """Load the first reachable TrueType font in ``candidates``, memoized.
 
     Each entry is either a plain path string or a ``(path, variation_name)``
     tuple. When the tuple form is used and the face is a variable font,
@@ -630,13 +641,25 @@ def load_font(candidates: list, size: int):
     A variation name that the file doesn't expose falls through to
     the default instance silently; the next fallback candidate only fires if
     the file itself is missing or unreadable.
+
+    Results are cached per-process keyed on ``(normalised_candidates, size)``.
+    ``fit_quote`` calls ``load_font`` up to 18 times per render with the same
+    candidate chain at different sizes; without a cache that's 36 candidate-
+    chain scans + 36 ``ImageFont.truetype`` opens per render. Cache lifetime
+    is the renderer subprocess (single-threaded), so no FD-leak risk.
+
+    Contract: callers must NOT mutate the returned font (e.g. by calling
+    ``set_variation_by_name`` directly). All variation pinning is encoded in
+    the candidate tuple so a different variation produces a different cache
+    key; an external mutation would silently corrupt other cache consumers.
     """
     global _FONT_FALLBACK_WARNED
-    for candidate in candidates:
-        if isinstance(candidate, tuple):
-            path, variation = candidate
-        else:
-            path, variation = candidate, None
+    normalized = _normalize_candidates(candidates)
+    cache_key = (normalized, size)
+    cached = _FONT_CACHE.get(cache_key)
+    if cached is not None:
+        return cached
+    for path, variation in normalized:
         if not Path(path).exists():
             continue
         try:
@@ -648,6 +671,7 @@ def load_font(candidates: list, size: int):
                 font.set_variation_by_name(variation)
             except (OSError, ValueError, AttributeError):
                 pass
+        _FONT_CACHE[cache_key] = font
         return font
     if not _FONT_FALLBACK_WARNED:
         print(
@@ -657,7 +681,9 @@ def load_font(candidates: list, size: int):
             flush=True,
         )
         _FONT_FALLBACK_WARNED = True
-    return ImageFont.load_default()
+    fallback = ImageFont.load_default()
+    _FONT_CACHE[cache_key] = fallback
+    return fallback
 
 
 def strip_underscore_emphasis(text: str) -> str:
@@ -695,23 +721,45 @@ TIME_PHRASE_PREFIXES = [
     "five minutes to",
 ]
 
+# Pre-compiled longest-first so the first prefix that matches the candidate
+# wins ("twenty-five minutes past" beats "minutes past" for the same row).
+# Order is load-bearing — keep this list sorted by descending prefix length.
+_TIME_PHRASE_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
+    (
+        prefix,
+        re.compile(
+            rf"(?<![A-Za-z0-9])(?<![A-Za-z0-9]-){re.escape(prefix)}"
+            rf"(?:[ ,]+[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*)?(?![A-Za-z0-9])(?!-[A-Za-z0-9])",
+            re.IGNORECASE,
+        ),
+    )
+    for prefix in sorted(TIME_PHRASE_PREFIXES, key=len, reverse=True)
+]
+
+
+def _direct_match_pattern(normalized_match: str) -> re.Pattern[str]:
+    return re.compile(
+        rf"(?<![A-Za-z0-9])(?<![A-Za-z0-9]-){re.escape(normalized_match)}(?![A-Za-z0-9])(?!-[A-Za-z0-9])",
+        re.IGNORECASE,
+    )
+
 
 def resolve_display_match(text: str, match_text: str) -> str:
     normalized_match = " ".join((match_text or "").split()).strip()
     if not normalized_match:
         return ""
 
-    direct = re.search(rf"(?<![A-Za-z0-9])(?<![A-Za-z0-9]-){re.escape(normalized_match)}(?![A-Za-z0-9])(?!-[A-Za-z0-9])", text, re.IGNORECASE)
+    direct = _direct_match_pattern(normalized_match).search(text)
     if direct:
         return direct.group(0)
 
-    for prefix in sorted(TIME_PHRASE_PREFIXES, key=len, reverse=True):
-        if not normalized_match.lower().startswith(prefix):
+    lower_match = normalized_match.lower()
+    for prefix, pattern in _TIME_PHRASE_PATTERNS:
+        if not lower_match.startswith(prefix):
             continue
-        pattern = re.compile(rf"(?<![A-Za-z0-9])(?<![A-Za-z0-9]-){re.escape(prefix)}(?:[ ,]+[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*)?(?![A-Za-z0-9])(?!-[A-Za-z0-9])", re.IGNORECASE)
         for m in pattern.finditer(text):
             candidate = m.group(0).strip(" ,.;:!?")
-            if candidate.lower().startswith(normalized_match.lower()):
+            if candidate.lower().startswith(lower_match):
                 return candidate
 
     return normalized_match
@@ -721,8 +769,7 @@ def tokenize_quote(text: str, match_text: str) -> list[tuple[str, bool]]:
     normalized_match = resolve_display_match(text, match_text)
     if not normalized_match:
         return [(text, False)]
-    pattern = re.compile(rf"(?<![A-Za-z0-9])(?<![A-Za-z0-9]-){re.escape(normalized_match)}(?![A-Za-z0-9])(?!-[A-Za-z0-9])", re.IGNORECASE)
-    match = pattern.search(text)
+    match = _direct_match_pattern(normalized_match).search(text)
     if not match:
         return [(text, False)]
 
@@ -742,6 +789,11 @@ def wrap_styled_text(draw, segments, regular_font, bold_font, max_width):
     lines = []
     current = []
     current_width = 0
+    # Space width is the same for every inter-word position that uses the same
+    # font object. fit_quote calls wrap_styled_text up to 18 times per render
+    # with two distinct fonts (regular + bold); a 140-char quote has ~25 spaces,
+    # so without this memo we'd run draw.textbbox(" ", …) ~450 times per render.
+    space_widths: dict[int, int] = {}
 
     for text, is_bold in segments:
         font = bold_font if is_bold else regular_font
@@ -757,8 +809,12 @@ def wrap_styled_text(draw, segments, regular_font, bold_font, max_width):
                 current.append((part, is_bold))
                 current_width += token_width
             if i < len(parts) - 1:
-                bbox = draw.textbbox((0, 0), " ", font=font)
-                space_width = bbox[2] - bbox[0]
+                font_id = id(font)
+                space_width = space_widths.get(font_id)
+                if space_width is None:
+                    bbox = draw.textbbox((0, 0), " ", font=font)
+                    space_width = bbox[2] - bbox[0]
+                    space_widths[font_id] = space_width
                 if current and current_width + space_width > max_width:
                     lines.append(current)
                     current = []

--- a/render_quote.py
+++ b/render_quote.py
@@ -681,9 +681,16 @@ def load_font(candidates: list, size: int):
             flush=True,
         )
         _FONT_FALLBACK_WARNED = True
-    fallback = ImageFont.load_default()
-    _FONT_CACHE[cache_key] = fallback
-    return fallback
+    # Deliberately NOT caching the bitmap fallback. A transient miss (NFS hiccup,
+    # filesystem briefly unavailable, momentary file-handle exhaustion) would
+    # otherwise pin the process to degraded rendering for the whole subprocess
+    # lifetime — and contact_sheet.py renders 144 frames in one process, so a
+    # single early hiccup would silently downgrade every later tile. Re-scanning
+    # the candidate chain on each fallback call is cheap (a few Path.exists
+    # checks) and lets the next call recover automatically once the font path
+    # is reachable again. The warn-once behaviour comes from
+    # _FONT_FALLBACK_WARNED, not from caching, so we still don't spam stderr.
+    return ImageFont.load_default()
 
 
 def strip_underscore_emphasis(text: str) -> str:

--- a/render_quote.py
+++ b/render_quote.py
@@ -618,7 +618,7 @@ def pick_quote(time_str: str, history_path: str | None = None, history_days: int
     )
 
 
-_FONT_CACHE: dict[tuple, "ImageFont.FreeTypeFont"] = {}
+_FONT_CACHE: dict[tuple, ImageFont.ImageFont] = {}
 
 
 def _normalize_candidates(candidates) -> tuple:

--- a/runtime_actions.py
+++ b/runtime_actions.py
@@ -34,20 +34,7 @@ from runtime_log import _log
 from runtime_quiet import _display_quiet_image, exit_quiet
 from runtime_state import RuntimeState
 from runtime_theme import resolve_effective_theme
-
-
-def _theme_cycle() -> tuple[str, ...]:
-    """Return the cycle order for button-B / web theme advancement.
-
-    Resolved lazily against ``render_quote.THEME_ORDER`` so this module keeps
-    its PIL-free import graph. Falls back to the original binary pair if
-    ``render_quote`` is unavailable, matching ``runtime_state._known_theme_names``.
-    """
-    try:
-        from render_quote import THEME_ORDER
-    except Exception:
-        return ("default", "dark")
-    return tuple(THEME_ORDER)
+from theme_names import theme_cycle as _theme_cycle
 
 
 def _next_theme(current: str) -> str:

--- a/runtime_state.py
+++ b/runtime_state.py
@@ -15,22 +15,7 @@ if TYPE_CHECKING:
     from threading import Timer
 
 
-def _known_theme_names() -> frozenset[str]:
-    """Registered render themes, resolved lazily to avoid pulling PIL into the
-    main-loop import graph. ``render_quote.THEMES`` imports Pillow at module
-    load; doing the import inside ``RuntimeState.__init__`` keeps the
-    one-time cost off ``run_clock`` startup and off any test that constructs
-    a RuntimeState without needing the renderer.
-
-    Falls back to the minimal original pair if the import fails (e.g. in a
-    stripped-down test harness) so a missing Pillow install can't wedge
-    state-file loading.
-    """
-    try:
-        from render_quote import THEMES
-    except Exception:
-        return frozenset({"default", "dark"})
-    return frozenset(THEMES.keys())
+from theme_names import known_theme_names as _known_theme_names
 
 
 class RuntimeState:

--- a/runtime_telemetry.py
+++ b/runtime_telemetry.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import contextlib
 import datetime as dt
 import json
+import os
 import re
 from pathlib import Path
 
@@ -57,8 +58,14 @@ def append_heartbeat(telemetry_path: str | None) -> None:
     ``error_count`` by the health summariser — they answer "is the loop
     alive?", not "is the panel being refreshed?", which is a different
     question an idle appliance should be able to answer "yes / no".
+
+    Heartbeats fire every ``HEARTBEAT_INTERVAL_SECONDS`` (~60 s on the
+    appliance), so they're written without ``fsync`` to bound SD-card write
+    amplification. Losing the last minute of "alive" pings to a power cut is
+    recoverable; losing a render error or backoff event is not — that's why
+    every other ``append_telemetry`` caller fsyncs.
     """
-    append_telemetry(telemetry_path, {"type": "heartbeat"})
+    _append_entry(telemetry_path, {"type": "heartbeat"}, fsync=False)
 
 
 def append_telemetry(telemetry_path: str | None, entry: dict) -> None:
@@ -73,7 +80,17 @@ def append_telemetry(telemetry_path: str | None, entry: dict) -> None:
     disk, path is a directory) must never surface to the caller, since this
     is called from the loop's error-recovery path — turning telemetry into
     a fatal failure mode would defeat its purpose.
+
+    Entries are flushed and ``os.fsync``'d before close so a SIGKILL / power
+    loss immediately after a render or error event can't leave the line
+    buffered in the kernel and lost — that's exactly when ``litclock_health``
+    needs the last few entries to distinguish "wedged" from "idle".
+    Heartbeats skip the fsync via ``append_heartbeat`` (see its docstring).
     """
+    _append_entry(telemetry_path, entry, fsync=True)
+
+
+def _append_entry(telemetry_path: str | None, entry: dict, *, fsync: bool) -> None:
     if not telemetry_path:
         return
     try:
@@ -83,6 +100,9 @@ def append_telemetry(telemetry_path: str | None, entry: dict) -> None:
         payload = {"ts": dt.datetime.now(dt.timezone.utc).isoformat(timespec="seconds"), **entry}
         with path.open("a", encoding="utf-8") as handle:
             handle.write(json.dumps(payload, ensure_ascii=False) + "\n")
+            if fsync:
+                handle.flush()
+                os.fsync(handle.fileno())
     except (OSError, TypeError, ValueError) as exc:
         _log(f"telemetry write to {telemetry_path!r} failed, dropping entry: {exc!r}", err=True)
 

--- a/runtime_theme.py
+++ b/runtime_theme.py
@@ -13,24 +13,13 @@ import datetime as dt
 
 from runtime_log import _log
 from runtime_state import RuntimeState
+from theme_names import known_theme_names as _registered_themes
 
 # Auto-theme: switch to dark theme during this window, default theme otherwise.
 # Boundaries chosen to match civil twilight in temperate latitudes; users who want
 # a tighter fit can pass --theme default or --theme dark explicitly.
 AUTO_DARK_START_HOUR = 18
 AUTO_DARK_END_HOUR = 6
-
-
-def _registered_themes() -> frozenset[str]:
-    """Registered render themes, resolved lazily to avoid pulling PIL into the
-    main-loop import graph at module load. Mirrors ``runtime_state._known_theme_names``
-    and falls back to the legacy pair if ``render_quote`` cannot be imported.
-    """
-    try:
-        from render_quote import THEMES
-    except Exception:
-        return frozenset({"default", "dark"})
-    return frozenset(THEMES.keys())
 
 
 def auto_theme_for(time_str: str) -> str:

--- a/tests/test_render_quote.py
+++ b/tests/test_render_quote.py
@@ -350,6 +350,41 @@ class TestLoadFontFallback:
         assert font is not None
         assert "no TrueType font found" not in capsys.readouterr().err
 
+    def test_fallback_path_not_cached_so_recovery_works(self, monkeypatch):
+        """A transient font-load failure (NFS hiccup, brief unavailability)
+        must not pin the process to the bitmap fallback. The cache stores
+        successfully-loaded fonts only; a later call after the file becomes
+        reachable again must re-scan and load the real font.
+
+        Regression guard for a Codex review concern: caching the fallback
+        would silently degrade rendering for the rest of the subprocess
+        (especially noticeable for ``contact_sheet.py`` which renders all
+        144 buckets in one process).
+        """
+        # Suppress the one-shot warning so capsys doesn't matter here.
+        monkeypatch.setattr(rq, "_FONT_FALLBACK_WARNED", True)
+        real_path = "/usr/share/fonts/truetype/dejavu/DejaVuSerif.ttf"
+        if not Path(real_path).exists():
+            pytest.skip("DejaVu Serif not installed")
+        # First call: pretend the file is missing → fallback to PIL's
+        # bundled default (or the bitmap default in older Pillows).
+        monkeypatch.setattr(rq.Path, "exists", lambda self: False)
+        a = rq.load_font([real_path], size=24)
+        # Second call: file is reachable again → should load the real font.
+        monkeypatch.undo()
+        monkeypatch.setattr(rq, "_FONT_FALLBACK_WARNED", True)
+        b = rq.load_font([real_path], size=24)
+        # `b` must be the real load: its underlying path matches what we asked
+        # for, and the cache now holds it. `a` did NOT come from real_path
+        # (the path was unreachable on that call) so it must be a different
+        # font, AND the fallback call must NOT have populated the cache —
+        # otherwise `b` would be `a` (the cached fallback).
+        b_path = getattr(b, "path", None)
+        assert b_path == real_path, f"second call should load {real_path!r}, got {b_path!r}"
+        assert a is not b, "fallback was cached and reused — recovery is broken"
+        # The cache contains exactly one entry (the successful load on call 2).
+        assert len(rq._FONT_CACHE) == 1
+
     def test_load_font_caches_results_per_size(self, monkeypatch):
         """``load_font`` is called up to 18 times per render in ``fit_quote``
         with the same candidate chain at different sizes; caching turns the

--- a/tests/test_render_quote.py
+++ b/tests/test_render_quote.py
@@ -15,6 +15,20 @@ pytestmark = pytest.mark.skipif(not PIL_AVAILABLE, reason="Pillow not installed"
 
 import render_quote as rq  # noqa: E402
 
+
+@pytest.fixture(autouse=True)
+def _isolate_font_cache():
+    """Clear ``render_quote._FONT_CACHE`` around every test so cache state
+    from a prior test can't mask path-existence assertions or fallback-path
+    expectations in the current one. The cache is a per-process performance
+    optimisation, not a correctness signal — tests that exercise either
+    branch should always start from an empty cache.
+    """
+    rq._FONT_CACHE.clear()
+    yield
+    rq._FONT_CACHE.clear()
+
+
 # ---------------------------------------------------------------------------
 # choose_layout
 # ---------------------------------------------------------------------------
@@ -290,10 +304,8 @@ class TestLoadFontFallback:
     def test_missing_candidates_returns_default_and_warns_once(self, monkeypatch, capsys):
         # Force the fallback path by flipping the module-level guard.
         monkeypatch.setattr(rq, "_FONT_FALLBACK_WARNED", False)
-        # Clear the per-process font cache so the fallback path actually runs;
-        # a previous test could have cached the same key.
-        monkeypatch.setattr(rq, "_FONT_CACHE", {})
-        # All candidate paths report as missing.
+        # All candidate paths report as missing. (Cache isolation is provided
+        # by the autouse ``_isolate_font_cache`` fixture at module scope.)
         monkeypatch.setattr(rq.Path, "exists", lambda self: False)
         font = rq.load_font(["/nope/one.ttf", "/nope/two.ttf"], size=24)
         assert font is not None  # the bitmap default
@@ -328,7 +340,6 @@ class TestLoadFontFallback:
         """A missing file referenced in a variation tuple falls through to the
         next candidate, exactly like a bare-path candidate would."""
         monkeypatch.setattr(rq, "_FONT_FALLBACK_WARNED", False)
-        monkeypatch.setattr(rq, "_FONT_CACHE", {})
         # First candidate is a tuple pointing at a missing file; second is a
         # plain path to a real system font that exists on the CI image.
         font = rq.load_font(
@@ -345,7 +356,6 @@ class TestLoadFontFallback:
         repeat opens into O(1) lookups. Verify by counting ``ImageFont.truetype``
         calls across two cache hits and one cache miss.
         """
-        monkeypatch.setattr(rq, "_FONT_CACHE", {})
         truetype_calls = []
         original_truetype = rq.ImageFont.truetype
 
@@ -365,11 +375,10 @@ class TestLoadFontFallback:
         assert a is b
         assert a is not c
 
-    def test_load_font_keys_on_variation(self, monkeypatch):
+    def test_load_font_keys_on_variation(self):
         """Different variation pins of the same path produce different cache
         entries, so a per-theme variable-font Bold/Regular split is isolated.
         """
-        monkeypatch.setattr(rq, "_FONT_CACHE", {})
         path = "/usr/share/fonts/truetype/dejavu/DejaVuSerif.ttf"
         plain = rq.load_font([path], size=20)
         with_variation = rq.load_font([(path, "Bold")], size=20)

--- a/tests/test_render_quote.py
+++ b/tests/test_render_quote.py
@@ -290,6 +290,9 @@ class TestLoadFontFallback:
     def test_missing_candidates_returns_default_and_warns_once(self, monkeypatch, capsys):
         # Force the fallback path by flipping the module-level guard.
         monkeypatch.setattr(rq, "_FONT_FALLBACK_WARNED", False)
+        # Clear the per-process font cache so the fallback path actually runs;
+        # a previous test could have cached the same key.
+        monkeypatch.setattr(rq, "_FONT_CACHE", {})
         # All candidate paths report as missing.
         monkeypatch.setattr(rq.Path, "exists", lambda self: False)
         font = rq.load_font(["/nope/one.ttf", "/nope/two.ttf"], size=24)
@@ -325,6 +328,7 @@ class TestLoadFontFallback:
         """A missing file referenced in a variation tuple falls through to the
         next candidate, exactly like a bare-path candidate would."""
         monkeypatch.setattr(rq, "_FONT_FALLBACK_WARNED", False)
+        monkeypatch.setattr(rq, "_FONT_CACHE", {})
         # First candidate is a tuple pointing at a missing file; second is a
         # plain path to a real system font that exists on the CI image.
         font = rq.load_font(
@@ -334,6 +338,43 @@ class TestLoadFontFallback:
         # Should have loaded DejaVu without emitting the warning.
         assert font is not None
         assert "no TrueType font found" not in capsys.readouterr().err
+
+    def test_load_font_caches_results_per_size(self, monkeypatch):
+        """``load_font`` is called up to 18 times per render in ``fit_quote``
+        with the same candidate chain at different sizes; caching turns the
+        repeat opens into O(1) lookups. Verify by counting ``ImageFont.truetype``
+        calls across two cache hits and one cache miss.
+        """
+        monkeypatch.setattr(rq, "_FONT_CACHE", {})
+        truetype_calls = []
+        original_truetype = rq.ImageFont.truetype
+
+        def counting_truetype(*args, **kwargs):
+            truetype_calls.append((args, kwargs))
+            return original_truetype(*args, **kwargs)
+
+        monkeypatch.setattr(rq.ImageFont, "truetype", counting_truetype)
+        candidates = ["/usr/share/fonts/truetype/dejavu/DejaVuSerif.ttf"]
+        a = rq.load_font(candidates, size=24)
+        b = rq.load_font(candidates, size=24)  # cache hit
+        c = rq.load_font(candidates, size=32)  # different size → cache miss
+        # Two distinct truetype opens (one per size); the duplicate-size call
+        # was served from cache.
+        assert len(truetype_calls) == 2
+        # Cache returns the *same* font object across calls with the same key.
+        assert a is b
+        assert a is not c
+
+    def test_load_font_keys_on_variation(self, monkeypatch):
+        """Different variation pins of the same path produce different cache
+        entries, so a per-theme variable-font Bold/Regular split is isolated.
+        """
+        monkeypatch.setattr(rq, "_FONT_CACHE", {})
+        path = "/usr/share/fonts/truetype/dejavu/DejaVuSerif.ttf"
+        plain = rq.load_font([path], size=20)
+        with_variation = rq.load_font([(path, "Bold")], size=20)
+        # Different keys → different cached objects (variation is part of key).
+        assert plain is not with_variation
 
 
 class TestThemeFonts:

--- a/tests/test_run_clock.py
+++ b/tests/test_run_clock.py
@@ -1163,6 +1163,38 @@ class TestAppendTelemetry:
         run_clock.append_telemetry(str(base), {"bucket": "h3_exact", "blob": NotSerialisable()})
         assert "telemetry write" in capsys.readouterr().err
 
+    def test_render_entry_calls_fsync(self, tmp_path):
+        """Render / error / action telemetry must fsync so a power loss after a
+        wedge-event entry can't lose the line that ``litclock_health`` needs to
+        distinguish "wedged" from "idle".
+        """
+        import runtime_telemetry
+
+        base = tmp_path / "telemetry.jsonl"
+        fsync_calls: list[int] = []
+        with patch.object(runtime_telemetry.os, "fsync", side_effect=lambda fd: fsync_calls.append(fd)):
+            run_clock.append_telemetry(str(base), {"bucket": "h3_exact", "render_ms": 500})
+        assert len(fsync_calls) == 1
+        # File contents are still correct.
+        daily = _today_telemetry_path(base)
+        assert json.loads(daily.read_text(encoding="utf-8").strip())["bucket"] == "h3_exact"
+
+    def test_heartbeat_skips_fsync(self, tmp_path):
+        """Heartbeats fire every ~60s on the appliance and are recoverable
+        (a missed minute of "alive" pings is fine), so they skip fsync to
+        bound SD-card write amplification.
+        """
+        import runtime_telemetry
+
+        base = tmp_path / "telemetry.jsonl"
+        fsync_calls: list[int] = []
+        with patch.object(runtime_telemetry.os, "fsync", side_effect=lambda fd: fsync_calls.append(fd)):
+            run_clock.append_heartbeat(str(base))
+        assert fsync_calls == []
+        # Heartbeat still landed on disk.
+        daily = _today_telemetry_path(base)
+        assert json.loads(daily.read_text(encoding="utf-8").strip())["type"] == "heartbeat"
+
 
 class TestDailyTelemetryPath:
     def test_standard_suffix(self, tmp_path):

--- a/theme_names.py
+++ b/theme_names.py
@@ -1,0 +1,53 @@
+"""PIL-free shim exposing the registered theme names + cycle order.
+
+Three runtime modules (:mod:`runtime_state`, :mod:`runtime_theme`,
+:mod:`runtime_actions`) need theme-name lists to validate persisted state,
+gate manual-theme overrides, and drive the button-B / web cycle. They each
+previously inlined a near-duplicate ``try: from render_quote import …`` lazy
+import with a hand-coded ``("default", "dark")`` fallback — and the fallback
+types had drifted (``frozenset`` vs ``tuple``) across copies. Consolidating
+into one module kills the drift class-by-construction.
+
+The lazy import is preserved (rather than an unconditional one at the top)
+so importing these helpers does not pull Pillow into the main-loop import
+graph at module load — ``render_quote.THEMES`` triggers ``from PIL import``,
+and we want :mod:`run_clock`, :mod:`runtime_state`, etc. to stay PIL-free
+on import for the test harness and for any future no-render mode.
+
+Failure mode: if ``render_quote`` cannot be imported (e.g. a stripped-down
+test fixture, or a Pillow install that's broken on the appliance), we fall
+back to the legacy ``("default", "dark")`` pair so state-file load /
+persisted-theme validation can still proceed. The appliance won't render in
+that state, but it also shouldn't wedge state-machine code.
+"""
+from __future__ import annotations
+
+_FALLBACK: tuple[str, ...] = ("default", "dark")
+
+
+def known_theme_names() -> frozenset[str]:
+    """Set of theme names registered in ``render_quote.THEMES``.
+
+    Used to validate persisted manual-theme values and gate
+    ``resolve_effective_theme`` overrides. Membership-style lookups; order
+    does not matter (use :func:`theme_cycle` when you need the curated
+    button-B / web-dropdown ordering).
+    """
+    try:
+        from render_quote import THEMES
+    except Exception:
+        return frozenset(_FALLBACK)
+    return frozenset(THEMES.keys())
+
+
+def theme_cycle() -> tuple[str, ...]:
+    """Curated order for button-B / web-dropdown theme advancement.
+
+    Pulled from ``render_quote.THEME_ORDER`` (an explicit tuple, distinct from
+    ``THEMES.keys()`` — the registered names without an ordering guarantee).
+    """
+    try:
+        from render_quote import THEME_ORDER
+    except Exception:
+        return _FALLBACK
+    return tuple(THEME_ORDER)

--- a/web_server.py
+++ b/web_server.py
@@ -495,8 +495,8 @@ class CuratorHandler(BaseHTTPRequestHandler):
     def _api_themes(self) -> None:
         """Expose the theme cycle so the UI dropdown and the Python cycle stay aligned.
 
-        Lazy import matches ``runtime_state._known_theme_names``: the module
-        stays free of Pillow at load time, and a broken renderer install
+        Lazy import via :mod:`theme_names` keeps Pillow off the web-server
+        module's load-time import graph, and a broken renderer install
         degrades to the historical pair instead of a 500 that would hide the
         rest of the UI. ``theme_arg`` / ``manual_theme`` / ``effective`` give
         the UI everything it needs to render the dropdown with the current
@@ -510,12 +510,9 @@ class CuratorHandler(BaseHTTPRequestHandler):
         reentrant. The snapshot is a consistent-enough view: effective
         resolution only uses wall time + the snapshotted values.
         """
+        from theme_names import theme_cycle
         ctx = self._ctx()
-        try:
-            from render_quote import THEME_ORDER
-            order = list(THEME_ORDER)
-        except Exception:
-            order = ["default", "dark"]
+        order = list(theme_cycle())
         import run_clock
         now = dt.datetime.now().strftime("%H:%M")
         with ctx.state.lock:


### PR DESCRIPTION
Renderer hot path (per-tick savings, no pixel diff vs assets/contact-sheet.png):

- load_font is now memoized per (normalised_candidates, size). fit_quote
  iterates up to 18 font sizes and calls load_font twice per step → 36
  candidate-chain scans + 36 ImageFont.truetype opens per render were
  reduced to one open per (chain, size). Documented contract: callers
  must not mutate returned font objects (variation pinning is encoded in
  the cache key).

- wrap_styled_text memoizes the per-font space width inside the call.
  draw.textbbox(" ", font=font) was firing once per inter-word position;
  for a 140-char quote across 18 size tries that's ~450 redundant
  measurements collapsed to one per font.

- The TIME_PHRASE_PREFIX regexes used by resolve_display_match are now
  pre-compiled at module scope (longest-first ordering preserved). The
  inline re.compile in tokenize_quote also goes through the shared
  _direct_match_pattern helper.

Telemetry durability:

- append_telemetry now flushes and os.fsyncs before close so a render /
  error / action / backoff entry survives SIGKILL or power loss — exactly
  the events litclock_health uses to distinguish "wedged" from "idle."
- Heartbeats keep the previous unsynced semantics (60s cadence, recoverable
  loss) to bound SD-card write amplification.

Shared theme-name helpers:

- New theme_names.py centralises known_theme_names() and theme_cycle().
  Replaces three near-duplicate lazy-import helpers in runtime_state,
  runtime_theme, runtime_actions (and a fourth ad-hoc copy in web_server)
  whose fallback types had drifted (frozenset vs tuple). Lazy import
  preserved so PIL stays out of the runtime module load graph.

Documentation:

- FOLLOWUPS.md: strike the "subtle field is unused" bullet — verified used
  at render_quote.py:928, 1015, 1158, 1178 (risograph shadow, scholar frame,
  comic underline). Strike the duplicate-helper bullet (resolved here).

Verification:

- ruff clean; 2,295 tests pass.
- contact_sheet.py output is byte-identical to assets/contact-sheet.png.
- New tests assert load_font cache hits/misses, variation-key isolation,
  fsync-on-render and skip-fsync-on-heartbeat behaviour.

https://claude.ai/code/session_01YX6ee2c551bAZAi4uziqVZ