### PR TITLE
Lift coverage on six small modules to 100%

### DIFF
--- a/runtime_actions.py
+++ b/runtime_actions.py
@@ -45,7 +45,7 @@ def _next_theme(current: str) -> str:
     on an unrecognised value.
     """
     order = _theme_cycle()
-    if not order:
+    if not order:  # pragma: no cover - defensive; theme_cycle always returns ≥2 entries
         return current
     try:
         idx = order.index(current)

--- a/runtime_config.py
+++ b/runtime_config.py
@@ -167,7 +167,7 @@ def load_config(
                 )
                 continue
         if kind == "hhmm":
-            if hhmm_validator is None:
+            if hhmm_validator is None:  # pragma: no cover - defensive; run_clock always injects one
                 # Defensive; should not happen because ``run_clock``
                 # always injects one. If it does, keep the string as-is
                 # and let downstream handling catch a bad value.

--- a/runtime_state.py
+++ b/runtime_state.py
@@ -11,7 +11,7 @@ import datetime as dt
 import threading
 from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover - type-checking only
     from threading import Timer
 
 

--- a/tests/test_atomic_io.py
+++ b/tests/test_atomic_io.py
@@ -117,3 +117,14 @@ class TestDirFsyncBestEffort:
     def test_missing_directory_is_ignored(self, tmp_path: Path) -> None:
         # The internal helper should not raise when the directory vanishes.
         atomic_io._fsync_dir(tmp_path / "does-not-exist")
+
+    def test_fsync_failure_is_swallowed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # An OSError from os.fsync (e.g. on a filesystem that doesn't
+        # support it) must not propagate — dir-fsync is best-effort.
+        def exploding_fsync(fd):
+            raise OSError("simulated fsync failure")
+
+        monkeypatch.setattr(os, "fsync", exploding_fsync)
+        atomic_io._fsync_dir(tmp_path)

--- a/tests/test_bucket_coverage.py
+++ b/tests/test_bucket_coverage.py
@@ -181,6 +181,14 @@ class TestLoadRows:
         rows = bc.load_rows(path)
         assert rows[0]["fuzzy_bucket"] == "h3_exact"
 
+    def test_unparseable_normalized_time_preserves_existing_bucket(self, tmp_jsonl):
+        # Has a colon (so we enter the try block) but the parts are not ints —
+        # exercises the ``except (ValueError, KeyError)`` branch in load_rows.
+        row = make_row(normalized_time="ab:cd", fuzzy_bucket="h3_exact")
+        path = tmp_jsonl([row])
+        rows = bc.load_rows(path)
+        assert rows[0]["fuzzy_bucket"] == "h3_exact"
+
 
 class TestMainCLI:
     def test_writes_json_and_markdown(self, tmp_path, tmp_jsonl, monkeypatch, capsys):

--- a/tests/test_theme_names.py
+++ b/tests/test_theme_names.py
@@ -10,6 +10,9 @@ import theme_names
 
 class TestKnownThemeNames:
     def test_returns_render_quote_themes(self) -> None:
+        # The shim is designed to stay importable without Pillow; the
+        # render_quote-path branch obviously can't be exercised without it.
+        pytest.importorskip("PIL")
         from render_quote import THEMES
 
         result = theme_names.known_theme_names()
@@ -25,6 +28,7 @@ class TestKnownThemeNames:
 
 class TestThemeCycle:
     def test_returns_render_quote_order(self) -> None:
+        pytest.importorskip("PIL")
         from render_quote import THEME_ORDER
 
         result = theme_names.theme_cycle()

--- a/tests/test_theme_names.py
+++ b/tests/test_theme_names.py
@@ -1,0 +1,37 @@
+"""Tests for the PIL-free theme-name shim."""
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+import theme_names
+
+
+class TestKnownThemeNames:
+    def test_returns_render_quote_themes(self) -> None:
+        from render_quote import THEMES
+
+        result = theme_names.known_theme_names()
+        assert isinstance(result, frozenset)
+        assert result == frozenset(THEMES.keys())
+
+    def test_falls_back_when_render_quote_unavailable(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """If ``render_quote`` cannot be imported, fall back to the legacy pair."""
+        monkeypatch.setitem(sys.modules, "render_quote", None)
+        result = theme_names.known_theme_names()
+        assert result == frozenset(("default", "dark"))
+
+
+class TestThemeCycle:
+    def test_returns_render_quote_order(self) -> None:
+        from render_quote import THEME_ORDER
+
+        result = theme_names.theme_cycle()
+        assert isinstance(result, tuple)
+        assert result == tuple(THEME_ORDER)
+
+    def test_falls_back_when_render_quote_unavailable(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setitem(sys.modules, "render_quote", None)
+        result = theme_names.theme_cycle()
+        assert result == ("default", "dark")


### PR DESCRIPTION
Six tiny gaps closed:
- theme_names.py 71% → 100%: new test_theme_names.py covers both the
  normal path and the render_quote-import-failed fallback for
  known_theme_names() and theme_cycle().
- atomic_io.py 97% → 100%: cover _fsync_dir's os.fsync OSError-swallow
  branch by monkeypatching os.fsync.
- bucket_coverage.py 98% → 100%: existing "invalid normalized_time" test
  short-circuits on the colon check; add a row whose normalized_time has
  a colon but unparseable parts so the (ValueError, KeyError) handler
  in load_rows actually fires.
- runtime_actions.py 99% → 100%: pragma the empty-cycle defensive
  branch in _next_theme — theme_cycle() always returns ≥2 entries.
- runtime_config.py 97% → 100%: pragma the hhmm_validator-is-None
  defensive branch (run_clock always injects one; the comment already
  said so).
- runtime_state.py 98% → 100%: pragma the TYPE_CHECKING-only Timer
  import.

2338 → 2344 tests, total coverage steady at 96% with 167 → 155
uncovered lines.