### PR TITLE
Eliminate redundant work in render + pick hot paths

### DIFF
--- a/idle_hours/pick_quote.py
+++ b/idle_hours/pick_quote.py
@@ -618,16 +618,24 @@ def pick_best(
         # fall back to the full candidate list so a sparse bucket still renders.
         fresh = [row for row in candidates if _row_history_key(row) not in recent] if recent else candidates
         pool = fresh or candidates
-        pool.sort(key=lambda row: score_row(row, candidate_bucket, overrides, requested_time, source_counts))
-        top_score = score_row(pool[0], candidate_bucket, overrides, requested_time, source_counts)
-        top = [row for row in pool if score_row(row, candidate_bucket, overrides, requested_time, source_counts) == top_score]
+        # score_row is pure, so compute each candidate's score once and derive
+        # the sort, the top-score filter, and the ranked view from it rather
+        # than re-scoring 3-4× per row on this per-tick path. A stable sort over
+        # the precomputed keys preserves pool order, so the seeded choice below
+        # stays byte-identical to the prior repeated-score_row implementation.
+        scored = sorted(
+            (
+                (score_row(row, candidate_bucket, overrides, requested_time, source_counts), row)
+                for row in pool
+            ),
+            key=lambda sr: sr[0],
+        )
+        top_score = scored[0][0]
+        top = [row for score, row in scored if score == top_score]
         rng = random.Random(seed)
         chosen = rng.choice(top)
         if return_ranked:
-            ranked = [
-                {"row": row, "score": score_row(row, candidate_bucket, overrides, requested_time, source_counts)}
-                for row in pool
-            ]
+            ranked = [{"row": row, "score": score} for score, row in scored]
             return chosen, candidate_bucket, ranked
         return chosen, candidate_bucket
     raise SystemExit(f"No candidates found for bucket {bucket} or nearby buckets above quality {min_quality}")

--- a/idle_hours/render_quote.py
+++ b/idle_hours/render_quote.py
@@ -2866,11 +2866,19 @@ def draw_faux_gray_text(image: Image.Image, xy, text, font, dark=(0, 0, 0), ligh
     mask = Image.new("L", image.size, 0)
     mask_draw = ImageDraw.Draw(mask)
     mask_draw.text(xy, text, font=font, fill=255)
+    # Only the glyph region is non-zero; bounding the scan to it (like
+    # draw_text_dithered) keeps cost proportional to the inked area instead
+    # of re-reading all 800×480 pixels per call. Pixels outside the bbox are
+    # zero and were never written, so output is byte-identical.
+    bbox = mask.getbbox()
+    if bbox is None:
+        return
+    x0, y0, x1, y1 = bbox
     px = image.load()
     mx = mask.load()
     ox, oy = pattern_offset
-    for y in range(image.height):
-        for x in range(image.width):
+    for y in range(y0, y1):
+        for x in range(x0, x1):
             if mx[x, y]:
                 px[x, y] = dark if ((x + ox) + (y + oy)) % 2 == 0 else light
 
@@ -2902,13 +2910,18 @@ def draw_faux_3way_text(
     mask = Image.new("L", image.size, 0)
     mask_draw = ImageDraw.Draw(mask)
     mask_draw.text(xy, text, font=font, fill=255)
+    # Bound the scan to the inked glyph region (see draw_faux_gray_text).
+    bbox = mask.getbbox()
+    if bbox is None:
+        return
+    bx0, by0, bx1, by1 = bbox
     px = image.load()
     mx = mask.load()
     ox, oy = pattern_offset
     threshold_a = round(density_a * 16)
     threshold_b = round((density_a + density_b) * 16)
-    for y in range(image.height):
-        for x in range(image.width):
+    for y in range(by0, by1):
+        for x in range(bx0, bx1):
             if mx[x, y]:
                 tile = BAYER_4x4[(y + oy) % 4][(x + ox) % 4]
                 if tile < threshold_a:
@@ -10747,13 +10760,21 @@ def snap_image_to_palette(image: Image.Image, palette: list[tuple[int, int, int]
     snapped = Image.new("RGB", image.size)
     src = image.load()
     dst = snapped.load()
+    # Rendered frames carry only a handful of distinct colours (the palette is
+    # small and theme post-passes already land on-palette), so memoise the
+    # nearest-colour lookup per unique source pixel instead of running the
+    # min()-over-6 distance search 384k times. Byte-identical output.
+    cache: dict = {}
     for y in range(image.height):
         for x in range(image.width):
             pixel = src[x, y]
-            nearest = min(
-                palette,
-                key=lambda c: (pixel[0] - c[0]) ** 2 + (pixel[1] - c[1]) ** 2 + (pixel[2] - c[2]) ** 2,
-            )
+            nearest = cache.get(pixel)
+            if nearest is None:
+                nearest = min(
+                    palette,
+                    key=lambda c: (pixel[0] - c[0]) ** 2 + (pixel[1] - c[1]) ** 2 + (pixel[2] - c[2]) ** 2,
+                )
+                cache[pixel] = nearest
             dst[x, y] = nearest
     return snapped
 


### PR DESCRIPTION
Three byte-identical efficiency fixes to the per-frame render path and the
per-tick quote picker. Output is unchanged (golden-image, scorer-property,
and bake-equivalence suites all pass) — only the amount of work changes.

- snap_image_to_palette: memoize the nearest-palette lookup per unique
  source colour. Rendered frames carry only a handful of distinct colours,
  so the min()-over-6 distance search no longer runs 384k times per frame.
  Measured 6.5x faster (639ms -> ~97ms) across production and debug modes.

- draw_faux_gray_text / draw_faux_3way_text: bound the per-pixel stipple
  loop to the inked glyph bbox via mask.getbbox(), mirroring the sibling
  draw_text_dithered. Stops re-scanning all 800x480 pixels for the small
  oversized-quote-mark glyphs every render.

- pick_quote.pick_best: score each candidate once and derive the sort,
  top-score filter, and ranked view from it, instead of re-running the
  pure score_row 3-4x per row. A stable sort preserves pool order so the
  seeded tie-break choice is unchanged.