### PR TITLE
Add CI status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # LitClock
 
+[![CI](https://github.com/gkoch02/litclock/actions/workflows/ci.yml/badge.svg)](https://github.com/gkoch02/litclock/actions/workflows/ci.yml)
+
 LitClock is a literary clock built from public-domain text. It picks a quote that matches the current fuzzy time bucket, renders it into an 800×480 image, and can push that image to an eInk display such as the Pimoroni Inky Impression 7.3.
 
 ![LitClock render preview](assets/preview.png)


### PR DESCRIPTION
The badge displays the current status of the GitHub Actions CI workflow,
providing quick visibility into test and lint status at a glance.

https://claude.ai/code/session_018aS7WAG1duY8KVoYw24oxt