### PR TITLE
Add --theme random mode: picks a theme at random each time the quote changes

### DIFF
--- a/run_clock.py
+++ b/run_clock.py
@@ -54,6 +54,7 @@ from runtime_theme import (  # noqa: F401  auto_theme_for + _maybe_reset_* re-ex
     _auto_theme_kwargs,
     _maybe_reset_manual_theme_at_midnight,
     auto_theme_for,
+    pick_random_theme,
     resolve_effective_theme,
 )
 
@@ -168,7 +169,7 @@ def parse_args() -> argparse.Namespace:
     ]
     parser.add_argument(
         "--theme",
-        choices=[*_theme_choices, "auto"],
+        choices=[*_theme_choices, "auto", "random"],
         default="default",
         help=(
             "Render theme passed through to render_quote.py. "
@@ -182,7 +183,8 @@ def parse_args() -> argparse.Namespace:
             "'nightvision' (black/green/yellow). 'auto' selects 'dark' between "
             "18:00 and 06:00 and 'default' otherwise — broaden the rotation via "
             "--auto-day-theme / --auto-night-theme. "
-            "Pressing button B cycles themes manually and overrides 'auto' until midnight."
+            "'random' picks a theme at random each time the displayed quote changes. "
+            "Pressing button B cycles themes manually and overrides 'auto'/'random' until midnight."
         ),
     )
     parser.add_argument(
@@ -603,7 +605,9 @@ def _render_unlocked(args: argparse.Namespace, state: RuntimeState, time_str: st
     instead of queuing behind it.
     """
     effective_theme = resolve_effective_theme(
-        state.theme_arg, time_str, state.manual_theme, **_auto_theme_kwargs(args),
+        state.theme_arg, time_str, state.manual_theme,
+        current_random_theme=state.current_random_theme,
+        **_auto_theme_kwargs(args),
     )
     actual_mode = mode or args.mode
     actual_bucket = bucket or bucket_for_time(time_str)
@@ -1283,8 +1287,12 @@ def main() -> int:
         once_state = RuntimeState(args.theme)
         _install_signal_handlers(once_state)
         time_str = current_time_str()
+        if args.theme == "random" and once_state.manual_theme is None:
+            once_state.current_random_theme = pick_random_theme()
         effective_theme = resolve_effective_theme(
-            args.theme, time_str, manual_theme=None, **_auto_theme_kwargs(args),
+            args.theme, time_str, manual_theme=None,
+            current_random_theme=once_state.current_random_theme,
+            **_auto_theme_kwargs(args),
         )
         # Peek before rendering so the ledger entry matches what render_quote picks.
         # Both see the same ledger state because run_clock appends only after render succeeds.
@@ -1331,7 +1339,9 @@ def main() -> int:
         try:
             time_str = current_time_str()
             effective_theme = resolve_effective_theme(
-                args.theme, time_str, state.manual_theme, **_auto_theme_kwargs(args),
+                args.theme, time_str, state.manual_theme,
+                current_random_theme=state.current_random_theme,
+                **_auto_theme_kwargs(args),
             )
             render_now(
                 args.render_script, args.output, args.width, args.height, args.display_script,
@@ -1418,13 +1428,31 @@ def main() -> int:
 
             bucket = current_bucket()
             effective_theme = resolve_effective_theme(
-                state.theme_arg, time_str, state.manual_theme, **_auto_theme_kwargs(args),
+                state.theme_arg, time_str, state.manual_theme,
+                current_random_theme=state.current_random_theme,
+                **_auto_theme_kwargs(args),
             )
             bucket_changed = bucket != state.last_bucket
             theme_changed = effective_theme != state.last_effective_theme and state.last_effective_theme is not None
             if bucket_changed or theme_changed:
                 try:
                     quote_id = peek_quote_id(time_str, history_path=history_path, history_days=args.history_days)
+                    # Random mode: pick a new theme whenever the quote changes (or on first render).
+                    if state.theme_arg == "random" and state.manual_theme is None:
+                        quote_changed = (
+                            (quote_id is not None and quote_id != state.last_quote_id)
+                            or state.current_random_theme is None
+                        )
+                        if quote_changed:
+                            new_rnd = pick_random_theme()
+                            with state.lock:
+                                state.current_random_theme = new_rnd
+                            effective_theme = new_rnd
+                            # Recompute so the dedup check below reflects the new pick.
+                            theme_changed = (
+                                effective_theme != state.last_effective_theme
+                                and state.last_effective_theme is not None
+                            )
                     if quote_id is not None and quote_id == state.last_quote_id and not theme_changed:
                         _log(f"bucket {bucket}: quote unchanged, skipping redraw")
                         # A successful peek that matches the last-rendered quote is still

--- a/run_clock.py
+++ b/run_clock.py
@@ -594,6 +594,28 @@ def render_now(
 _IDENTITY_RENDER_MODES: frozenset[str] = frozenset({"production", "debug"})
 
 
+def _maybe_pick_random_theme(state: RuntimeState, quote_id: tuple | None) -> str | None:
+    """Pick a new random theme when the quote changes in ``--theme random`` mode.
+
+    Returns the newly-chosen theme name when a pick was made (the caller should
+    update ``effective_theme`` and recompute ``theme_changed``), or ``None``
+    when the mode is inactive, a manual override is in effect, or the quote
+    hasn't changed and a theme is already stored.
+    """
+    if state.theme_arg != "random" or state.manual_theme is not None:
+        return None
+    quote_changed = (
+        (quote_id is not None and quote_id != state.last_quote_id)
+        or state.current_random_theme is None
+    )
+    if not quote_changed:
+        return None
+    new_theme = pick_random_theme()
+    with state.lock:
+        state.current_random_theme = new_theme
+    return new_theme
+
+
 def _render_unlocked(args: argparse.Namespace, state: RuntimeState, time_str: str, history_path: str | None,
                      mode: str | None = None, bucket: str | None = None, quote_id: tuple | None = None) -> None:
     """Core render-and-push. The caller MUST already hold ``state.render_lock``.
@@ -1437,22 +1459,14 @@ def main() -> int:
             if bucket_changed or theme_changed:
                 try:
                     quote_id = peek_quote_id(time_str, history_path=history_path, history_days=args.history_days)
-                    # Random mode: pick a new theme whenever the quote changes (or on first render).
-                    if state.theme_arg == "random" and state.manual_theme is None:
-                        quote_changed = (
-                            (quote_id is not None and quote_id != state.last_quote_id)
-                            or state.current_random_theme is None
+                    new_rnd = _maybe_pick_random_theme(state, quote_id)
+                    if new_rnd is not None:
+                        effective_theme = new_rnd
+                        # Recompute so the dedup check below reflects the new pick.
+                        theme_changed = (
+                            effective_theme != state.last_effective_theme
+                            and state.last_effective_theme is not None
                         )
-                        if quote_changed:
-                            new_rnd = pick_random_theme()
-                            with state.lock:
-                                state.current_random_theme = new_rnd
-                            effective_theme = new_rnd
-                            # Recompute so the dedup check below reflects the new pick.
-                            theme_changed = (
-                                effective_theme != state.last_effective_theme
-                                and state.last_effective_theme is not None
-                            )
                     if quote_id is not None and quote_id == state.last_quote_id and not theme_changed:
                         _log(f"bucket {bucket}: quote unchanged, skipping redraw")
                         # A successful peek that matches the last-rendered quote is still

--- a/runtime_actions.py
+++ b/runtime_actions.py
@@ -136,6 +136,7 @@ def action_skip(args: argparse.Namespace, state: RuntimeState, *, label: str = "
             quote_id = run_clock.peek_quote_id(
                 time_str, history_path=history_path, history_days=args.history_days,
             )
+            run_clock._maybe_pick_random_theme(state, quote_id)
             run_clock._render_unlocked(args, state, time_str, history_path, quote_id=quote_id)
             if quote_id is not None:
                 run_clock._append_history_after_render(state, history_path, quote_id)
@@ -178,6 +179,7 @@ def action_unskip(args: argparse.Namespace, state: RuntimeState, *, label: str =
             quote_id = run_clock.peek_quote_id(
                 time_str, history_path=history_path, history_days=args.history_days,
             )
+            run_clock._maybe_pick_random_theme(state, quote_id)
             run_clock._render_unlocked(args, state, time_str, history_path, quote_id=quote_id)
             if quote_id is not None:
                 run_clock._append_history_after_render(state, history_path, quote_id)

--- a/runtime_actions.py
+++ b/runtime_actions.py
@@ -236,7 +236,9 @@ def action_theme(
             previous_theme = state.manual_theme
             time_str = run_clock.current_time_str()
             current = state.last_effective_theme or resolve_effective_theme(
-                state.theme_arg, time_str, previous_theme, **_auto_theme_kwargs(args),
+                state.theme_arg, time_str, previous_theme,
+                current_random_theme=state.current_random_theme,
+                **_auto_theme_kwargs(args),
             )
             new_theme = target if target is not None else _next_theme(current)
             # Guard against "Apply" on an unchanged dropdown selection. The

--- a/runtime_quiet.py
+++ b/runtime_quiet.py
@@ -173,7 +173,9 @@ def enter_quiet(
             # tells render_quote.py to skip pick_quote and paint a centred
             # message instead — no quote, no history append.
             effective_theme = resolve_effective_theme(
-                state.theme_arg, time_str, state.manual_theme, **_auto_theme_kwargs(args),
+                state.theme_arg, time_str, state.manual_theme,
+                current_random_theme=state.current_random_theme,
+                **_auto_theme_kwargs(args),
             )
             with state.render_lock:
                 run_clock.render_now(
@@ -190,7 +192,9 @@ def enter_quiet(
                 )
         else:
             effective_theme = resolve_effective_theme(
-                state.theme_arg, time_str, state.manual_theme, **_auto_theme_kwargs(args),
+                state.theme_arg, time_str, state.manual_theme,
+                current_random_theme=state.current_random_theme,
+                **_auto_theme_kwargs(args),
             )
             with state.render_lock:
                 run_clock.render_now(

--- a/runtime_state.py
+++ b/runtime_state.py
@@ -39,8 +39,12 @@ class RuntimeState:
         # to an effective render theme per-tick via ``resolve_effective_theme``.
         self.theme_arg = theme_arg
         # Button-B / web dropdown override, cleared at midnight when
-        # ``theme_arg == "auto"``. Any registered theme name or ``None``.
+        # ``theme_arg`` is ``"auto"`` or ``"random"``. Any registered theme name or ``None``.
         self.manual_theme: str | None = None
+        # Current theme for ``--theme random``; updated by the main loop when
+        # the displayed quote changes. Not persisted — a restart picks a fresh
+        # random theme on the first render.
+        self.current_random_theme: str | None = None
         self.manual_quiet = False             # toggled by button D
         self.last_bucket: str | None = None
         self.last_quote_id: tuple | None = None

--- a/runtime_state.py
+++ b/runtime_state.py
@@ -35,8 +35,8 @@ class RuntimeState:
         self.ledger_lock = threading.Lock()
         # CLI ``--theme`` value — any registered theme name in
         # ``render_quote.THEMES`` (default/dark/scholar/newsprint/nightvision
-        # at the time of writing) or ``"auto"``. Stored verbatim; resolved
-        # to an effective render theme per-tick via ``resolve_effective_theme``.
+        # at the time of writing), ``"auto"``, or ``"random"``. Stored verbatim;
+        # resolved to an effective render theme per-tick via ``resolve_effective_theme``.
         self.theme_arg = theme_arg
         # Button-B / web dropdown override, cleared at midnight when
         # ``theme_arg`` is ``"auto"`` or ``"random"``. Any registered theme name or ``None``.

--- a/runtime_theme.py
+++ b/runtime_theme.py
@@ -10,6 +10,7 @@ existing call sites and test patches keep resolving.
 from __future__ import annotations
 
 import datetime as dt
+import random
 
 from runtime_log import _log
 from runtime_state import RuntimeState
@@ -54,11 +55,18 @@ def _auto_theme_kwargs(args) -> dict[str, str]:
     }
 
 
+def pick_random_theme() -> str:
+    """Pick a random theme from the registered cycle."""
+    from theme_names import theme_cycle
+    return random.choice(list(theme_cycle()))
+
+
 def resolve_effective_theme(
     theme_arg: str,
     time_str: str,
     manual_theme: str | None,
     *,
+    current_random_theme: str | None = None,
     auto_day_theme: str = "default",
     auto_night_theme: str = "dark",
 ) -> str:
@@ -76,6 +84,11 @@ def resolve_effective_theme(
     """
     if manual_theme is not None and manual_theme in _registered_themes():
         return manual_theme
+    if theme_arg == "random":
+        # current_random_theme is set by the main loop when the quote changes.
+        # Fall back to a fresh pick only when called from --once or startup
+        # (where no main-loop tick has populated the field yet).
+        return current_random_theme if current_random_theme is not None else pick_random_theme()
     if theme_arg == "auto":
         return auto_theme_for(time_str, auto_day_theme, auto_night_theme)
     return theme_arg
@@ -89,7 +102,7 @@ def _maybe_reset_manual_theme_at_midnight(args, state: RuntimeState) -> None:
         if state.last_seen_date is None:
             state.last_seen_date = today
             return
-        if today != state.last_seen_date and state.theme_arg == "auto" and state.manual_theme is not None:
+        if today != state.last_seen_date and state.theme_arg in ("auto", "random") and state.manual_theme is not None:
             _log(f"midnight rollover: clearing manual theme override ({state.manual_theme})")
             state.manual_theme = None
             run_clock.save_runtime_state(args.state_path, state.snapshot_for_persistence())

--- a/tests/test_run_clock.py
+++ b/tests/test_run_clock.py
@@ -3111,6 +3111,131 @@ class TestActionThemeCycle:
                     run_clock.parse_args()
 
 
+class TestRandomThemeMode:
+    """Tests for ``--theme random``: a meta-mode that picks a theme at random
+    each time the displayed quote changes, parallel to ``--theme auto``."""
+
+    def test_pick_random_theme_returns_registered_theme(self):
+        """``pick_random_theme()`` always returns a name from the registered cycle."""
+        from theme_names import theme_cycle
+        valid = set(theme_cycle())
+        for _ in range(30):
+            result = run_clock.pick_random_theme()
+            assert result in valid, f"pick_random_theme() returned {result!r}, not in theme_cycle()"
+
+    def test_resolve_random_uses_current_random_theme(self):
+        """When ``current_random_theme`` is set, ``resolve_effective_theme`` returns it."""
+        result = run_clock.resolve_effective_theme("random", "10:00", None, current_random_theme="scholar")
+        assert result == "scholar"
+
+    def test_resolve_random_manual_override_wins(self):
+        """``manual_theme`` takes priority over the stored random theme."""
+        result = run_clock.resolve_effective_theme("random", "10:00", "dark", current_random_theme="scholar")
+        assert result == "dark"
+
+    def test_resolve_random_fallback_when_none(self):
+        """When ``current_random_theme`` is None, a valid theme is picked on the fly."""
+        from theme_names import theme_cycle
+        result = run_clock.resolve_effective_theme("random", "10:00", None, current_random_theme=None)
+        assert result in set(theme_cycle())
+
+    def test_random_theme_cli_accepted(self):
+        """``--theme random`` is accepted by argparse without raising SystemExit."""
+        with patch("sys.argv", ["run_clock.py", "--theme", "random", "--once"]):
+            try:
+                ns = run_clock.parse_args()
+            except SystemExit:
+                raise AssertionError("--theme random was rejected by argparse")
+            assert ns.theme == "random"
+
+    def test_random_mode_picks_new_theme_on_quote_change(self, tmp_path):
+        """Main loop updates ``state.current_random_theme`` when the quote changes."""
+        state = run_clock.RuntimeState("random")
+        state.last_bucket = "h3_exact"
+        state.last_quote_id = ("111", 10, "old quote", "old match")
+        state.last_effective_theme = "default"
+        state.current_random_theme = "default"
+
+        new_quote_id = ("222", 20, "new quote", "new match")
+        fixed_theme = "scholar"
+
+        with patch("run_clock.pick_random_theme", return_value=fixed_theme), \
+             patch("run_clock.peek_quote_id", return_value=new_quote_id), \
+             patch("run_clock.render_now"), \
+             patch("run_clock._persist_state_after_render"), \
+             patch("run_clock._append_history_after_render"), \
+             patch("run_clock.current_bucket", return_value="h3_five_past"), \
+             patch("run_clock.current_time_str", return_value="03:05"):
+            # Simulate one tick that triggers a re-render
+            bucket = "h3_five_past"
+            time_str = "03:05"
+            effective_theme = run_clock.resolve_effective_theme(
+                state.theme_arg, time_str, state.manual_theme,
+                current_random_theme=state.current_random_theme,
+            )
+            bucket_changed = bucket != state.last_bucket
+            assert bucket_changed
+
+            quote_id = new_quote_id
+            # Apply random pick logic (mirrors main loop)
+            if state.theme_arg == "random" and state.manual_theme is None:
+                quote_changed = (
+                    (quote_id is not None and quote_id != state.last_quote_id)
+                    or state.current_random_theme is None
+                )
+                if quote_changed:
+                    new_rnd = run_clock.pick_random_theme()
+                    with state.lock:
+                        state.current_random_theme = new_rnd
+                    effective_theme = new_rnd
+
+        assert state.current_random_theme == fixed_theme
+        assert effective_theme == fixed_theme
+
+    def test_random_mode_stable_on_same_quote(self, tmp_path):
+        """``state.current_random_theme`` is NOT updated when the quote is unchanged."""
+        state = run_clock.RuntimeState("random")
+        state.last_bucket = "h3_exact"
+        same_quote_id = ("111", 10, "same quote", "same match")
+        state.last_quote_id = same_quote_id
+        state.last_effective_theme = "comic"
+        state.current_random_theme = "comic"
+
+        original_theme = state.current_random_theme
+
+        # Simulate pick logic with same quote_id
+        quote_id = same_quote_id
+        if state.theme_arg == "random" and state.manual_theme is None:
+            quote_changed = (
+                (quote_id is not None and quote_id != state.last_quote_id)
+                or state.current_random_theme is None
+            )
+            if quote_changed:  # should be False
+                with state.lock:
+                    state.current_random_theme = "scholar"
+
+        assert state.current_random_theme == original_theme
+
+    def test_random_mode_midnight_reset_clears_manual_theme(self, tmp_path):
+        """``_maybe_reset_manual_theme_at_midnight`` clears ``manual_theme`` for
+        ``theme_arg="random"``, just like it does for ``theme_arg="auto"``."""
+        import datetime as dt
+        state = run_clock.RuntimeState("random")
+        state.manual_theme = "nightvision"
+        state.last_seen_date = dt.date(2026, 1, 1)
+
+        args = argparse.Namespace(
+            theme="random", state_path=str(tmp_path / "state.json"),
+            auto_day_theme="default", auto_night_theme="dark",
+        )
+        with patch("run_clock.save_runtime_state"), \
+             patch("datetime.date") as mock_date:
+            mock_date.today.return_value = dt.date(2026, 1, 2)
+            run_clock._maybe_reset_manual_theme_at_midnight(args, state)
+
+        assert state.manual_theme is None
+
+
 class TestPressDroppedTelemetry:
     """``_button_render_gate`` emits a ``mode="press_dropped"`` entry when
     the non-blocking ``render_lock.acquire`` fails. One entry per dropped

--- a/tests/test_run_clock.py
+++ b/tests/test_run_clock.py
@@ -3220,6 +3220,55 @@ class TestRandomThemeMode:
 
         assert state.manual_theme is None
 
+    def test_action_skip_picks_new_random_theme(self, tmp_path):
+        """``action_skip`` updates ``state.current_random_theme`` when in random mode."""
+        state = run_clock.RuntimeState("random")
+        state.current_random_theme = "default"
+        state.last_quote_id = ("111", 10, "old", "old match")
+        state.last_effective_theme = "default"
+        new_quote_id = ("222", 20, "new", "new match")
+
+        args = argparse.Namespace(
+            theme="random", history_path="", history_days=7, mode="debug",
+            render_script="render_quote.py", output="output/current.png",
+            width=800, height=480, display_script=None, telemetry_path="",
+            state_path=str(tmp_path / "state.json"),
+            auto_day_theme="default", auto_night_theme="dark",
+        )
+        with patch("run_clock.pick_random_theme", return_value="scholar"), \
+             patch("run_clock.peek_quote_id", return_value=new_quote_id), \
+             patch("run_clock._render_unlocked"), \
+             patch("run_clock._append_history_after_render"):
+            run_clock.action_skip(args, state, label="button A")
+
+        assert state.current_random_theme == "scholar"
+
+    def test_action_unskip_picks_new_random_theme(self, tmp_path):
+        """``action_unskip`` updates ``state.current_random_theme`` when in random mode."""
+        state = run_clock.RuntimeState("random")
+        state.current_random_theme = "comic"
+        state.last_skipped = ("111", 10, "old", "old match")
+        state.last_quote_id = ("111", 10, "old", "old match")
+        state.last_effective_theme = "comic"
+        new_quote_id = ("333", 30, "restored", "restored match")
+
+        args = argparse.Namespace(
+            theme="random", history_path="", history_days=7, mode="debug",
+            render_script="render_quote.py", output="output/current.png",
+            width=800, height=480, display_script=None, telemetry_path="",
+            state_path=str(tmp_path / "state.json"),
+            auto_day_theme="default", auto_night_theme="dark",
+        )
+        with patch("run_clock.pick_random_theme", return_value="nightvision"), \
+             patch("run_clock.peek_quote_id", return_value=new_quote_id), \
+             patch("run_clock._render_unlocked"), \
+             patch("run_clock._append_history_after_render"), \
+             patch("run_clock.pick_quote_module") as mock_pq:
+            mock_pq.remove_last_history_entry.return_value = True
+            run_clock.action_unskip(args, state, label="button A")
+
+        assert state.current_random_theme == "nightvision"
+
 
 class TestPressDroppedTelemetry:
     """``_button_render_gate`` emits a ``mode="press_dropped"`` entry when

--- a/tests/test_run_clock.py
+++ b/tests/test_run_clock.py
@@ -3148,73 +3148,58 @@ class TestRandomThemeMode:
                 raise AssertionError("--theme random was rejected by argparse")
             assert ns.theme == "random"
 
-    def test_random_mode_picks_new_theme_on_quote_change(self, tmp_path):
-        """Main loop updates ``state.current_random_theme`` when the quote changes."""
+    def test_random_mode_picks_new_theme_on_quote_change(self):
+        """``_maybe_pick_random_theme`` updates ``state.current_random_theme``
+        and returns the new theme when the quote changes."""
         state = run_clock.RuntimeState("random")
-        state.last_bucket = "h3_exact"
         state.last_quote_id = ("111", 10, "old quote", "old match")
-        state.last_effective_theme = "default"
         state.current_random_theme = "default"
 
         new_quote_id = ("222", 20, "new quote", "new match")
-        fixed_theme = "scholar"
+        with patch("run_clock.pick_random_theme", return_value="scholar"):
+            result = run_clock._maybe_pick_random_theme(state, new_quote_id)
 
-        with patch("run_clock.pick_random_theme", return_value=fixed_theme), \
-             patch("run_clock.peek_quote_id", return_value=new_quote_id), \
-             patch("run_clock.render_now"), \
-             patch("run_clock._persist_state_after_render"), \
-             patch("run_clock._append_history_after_render"), \
-             patch("run_clock.current_bucket", return_value="h3_five_past"), \
-             patch("run_clock.current_time_str", return_value="03:05"):
-            # Simulate one tick that triggers a re-render
-            bucket = "h3_five_past"
-            time_str = "03:05"
-            effective_theme = run_clock.resolve_effective_theme(
-                state.theme_arg, time_str, state.manual_theme,
-                current_random_theme=state.current_random_theme,
-            )
-            bucket_changed = bucket != state.last_bucket
-            assert bucket_changed
+        assert result == "scholar"
+        assert state.current_random_theme == "scholar"
 
-            quote_id = new_quote_id
-            # Apply random pick logic (mirrors main loop)
-            if state.theme_arg == "random" and state.manual_theme is None:
-                quote_changed = (
-                    (quote_id is not None and quote_id != state.last_quote_id)
-                    or state.current_random_theme is None
-                )
-                if quote_changed:
-                    new_rnd = run_clock.pick_random_theme()
-                    with state.lock:
-                        state.current_random_theme = new_rnd
-                    effective_theme = new_rnd
-
-        assert state.current_random_theme == fixed_theme
-        assert effective_theme == fixed_theme
-
-    def test_random_mode_stable_on_same_quote(self, tmp_path):
-        """``state.current_random_theme`` is NOT updated when the quote is unchanged."""
+    def test_random_mode_stable_on_same_quote(self):
+        """``_maybe_pick_random_theme`` returns None and leaves
+        ``state.current_random_theme`` unchanged when the quote is identical."""
         state = run_clock.RuntimeState("random")
-        state.last_bucket = "h3_exact"
         same_quote_id = ("111", 10, "same quote", "same match")
         state.last_quote_id = same_quote_id
-        state.last_effective_theme = "comic"
         state.current_random_theme = "comic"
 
-        original_theme = state.current_random_theme
+        result = run_clock._maybe_pick_random_theme(state, same_quote_id)
 
-        # Simulate pick logic with same quote_id
-        quote_id = same_quote_id
-        if state.theme_arg == "random" and state.manual_theme is None:
-            quote_changed = (
-                (quote_id is not None and quote_id != state.last_quote_id)
-                or state.current_random_theme is None
-            )
-            if quote_changed:  # should be False
-                with state.lock:
-                    state.current_random_theme = "scholar"
+        assert result is None
+        assert state.current_random_theme == "comic"
 
-        assert state.current_random_theme == original_theme
+    def test_random_mode_picks_on_first_render_when_no_theme_set(self):
+        """``_maybe_pick_random_theme`` picks on first render even when
+        ``quote_id`` matches ``last_quote_id`` (both None / startup)."""
+        state = run_clock.RuntimeState("random")
+        state.last_quote_id = None
+        state.current_random_theme = None  # not yet set
+
+        with patch("run_clock.pick_random_theme", return_value="nightvision"):
+            result = run_clock._maybe_pick_random_theme(state, None)
+
+        assert result == "nightvision"
+        assert state.current_random_theme == "nightvision"
+
+    def test_random_mode_skipped_when_manual_theme_set(self):
+        """``_maybe_pick_random_theme`` is a no-op when ``manual_theme`` is active
+        (button B override pins a specific theme until midnight)."""
+        state = run_clock.RuntimeState("random")
+        state.manual_theme = "dark"
+        state.current_random_theme = "default"
+        state.last_quote_id = ("111", 10, "q", "m")
+
+        result = run_clock._maybe_pick_random_theme(state, ("222", 20, "q2", "m2"))
+
+        assert result is None
+        assert state.current_random_theme == "default"
 
     def test_random_mode_midnight_reset_clears_manual_theme(self, tmp_path):
         """``_maybe_reset_manual_theme_at_midnight`` clears ``manual_theme`` for

--- a/web_server.py
+++ b/web_server.py
@@ -537,7 +537,9 @@ class CuratorHandler(BaseHTTPRequestHandler):
             quote_id = state.last_quote_id
             bucket = state.last_bucket or bucket_for_time(now)
             theme = state.last_effective_theme or run_clock.resolve_effective_theme(
-                state.theme_arg, now, state.manual_theme, **run_clock._auto_theme_kwargs(ctx.args),
+                state.theme_arg, now, state.manual_theme,
+                current_random_theme=state.current_random_theme,
+                **run_clock._auto_theme_kwargs(ctx.args),
             )
             manual_quiet = state.manual_quiet
             manual_theme = state.manual_theme
@@ -890,8 +892,11 @@ class CuratorHandler(BaseHTTPRequestHandler):
             manual = ctx.state.manual_theme
             theme_arg = ctx.state.theme_arg
             last_effective = ctx.state.last_effective_theme
+            current_random = ctx.state.current_random_theme
         effective = last_effective or run_clock.resolve_effective_theme(
-            theme_arg, now, manual, **run_clock._auto_theme_kwargs(ctx.args),
+            theme_arg, now, manual,
+            current_random_theme=current_random,
+            **run_clock._auto_theme_kwargs(ctx.args),
         )
         self._json(HTTPStatus.OK, {
             "themes": order,


### PR DESCRIPTION
Introduces a new meta-mode alongside --theme auto. When --theme random is
active the main loop selects a random theme from the registered cycle on
every quote change and keeps it stable while the same quote is on screen.
Button B still cycles themes manually (leaving random mode until midnight),
midnight reset applies as it does for auto, and --once picks one fresh
theme per invocation.

https://claude.ai/code/session_011n7uzbR8b9jLJRvukG7L5a