### PR TITLE
Add Idle Hours wordmark banner to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="idle_hours/assets/logo.svg" alt="Idle Hours" width="800">
+</p>
+
 # Idle Hours
 
 [![CI](https://github.com/gkoch02/idle-hours/actions/workflows/ci.yml/badge.svg)](https://github.com/gkoch02/idle-hours/actions/workflows/ci.yml)

--- a/idle_hours/assets/logo.svg
+++ b/idle_hours/assets/logo.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg"
+     viewBox="0 0 1600 400"
+     preserveAspectRatio="xMidYMid meet"
+     role="img"
+     aria-labelledby="idle-hours-logo-title">
+  <title id="idle-hours-logo-title">Idle Hours — a literary clock</title>
+
+  <rect width="1600" height="400" fill="#ffffff"/>
+
+  <text x="800" y="210"
+        text-anchor="middle"
+        font-family="'Playfair Display', 'EB Garamond', Georgia, 'Times New Roman', serif"
+        font-weight="700"
+        font-size="200"
+        letter-spacing="-2"
+        fill="#000000">Idle Hours</text>
+
+  <line x1="520" y1="260" x2="1068" y2="260"
+        stroke="#000000" stroke-width="1.5"/>
+  <rect x="1068" y="254" width="12" height="12" fill="#ff0000"/>
+
+  <text x="800" y="320"
+        text-anchor="middle"
+        font-family="'Playfair Display', 'EB Garamond', Georgia, 'Times New Roman', serif"
+        font-weight="400"
+        font-size="40"
+        fill="#000000">A literary clock for <tspan font-weight="700" fill="#ff0000">every idle hour</tspan>.</text>
+</svg>


### PR DESCRIPTION
Hand-authored 1600×400 SVG in the Spectra 6 palette and default-theme
Playfair Display register, surfaced above the H1. Mirrors the
renderer's matched-time-phrase treatment by painting "every idle hour"
in red bold inside the tagline, and uses the swiss theme's signature
hairline-rule-plus-red-square anchor as the only ornament so the
banner reads as a real product render rather than a competing graphic.

https://claude.ai/code/session_01BAQMuWiGXUhrfJovFRTk4f