### PR TITLE
Show every documented 2-ink recipe in diags swatch band

### DIFF
--- a/render_quote.py
+++ b/render_quote.py
@@ -5096,24 +5096,44 @@ def render_static_message(message: str, width: int, height: int, theme: str = "d
     return snap_image_to_palette(image, SPECTRA6_PALETTE)
 
 
-# Synthesised two-ink stipple recipes documented in CLAUDE.md. Each entry is
-# (display name, dark ink, light ink, light density, short label). The order
-# here drives the bottom swatch row of the diagnostic frame; the four
-# in-use recipes (tangerine / candlelit / mint / coral) are grouped first so
-# they read as the active palette before the reference / unused recipes
-# fanning out to the right.
+# Synthesised two-ink stipple recipes documented in spectra6_color_recipes.md
+# (and summarised in CLAUDE.md). Each entry is (display name, dark ink, light
+# ink, light density, short label). The order here drives the two-row swatch
+# band at the bottom of the diagnostic frame; the four in-use recipes
+# (tangerine / candlelit / mint / coral) lead so they read as the active
+# palette before the reference / unused recipes. ``sage`` follows the doc's
+# "for ratios above 50%, swap dark/light and pass the complementary density"
+# rule (75% white + 25% green → sparse-1-in-4 green on white). ``lime`` uses
+# the same 0.375 biased-Bayer recipe as ``tangerine`` but with the green/yellow
+# pair. The full set covers every two-ink recipe reachable through
+# ``draw_text_dithered`` today — three-ink mixes (lavender, salmon, …) need a
+# ``_three_way_bayer`` primitive that doesn't exist yet.
 _DIAGS_SYNTH_SWATCHES: list[tuple[str, tuple[int, int, int], tuple[int, int, int], float, str]] = [
-    ("tangerine", SPECTRA6["red"], SPECTRA6["yellow"], 0.375, "R+Y 5:3"),
-    ("candlelit", SPECTRA6["red"], SPECTRA6["white"], 0.25, "R+W 3:1"),
-    ("mint",      SPECTRA6["green"], SPECTRA6["white"], 0.5, "G+W 1:1"),
-    ("coral",     SPECTRA6["red"], SPECTRA6["white"], 0.5, "R+W 1:1"),
-    ("amber",     SPECTRA6["red"], SPECTRA6["yellow"], 0.5, "R+Y 1:1"),
-    ("violet",    SPECTRA6["red"], SPECTRA6["blue"], 0.5, "R+B 1:1"),
-    ("sky",       SPECTRA6["blue"], SPECTRA6["white"], 0.5, "B+W 1:1"),
-    ("cyan",      SPECTRA6["green"], SPECTRA6["blue"], 0.5, "G+B 1:1"),
-    ("sepia",     SPECTRA6["red"], SPECTRA6["green"], 0.5, "R+G 1:1"),
-    ("olive",     SPECTRA6["yellow"], SPECTRA6["green"], 0.5, "Y+G 1:1"),
+    # Row 1 — reds / oranges / violets / sepia / cream
+    ("tangerine", SPECTRA6["red"],    SPECTRA6["yellow"], 0.375, "R+Y 5:3"),
+    ("candlelit", SPECTRA6["red"],    SPECTRA6["white"],  0.25,  "R+W 3:1"),
+    ("coral",     SPECTRA6["red"],    SPECTRA6["white"],  0.5,   "R+W 1:1"),
+    ("amber",     SPECTRA6["red"],    SPECTRA6["yellow"], 0.5,   "R+Y 1:1"),
+    ("violet",    SPECTRA6["red"],    SPECTRA6["blue"],   0.5,   "R+B 1:1"),
+    ("maroon",    SPECTRA6["red"],    SPECTRA6["black"],  0.5,   "R+K 1:1"),
+    ("sepia",     SPECTRA6["red"],    SPECTRA6["green"],  0.5,   "R+G 1:1"),
+    ("cream",     SPECTRA6["yellow"], SPECTRA6["white"],  0.5,   "Y+W 1:1"),
+    # Row 2 — greens / blues / neutrals
+    ("mint",      SPECTRA6["green"],  SPECTRA6["white"],  0.5,   "G+W 1:1"),
+    ("sage",      SPECTRA6["white"],  SPECTRA6["green"],  0.25,  "W+G 3:1"),
+    ("olive",     SPECTRA6["yellow"], SPECTRA6["green"],  0.5,   "Y+G 1:1"),
+    ("lime",      SPECTRA6["yellow"], SPECTRA6["green"],  0.375, "Y+G 5:3"),
+    ("forest",    SPECTRA6["green"],  SPECTRA6["black"],  0.5,   "G+K 1:1"),
+    ("cyan",      SPECTRA6["green"],  SPECTRA6["blue"],   0.5,   "G+B 1:1"),
+    ("sky",       SPECTRA6["blue"],   SPECTRA6["white"],  0.5,   "B+W 1:1"),
+    ("navy",      SPECTRA6["blue"],   SPECTRA6["black"],  0.5,   "B+K 1:1"),
+    ("gray",      SPECTRA6["black"],  SPECTRA6["white"],  0.5,   "K+W 1:1"),
 ]
+
+# Number of swatches in the first row of the diags synth band. The list above
+# splits 8 / 9, keeping the in-use recipes left-justified on row 1 and the
+# larger remainder on row 2 so per-swatch widths stay readable (~79 px).
+_DIAGS_SYNTH_ROW1_COUNT = 8
 
 _DIAGS_SPECTRA6_SWATCHES: list[tuple[str, tuple[int, int, int], str]] = [
     ("white",  SPECTRA6["white"],  "#FFFFFF"),
@@ -5351,33 +5371,42 @@ def render_diags_frame(time_str: str, quote_row: dict, width: int, height: int) 
         draw.text((x0 + 5, sw_top + 18), hex_code, font=label_reg, fill=label_fill)
 
     # ----- Bottom section: synthesised stipple swatches -----
-    s2_y = sw_top + sw_h + 18
+    # Two-row band so all 17 documented two-ink recipes fit at a readable
+    # ~79 px swatch width; a single row would compress to ~40 px and clip
+    # the 10 pt "tangerine" / "candlelit" labels.
+    s2_y = sw_top + sw_h + 14
     draw.text((PAD_X, s2_y), "SYNTHESISED (2-INK STIPPLE)", font=section_font, fill=colors["accent"])
 
-    sw2_top = s2_y + 18
-    sw2_color_h = 38
-    sw2_label_h = 28
-    sw2_h = sw2_color_h + sw2_label_h
+    sw2_top = s2_y + 16
+    sw2_color_h = 28
+    sw2_label_h = 22
+    sw2_row_h = sw2_color_h + sw2_label_h
+    sw2_row_gap = 4
     sw2_gap = 5
-    sw2_count = len(_DIAGS_SYNTH_SWATCHES)
-    sw2_w = (avail_w - (sw2_count - 1) * sw2_gap) // sw2_count
+    sw2_row1_count = _DIAGS_SYNTH_ROW1_COUNT
+    sw2_row2_count = len(_DIAGS_SYNTH_SWATCHES) - sw2_row1_count
     for i, (name, dark, light, density, recipe) in enumerate(_DIAGS_SYNTH_SWATCHES):
-        x0 = PAD_X + i * (sw2_w + sw2_gap)
-        x1 = x0 + sw2_w
-        color_y1 = sw2_top + sw2_color_h
-        y1 = sw2_top + sw2_h
+        if i < sw2_row1_count:
+            row_idx, col_idx, row_count = 0, i, sw2_row1_count
+        else:
+            row_idx, col_idx, row_count = 1, i - sw2_row1_count, sw2_row2_count
+        row_w = (avail_w - (row_count - 1) * sw2_gap) // row_count
+        row_top = sw2_top + row_idx * (sw2_row_h + sw2_row_gap)
+        x0 = PAD_X + col_idx * (row_w + sw2_gap)
+        x1 = x0 + row_w
+        color_y1 = row_top + sw2_color_h
         # Paint the full coloured stipple area first; the inset of 1 leaves
         # the outline cleanly visible after the rectangle stroke below.
-        _fill_swatch_stipple(image, (x0 + 1, sw2_top + 1, x1, color_y1), dark, light, density)
-        draw.rectangle((x0, sw2_top, x1, color_y1), outline=colors["text"], width=1)
+        _fill_swatch_stipple(image, (x0 + 1, row_top + 1, x1, color_y1), dark, light, density)
+        draw.rectangle((x0, row_top, x1, color_y1), outline=colors["text"], width=1)
         # Labels go below the coloured cell so the stipple texture stays
         # fully visible — the whole point of the synth swatches is to
         # show how the recipe reads on-panel at this size.
-        draw.text((x0, color_y1 + 3), name, font=label_bold, fill=colors["text"])
-        draw.text((x0, color_y1 + 15), recipe, font=label_reg, fill=colors["subtle"])
+        draw.text((x0, color_y1 + 2), name, font=label_bold, fill=colors["text"])
+        draw.text((x0, color_y1 + 12), recipe, font=label_reg, fill=colors["subtle"])
 
     # ----- Footer: short quote preview + attribution -----
-    quote_y = sw2_top + sw2_h + 8
+    quote_y = sw2_top + 2 * sw2_row_h + sw2_row_gap + 6
     quote_font = load_font(theme_font_candidates("diags", "quote_regular"), size=13)
     preview = (quote_row.get("display_quote") or "").strip()
     preview = normalize_dashes(strip_underscore_emphasis(preview))

--- a/render_quote.py
+++ b/render_quote.py
@@ -5241,16 +5241,94 @@ def _fill_swatch_stipple(
                 px[x, y] = light if BAYER_4x4[y % 4][x % 4] < threshold else dark
 
 
+def _fill_swatch_stipple_3way(
+    image: Image.Image,
+    rect: tuple[int, int, int, int],
+    ink_a: tuple[int, int, int],
+    ink_b: tuple[int, int, int],
+    ink_c: tuple[int, int, int],
+    density_a: float,
+    density_b: float,
+) -> None:
+    """Paint a rectangular region with a 3-ink Bayer stipple.
+
+    Partitions the 4×4 Bayer tile by two thresholds: cells where the tile
+    value is below ``round(density_a * 16)`` get ``ink_a``, cells below
+    ``round((density_a + density_b) * 16)`` get ``ink_b``, the remainder
+    get ``ink_c``. The third density is implicit (``1 − density_a −
+    density_b``). This is the ``_three_way_bayer`` primitive
+    ``spectra6_color_recipes.md`` references as the prerequisite for the
+    documented three-ink recipes (lavender, salmon, plum, …); see that
+    doc's "Three-ink recipes" section for the recipes and their
+    weight splits.
+
+    Clipping semantics match ``_fill_swatch_stipple`` (silently truncate to
+    image bounds so thumbnail-size diags renders don't crash on rects that
+    sit fully below the canvas).
+    """
+    x0, y0, x1, y1 = rect
+    w, h = image.size
+    x0 = max(0, x0)
+    y0 = max(0, y0)
+    x1 = min(w, x1)
+    y1 = min(h, y1)
+    if x1 <= x0 or y1 <= y0:
+        return
+    threshold_a = round(density_a * 16)
+    threshold_b = round((density_a + density_b) * 16)
+    px = image.load()
+    for y in range(y0, y1):
+        for x in range(x0, x1):
+            cell = BAYER_4x4[y % 4][x % 4]
+            if cell < threshold_a:
+                px[x, y] = ink_a
+            elif cell < threshold_b:
+                px[x, y] = ink_b
+            else:
+                px[x, y] = ink_c
+
+
+# Synthesised three-ink stipple recipes documented in
+# ``spectra6_color_recipes.md`` ("Three-ink recipes" section). Each entry is
+# (display name, ink_a, ink_b, ink_c, density_a, density_b, short label).
+# The implicit third density is ``1 - density_a - density_b``. Rendered by
+# the diags frame in two rows of 6 below the two-ink band so an operator
+# can see whether (e.g.) the 1/3-each lavender or the white-heavy lilac
+# actually reads as the named pastel at panel distance.
+_DIAGS_TRIPLE_SWATCHES: list[
+    tuple[str, tuple[int, int, int], tuple[int, int, int], tuple[int, int, int], float, float, str]
+] = [
+    # Pastels (3rd ink = white)
+    ("light orange", SPECTRA6["red"],    SPECTRA6["yellow"], SPECTRA6["white"], 0.40,    0.40,    "R+Y+W 40/40/20"),
+    ("salmon",       SPECTRA6["red"],    SPECTRA6["yellow"], SPECTRA6["white"], 1 / 3,   1 / 3,   "R+Y+W 1:1:1"),
+    ("peach",        SPECTRA6["red"],    SPECTRA6["yellow"], SPECTRA6["white"], 0.30,    0.50,    "R+Y+W 30/50/20"),
+    ("lavender",     SPECTRA6["red"],    SPECTRA6["blue"],   SPECTRA6["white"], 1 / 3,   1 / 3,   "R+B+W 1:1:1"),
+    ("lilac",        SPECTRA6["red"],    SPECTRA6["blue"],   SPECTRA6["white"], 0.25,    0.25,    "R+B+W 25/25/50"),
+    ("seafoam",      SPECTRA6["green"],  SPECTRA6["blue"],   SPECTRA6["white"], 0.40,    0.30,    "G+B+W 40/30/30"),
+    # Pastels continued + deep tones (3rd ink = white or black) + chromatic (no W/K)
+    ("khaki",        SPECTRA6["yellow"], SPECTRA6["green"],  SPECTRA6["white"], 0.40,    0.30,    "Y+G+W 40/30/30"),
+    ("beige",        SPECTRA6["red"],    SPECTRA6["yellow"], SPECTRA6["white"], 0.25,    0.25,    "R+Y+W 25/25/50"),
+    ("plum",         SPECTRA6["red"],    SPECTRA6["blue"],   SPECTRA6["black"], 1 / 3,   1 / 3,   "R+B+K 1:1:1"),
+    ("print sepia",  SPECTRA6["red"],    SPECTRA6["yellow"], SPECTRA6["black"], 0.40,    0.40,    "R+Y+K 40/40/20"),
+    ("burnt orange", SPECTRA6["red"],    SPECTRA6["yellow"], SPECTRA6["green"], 0.50,    0.40,    "R+Y+G 50/40/10"),
+    ("forest-teal",  SPECTRA6["green"],  SPECTRA6["blue"],   SPECTRA6["yellow"], 0.40,   0.40,    "G+B+Y 40/40/20"),
+]
+
+_DIAGS_TRIPLE_ROW1_COUNT = 6
+
+
 def render_diags_frame(time_str: str, quote_row: dict, width: int, height: int) -> Image.Image:
     """Render the diagnostic frame for the ``diags`` theme.
 
     Replaces the literary layout with a status panel: large clock, picker
     metrics (bucket / layout / quality / source / matched phrase), the
-    Spectra 6 native palette, the synthesised two-ink stipple recipes
-    documented in CLAUDE.md, and a one-line quote preview at the bottom.
-    Useful for on-panel calibration ("does ``mint`` actually read green at
-    panel distance?") and for confirming the picker chose what you'd
-    expect.
+    Spectra 6 native palette, and the synthesised two- and three-ink
+    stipple recipes documented in ``spectra6_color_recipes.md``. Useful
+    for on-panel calibration ("does ``mint`` actually read green at panel
+    distance? does ``lavender`` actually read as a pastel violet?") and
+    for confirming the picker chose what you'd expect — the BUCKET /
+    LAYOUT / QUALITY / ID / MATCHED fields in the status table at top
+    carry that confirmation now that the literary footer is gone.
     """
     colors = THEMES["diags"]
     image = Image.new("RGB", (width, height), color=colors["page_bg"])
@@ -5349,11 +5427,11 @@ def render_diags_frame(time_str: str, quote_row: dict, width: int, height: int) 
     label_bold = load_font(META_FONT_BOLD_CANDIDATES, size=10)
     label_reg = load_font(META_FONT_CANDIDATES, size=10)
 
-    s1_y = 192
+    s1_y = 186
     draw.text((PAD_X, s1_y), "SPECTRA 6 NATIVE PALETTE", font=section_font, fill=colors["accent"])
 
-    sw_top = s1_y + 18
-    sw_h = 56
+    sw_top = s1_y + 14
+    sw_h = 36
     sw_gap = 6
     sw_count = len(_DIAGS_SPECTRA6_SWATCHES)
     avail_w = width - 2 * PAD_X
@@ -5370,66 +5448,65 @@ def render_diags_frame(time_str: str, quote_row: dict, width: int, height: int) 
         draw.text((x0 + 5, sw_top + 4), name.upper(), font=label_bold, fill=label_fill)
         draw.text((x0 + 5, sw_top + 18), hex_code, font=label_reg, fill=label_fill)
 
-    # ----- Bottom section: synthesised stipple swatches -----
-    # Two-row band so all 17 documented two-ink recipes fit at a readable
-    # ~79 px swatch width; a single row would compress to ~40 px and clip
-    # the 10 pt "tangerine" / "candlelit" labels.
-    s2_y = sw_top + sw_h + 14
-    draw.text((PAD_X, s2_y), "SYNTHESISED (2-INK STIPPLE)", font=section_font, fill=colors["accent"])
-
-    sw2_top = s2_y + 16
-    sw2_color_h = 28
+    # ----- Synth bands -----
+    # Two-ink: 17 recipes in 2 rows (8 + 9). Three-ink: 12 recipes in 2 rows
+    # (6 + 6). All four rows share the same per-swatch geometry; only the
+    # column count and the painter (2-ink vs 3-ink Bayer partition) change.
+    # Labels are bold-name + faded-recipe, two 9 pt lines. The four rows
+    # plus their two section headers are the lower half of the frame —
+    # the literary footer (quote preview + attribution) was dropped to make
+    # room. The status table at top already carries the diagnostic info
+    # (BUCKET / LAYOUT / QUALITY / ID / MATCHED) that footer surfaced.
+    label_bold_9 = load_font(META_FONT_BOLD_CANDIDATES, size=9)
+    label_reg_9 = load_font(META_FONT_CANDIDATES, size=9)
+    sw2_color_h = 22
     sw2_label_h = 22
     sw2_row_h = sw2_color_h + sw2_label_h
-    sw2_row_gap = 4
+    sw2_row_gap = 3
     sw2_gap = 5
-    sw2_row1_count = _DIAGS_SYNTH_ROW1_COUNT
-    sw2_row2_count = len(_DIAGS_SYNTH_SWATCHES) - sw2_row1_count
-    for i, (name, dark, light, density, recipe) in enumerate(_DIAGS_SYNTH_SWATCHES):
-        if i < sw2_row1_count:
-            row_idx, col_idx, row_count = 0, i, sw2_row1_count
-        else:
-            row_idx, col_idx, row_count = 1, i - sw2_row1_count, sw2_row2_count
-        row_w = (avail_w - (row_count - 1) * sw2_gap) // row_count
-        row_top = sw2_top + row_idx * (sw2_row_h + sw2_row_gap)
-        x0 = PAD_X + col_idx * (row_w + sw2_gap)
-        x1 = x0 + row_w
-        color_y1 = row_top + sw2_color_h
-        # Paint the full coloured stipple area first; the inset of 1 leaves
-        # the outline cleanly visible after the rectangle stroke below.
-        _fill_swatch_stipple(image, (x0 + 1, row_top + 1, x1, color_y1), dark, light, density)
-        draw.rectangle((x0, row_top, x1, color_y1), outline=colors["text"], width=1)
-        # Labels go below the coloured cell so the stipple texture stays
-        # fully visible — the whole point of the synth swatches is to
-        # show how the recipe reads on-panel at this size.
-        draw.text((x0, color_y1 + 2), name, font=label_bold, fill=colors["text"])
-        draw.text((x0, color_y1 + 12), recipe, font=label_reg, fill=colors["subtle"])
 
-    # ----- Footer: short quote preview + attribution -----
-    quote_y = sw2_top + 2 * sw2_row_h + sw2_row_gap + 6
-    quote_font = load_font(theme_font_candidates("diags", "quote_regular"), size=13)
-    preview = (quote_row.get("display_quote") or "").strip()
-    preview = normalize_dashes(strip_underscore_emphasis(preview))
-    if len(preview) > 130:
-        preview = preview[:128].rstrip() + "…"
-    if preview:
-        preview = "“" + preview + "”"
-        lines = wrap_text(draw, preview, quote_font, width - 2 * PAD_X)[:1]
-        for line in lines:
-            draw.text((PAD_X, quote_y), line, font=quote_font, fill=colors["text"])
-            quote_y += 16
+    def _paint_synth_row(row_top: int, entries: list, painter) -> None:
+        n = len(entries)
+        row_w = (avail_w - (n - 1) * sw2_gap) // n
+        for col_idx, entry in enumerate(entries):
+            x0 = PAD_X + col_idx * (row_w + sw2_gap)
+            x1 = x0 + row_w
+            color_y1 = row_top + sw2_color_h
+            # Paint the full coloured stipple area first; the inset of 1 leaves
+            # the outline cleanly visible after the rectangle stroke below.
+            painter(entry, (x0 + 1, row_top + 1, x1, color_y1))
+            draw.rectangle((x0, row_top, x1, color_y1), outline=colors["text"], width=1)
+            name = entry[0]
+            recipe = entry[-1]
+            draw.text((x0, color_y1 + 2), name, font=label_bold_9, fill=colors["text"])
+            draw.text((x0, color_y1 + 12), recipe, font=label_reg_9, fill=colors["subtle"])
 
-    author_text = (quote_row.get("author") or "").strip()
-    title_text = (quote_row.get("title") or "").strip()
-    attrib_parts = [p for p in (author_text, title_text) if p]
-    if attrib_parts:
-        attrib_font = load_font(META_FONT_BOLD_CANDIDATES, size=12)
-        attrib = "— " + " · ".join(attrib_parts)
-        bbox = draw.textbbox((0, 0), attrib, font=attrib_font)
-        if bbox[2] - bbox[0] > width - 2 * PAD_X:
-            # Truncate the longer of the two parts so the line fits.
-            attrib = attrib[: max(1, len(attrib) - (bbox[2] - bbox[0] - (width - 2 * PAD_X)) // 6)] + "…"
-        draw.text((PAD_X, quote_y), attrib, font=attrib_font, fill=colors["accent"])
+    def _two_ink_painter(entry, rect):
+        _name, dark, light, density, _recipe = entry
+        _fill_swatch_stipple(image, rect, dark, light, density)
+
+    def _three_ink_painter(entry, rect):
+        _name, ink_a, ink_b, ink_c, density_a, density_b, _recipe = entry
+        _fill_swatch_stipple_3way(image, rect, ink_a, ink_b, ink_c, density_a, density_b)
+
+    # ----- Two-ink synth band -----
+    s2_y = sw_top + sw_h + 8
+    draw.text((PAD_X, s2_y), "SYNTHESISED (2-INK STIPPLE)", font=section_font, fill=colors["accent"])
+    sw2_top = s2_y + 14
+    sw2_row1 = _DIAGS_SYNTH_SWATCHES[:_DIAGS_SYNTH_ROW1_COUNT]
+    sw2_row2 = _DIAGS_SYNTH_SWATCHES[_DIAGS_SYNTH_ROW1_COUNT:]
+    _paint_synth_row(sw2_top, sw2_row1, _two_ink_painter)
+    _paint_synth_row(sw2_top + sw2_row_h + sw2_row_gap, sw2_row2, _two_ink_painter)
+
+    # ----- Three-ink synth band -----
+    sw2_band_end = sw2_top + 2 * sw2_row_h + sw2_row_gap
+    s3_y = sw2_band_end + 6
+    draw.text((PAD_X, s3_y), "SYNTHESISED (3-INK STIPPLE)", font=section_font, fill=colors["accent"])
+    sw3_top = s3_y + 14
+    sw3_row1 = _DIAGS_TRIPLE_SWATCHES[:_DIAGS_TRIPLE_ROW1_COUNT]
+    sw3_row2 = _DIAGS_TRIPLE_SWATCHES[_DIAGS_TRIPLE_ROW1_COUNT:]
+    _paint_synth_row(sw3_top, sw3_row1, _three_ink_painter)
+    _paint_synth_row(sw3_top + sw2_row_h + sw2_row_gap, sw3_row2, _three_ink_painter)
 
     return snap_image_to_palette(image, SPECTRA6_PALETTE)
 

--- a/spectra6_color_recipes.md
+++ b/spectra6_color_recipes.md
@@ -78,9 +78,11 @@ Single combined catalogue: recipes the codebase pulls today plus the unused-but-
 | Cream | yellow + white at 1/2 : 1/2 | `dark=yellow, light=white` | — | Warm off-white for parchment / vellum themes. Forward reference. |
 | Gray (50/50) | black + white at 1/2 : 1/2 | `dark=black, light=white` | — | Frans-Willem. The renderer typically uses solid black or solid white directly rather than gray stipple, but listed here for completeness — a forward reference for an "engineering monochrome" theme that wants a softer body fill. |
 
-## Three-ink recipes — forward references only
+## Three-ink recipes
 
-**Not yet supported by `draw_text_dithered`.** Every recipe below would need a new primitive — a `_three_way_bayer` helper that partitions the 4×4 Bayer tile into three regions by threshold (e.g. tile cell `< 6` → ink A, `6..10` → ink B, `>= 11` → ink C — a 6/5/5 cell split for an even mix, biased cell counts for asymmetric ratios). The existing infrastructure handles the two-ink case only.
+**`render_quote._fill_swatch_stipple_3way`** is the implemented primitive — partitions the 4×4 Bayer tile into three regions by threshold (cells `< round(density_a * 16)` → ink A, cells `< round((density_a + density_b) * 16)` → ink B, the remainder → ink C). The implicit third density is `1 − density_a − density_b`. It powers the diags theme's 3-ink swatch band (`_DIAGS_TRIPLE_SWATCHES`) so an operator can hold the panel and verify whether (e.g.) the 1/3-each lavender or the white-heavy lilac actually reads as the named pastel at panel distance.
+
+`draw_text_dithered` itself (the glyph-mask painter) still operates on two inks only. A theme that wants to paint *text* in a three-ink recipe — rather than a swatch fill or decorative graphic — needs to extend `draw_text_dithered` with a similar 3-way Bayer branch, or composite via two `draw_text_dithered` passes onto a `_fill_swatch_stipple_3way`-painted background. For decorative graphics and swatch fills the primitive below is the entry point today.
 
 Recipes are grouped by *which pole of the octahedron* the third ink contributes — pastels (white-lifted), deep tones (black-darkened), and chromatic mixes (no W/K, all three inks equatorial). The luminance-asymmetry rule from the two-ink section still applies: when one of the three inks is yellow or white, bias the cell-count partition away from it or the brighter ink will dominate.
 
@@ -115,7 +117,7 @@ Recipes are grouped by *which pole of the octahedron* the third ink contributes 
 | Burnt orange / terracotta | red + yellow + green @ 50 / 40 / 10 | The green dulls tangerine into terracotta. Future desert / canyon theme. |
 | Forest-teal | green + blue + yellow @ 40 / 40 / 20 | Cyan dragged toward olive — denser than seafoam, for a deep-forest theme. |
 
-Anyone adding the three-ink primitive should add a sweep test similar to the existing `TestDrawTextDithered::test_<ratio>_split` family pinning the per-region pixel counts within `±2%` tolerance on a fixed sample tile.
+`TestFillSwatchStipple3way::test_partition_ratios` (in `tests/test_render_quote.py`) sweeps the five density splits used by the diags swatch band and pins each region's pixel count within `±2%` tolerance on a fixed 32×32 sample tile — extend it when adding a new recipe whose density split isn't already covered.
 
 ## Four-ink recipes — narrower edge
 

--- a/tests/test_render_quote.py
+++ b/tests/test_render_quote.py
@@ -2064,9 +2064,9 @@ class TestDiagsSynthSwatches:
         assert row2 == 9
 
     def test_both_rows_paint_non_background_pixels(self):
-        # Full-canvas render: both swatch rows must actually paint, so a
-        # broken row-splitting loop (e.g. wrong index arithmetic) trips a
-        # visible regression rather than silently leaving row 2 blank.
+        # Full-canvas render: both two-ink swatch rows must actually paint,
+        # so a broken row-splitting loop (e.g. wrong index arithmetic) trips
+        # a visible regression rather than silently leaving row 2 blank.
         row = {
             "display_quote": "A test quote.",
             "matched_text": "midnight",
@@ -2078,14 +2078,164 @@ class TestDiagsSynthSwatches:
         img = rq.render_diags_frame("12:00", row, 800, 480)
         assert img.size == (800, 480)
         page_bg = rq.THEMES["diags"]["page_bg"]
-        # Sample a pixel near the middle of each row's coloured band. The
-        # synth section sits below the SPECTRA 6 native palette; row 1 is
-        # ~y=320 and row 2 is ~y=370 in the current layout. Use a small
-        # tolerance band around those midpoints.
-        for y_sample in (320, 374):
+        # Sample a pixel near the middle of each row's coloured band. With
+        # the four-row layout (2-ink × 2 + 3-ink × 2) the 2-ink rows sit
+        # roughly at y=280 (row 1) and y=327 (row 2).
+        for y_sample in (280, 327):
             sampled = {img.getpixel((x, y_sample)) for x in range(50, 750, 50)}
             non_bg = {px for px in sampled if px != page_bg}
-            assert non_bg, f"row at y={y_sample} painted no non-background pixels"
+            assert non_bg, f"2-ink row at y={y_sample} painted no non-background pixels"
+
+
+class TestDiagsTripleSwatches:
+    """The diags theme's 3-ink stipple band must cover every three-ink
+    recipe ``spectra6_color_recipes.md`` lists as documented (pastels,
+    deep tones, chromatic mixes — minus the maroon/navy/rich-black 2-ink
+    rows that live in the deep-tones section but are 2-ink in practice).
+    """
+
+    _EXPECTED_TRIPLES: frozenset[str] = frozenset(
+        {
+            # Pastels (3rd ink = white)
+            "light orange",
+            "salmon",
+            "peach",
+            "lavender",
+            "lilac",
+            "seafoam",
+            "khaki",
+            "beige",
+            # Deep tones (3rd ink = black)
+            "plum",
+            "print sepia",
+            # Chromatic (no white or black)
+            "burnt orange",
+            "forest-teal",
+        }
+    )
+
+    def test_triple_list_matches_documented_recipes(self):
+        names = {entry[0] for entry in rq._DIAGS_TRIPLE_SWATCHES}
+        assert names == self._EXPECTED_TRIPLES, (
+            "diags triple swatch list drifted from spectra6_color_recipes.md — "
+            f"missing: {self._EXPECTED_TRIPLES - names}; extra: {names - self._EXPECTED_TRIPLES}"
+        )
+
+    def test_triple_count_matches_row_split(self):
+        # Two rows of six. Guard against a future edit that grows the list
+        # without rebalancing.
+        assert len(rq._DIAGS_TRIPLE_SWATCHES) == 12
+        assert rq._DIAGS_TRIPLE_ROW1_COUNT == 6
+        row2 = len(rq._DIAGS_TRIPLE_SWATCHES) - rq._DIAGS_TRIPLE_ROW1_COUNT
+        assert row2 == 6
+
+    def test_densities_are_valid(self):
+        # Each entry's (density_a + density_b) must sit in [0, 1) so that
+        # ink_c gets a non-empty cell partition. The implicit third density
+        # is 1 - density_a - density_b.
+        for entry in rq._DIAGS_TRIPLE_SWATCHES:
+            name, _ink_a, _ink_b, _ink_c, density_a, density_b, _recipe = entry
+            total = density_a + density_b
+            assert 0 <= density_a <= 1, f"{name}: density_a={density_a} out of range"
+            assert 0 <= density_b <= 1, f"{name}: density_b={density_b} out of range"
+            assert total < 1, f"{name}: density_a+density_b={total} leaves no room for ink_c"
+
+    def test_three_ink_rows_paint_non_background_pixels(self):
+        # Full-canvas render: both 3-ink rows must actually paint so a
+        # broken loop or off-by-one row index trips a visible regression.
+        row = {
+            "display_quote": "A test quote.",
+            "matched_text": "midnight",
+            "bucket": "h12_exact",
+            "quality_score": 80,
+            "source_id": "1",
+            "line_number": 1,
+        }
+        img = rq.render_diags_frame("12:00", row, 800, 480)
+        page_bg = rq.THEMES["diags"]["page_bg"]
+        # 3-ink rows sit roughly at y=391 (row 1) and y=438 (row 2).
+        for y_sample in (391, 438):
+            sampled = {img.getpixel((x, y_sample)) for x in range(50, 750, 50)}
+            non_bg = {px for px in sampled if px != page_bg}
+            assert non_bg, f"3-ink row at y={y_sample} painted no non-background pixels"
+
+
+class TestFillSwatchStipple3way:
+    """``_fill_swatch_stipple_3way`` is the new ``_three_way_bayer``
+    primitive ``spectra6_color_recipes.md`` references as the
+    prerequisite for the documented three-ink recipes. The ratio sweep
+    below pins the per-region pixel counts within ±2% tolerance on a
+    fixed 32×32 sample tile, matching the discipline the doc asks for
+    when introducing the primitive.
+    """
+
+    _INK_A: tuple[int, int, int] = (255, 0, 0)
+    _INK_B: tuple[int, int, int] = (0, 255, 0)
+    _INK_C: tuple[int, int, int] = (0, 0, 255)
+    _BG: tuple[int, int, int] = (1, 2, 3)
+
+    @classmethod
+    def _counts(cls, image):
+        pixels = list(image.getdata())
+        return {
+            "a": pixels.count(cls._INK_A),
+            "b": pixels.count(cls._INK_B),
+            "c": pixels.count(cls._INK_C),
+        }
+
+    @pytest.mark.parametrize(
+        "density_a, density_b, expected_ratios",
+        [
+            # Even mix: 5/6/5 cell split (round(0.333*16)=5,
+            # round(0.667*16)=11, so middle region is cells 5..10 = 6 cells)
+            (1 / 3, 1 / 3, (5 / 16, 6 / 16, 5 / 16)),
+            # 40/40/20 — pastels and print sepia
+            (0.40, 0.40, (6 / 16, 7 / 16, 3 / 16)),
+            # 50/40/10 — burnt orange
+            (0.50, 0.40, (8 / 16, 6 / 16, 2 / 16)),
+            # 25/25/50 — lilac, beige
+            (0.25, 0.25, (4 / 16, 4 / 16, 8 / 16)),
+            # 30/50/20 — peach
+            (0.30, 0.50, (5 / 16, 8 / 16, 3 / 16)),
+        ],
+    )
+    def test_partition_ratios(self, density_a, density_b, expected_ratios):
+        # 32×32 tile is a clean multiple of the 4×4 Bayer matrix, so the
+        # pixel counts settle exactly on the partition boundaries — no
+        # remainder noise to absorb in the tolerance.
+        image = Image.new("RGB", (32, 32), self._BG)
+        rq._fill_swatch_stipple_3way(
+            image,
+            (0, 0, 32, 32),
+            self._INK_A,
+            self._INK_B,
+            self._INK_C,
+            density_a,
+            density_b,
+        )
+        counts = self._counts(image)
+        total = sum(counts.values())
+        assert total == 32 * 32, "primitive failed to cover the rect"
+        ratios = (counts["a"] / total, counts["b"] / total, counts["c"] / total)
+        for got, want in zip(ratios, expected_ratios):
+            assert abs(got - want) <= 0.02, f"ratio {got:.3f} drifted from {want:.3f}"
+
+    def test_clips_rect_to_image_bounds(self):
+        # Same clipping defence as the 2-ink primitive — out-of-bounds
+        # rect must not raise on the diags thumbnail (320×192) where the
+        # 3-ink band lives below the visible canvas.
+        image = Image.new("RGB", (320, 192), self._BG)
+        rq._fill_swatch_stipple_3way(
+            image,
+            (10, 300, 60, 340),
+            self._INK_A,
+            self._INK_B,
+            self._INK_C,
+            0.4,
+            0.3,
+        )
+        # Untouched: every pixel still the sentinel background.
+        assert image.getextrema() == ((1, 1), (2, 2), (3, 3))
 
 
 class TestDrawTextDithered:

--- a/tests/test_render_quote.py
+++ b/tests/test_render_quote.py
@@ -2011,6 +2011,83 @@ class TestFillSwatchStippleClipping:
         assert img.size == (320, 192)
 
 
+class TestDiagsSynthSwatches:
+    """The diags theme's synth swatch band is the on-panel visual reference
+    for the two-ink recipes documented in ``spectra6_color_recipes.md``.
+    The doc and the swatch list must stay in sync — if someone adds a new
+    reachable two-ink recipe to the doc, the operator should see it on the
+    panel; if someone drops a recipe from the swatch list, this test fails
+    loudly so the omission is intentional rather than accidental.
+    """
+
+    # Every two-ink recipe the doc lists as reachable via
+    # ``draw_text_dithered`` today. Mirrors the catalogue in
+    # ``spectra6_color_recipes.md`` (two-ink table + the maroon/navy rows
+    # the "Deep tones" section flags as 2-ink in practice).
+    _EXPECTED_RECIPES: frozenset[str] = frozenset(
+        {
+            "tangerine",
+            "amber",
+            "coral",
+            "candlelit",
+            "mint",
+            "sage",
+            "cyan",
+            "sky",
+            "violet",
+            "sepia",
+            "forest",
+            "olive",
+            "lime",
+            "cream",
+            "gray",
+            "maroon",
+            "navy",
+        }
+    )
+
+    def test_swatch_list_has_every_documented_recipe(self):
+        names = {entry[0] for entry in rq._DIAGS_SYNTH_SWATCHES}
+        assert names == self._EXPECTED_RECIPES, (
+            "diags synth swatch list drifted from spectra6_color_recipes.md — "
+            f"missing: {self._EXPECTED_RECIPES - names}; extra: {names - self._EXPECTED_RECIPES}"
+        )
+
+    def test_swatch_count_matches_row_split(self):
+        # Two-row layout: row 1 holds _DIAGS_SYNTH_ROW1_COUNT entries, row 2
+        # holds the remainder. Guard against a future edit that grows the
+        # list without rebalancing the row counts (which would silently
+        # shrink row-1 swatches and overflow row-2 onto a third row).
+        assert len(rq._DIAGS_SYNTH_SWATCHES) == 17
+        assert rq._DIAGS_SYNTH_ROW1_COUNT == 8
+        row2 = len(rq._DIAGS_SYNTH_SWATCHES) - rq._DIAGS_SYNTH_ROW1_COUNT
+        assert row2 == 9
+
+    def test_both_rows_paint_non_background_pixels(self):
+        # Full-canvas render: both swatch rows must actually paint, so a
+        # broken row-splitting loop (e.g. wrong index arithmetic) trips a
+        # visible regression rather than silently leaving row 2 blank.
+        row = {
+            "display_quote": "A test quote.",
+            "matched_text": "midnight",
+            "bucket": "h12_exact",
+            "quality_score": 80,
+            "source_id": "1",
+            "line_number": 1,
+        }
+        img = rq.render_diags_frame("12:00", row, 800, 480)
+        assert img.size == (800, 480)
+        page_bg = rq.THEMES["diags"]["page_bg"]
+        # Sample a pixel near the middle of each row's coloured band. The
+        # synth section sits below the SPECTRA 6 native palette; row 1 is
+        # ~y=320 and row 2 is ~y=370 in the current layout. Use a small
+        # tolerance band around those midpoints.
+        for y_sample in (320, 374):
+            sampled = {img.getpixel((x, y_sample)) for x in range(50, 750, 50)}
+            non_bg = {px for px in sampled if px != page_bg}
+            assert non_bg, f"row at y={y_sample} painted no non-background pixels"
+
+
 class TestDrawTextDithered:
     """The deco theme's red-biased orange added a third density branch
     (4×4 Bayer at arbitrary thresholds) to ``draw_text_dithered``.


### PR DESCRIPTION
The diags theme's stipple band only displayed 10 of the 17 two-ink
recipes catalogued in spectra6_color_recipes.md, defeating its purpose
as the on-panel calibration reference for the recipes a future theme
might want to pull. Extend _DIAGS_SYNTH_SWATCHES with the seven missing
entries (sage, forest, lime, cream, gray, maroon, navy) and lay the
band out as two rows so per-swatch widths stay readable.