### PR TITLE
Fix correctness bugs across picker, runtime, miner, web, and health

### DIFF
--- a/idle_hours/clean_display_quotes.py
+++ b/idle_hours/clean_display_quotes.py
@@ -7,6 +7,7 @@ import json
 import re
 from pathlib import Path
 
+from idle_hours import atomic_io
 from idle_hours.jsonl_io import iter_jsonl
 
 BASE_DIR = Path(__file__).resolve().parent
@@ -286,10 +287,9 @@ def main() -> int:
         row["cleanup_status"] = cleanup_status
         rows.append(row)
 
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-    with output_path.open("w", encoding="utf-8") as handle:
-        for row in rows:
-            handle.write(json.dumps(row, ensure_ascii=False) + "\n")
+    atomic_io.atomic_write_lines(
+        output_path, (json.dumps(row, ensure_ascii=False) for row in rows)
+    )
 
     fragments = sum(1 for row in rows if row["display_fragment"])
     print(f"Wrote {len(rows)} cleaned candidates to {output_path}")

--- a/idle_hours/enrich_metadata.py
+++ b/idle_hours/enrich_metadata.py
@@ -6,6 +6,7 @@ import argparse
 import json
 from pathlib import Path
 
+from idle_hours import atomic_io
 from idle_hours.jsonl_io import iter_jsonl
 
 BASE_DIR = Path(__file__).resolve().parent
@@ -91,10 +92,9 @@ def main() -> int:
         row["author"] = author
         rows.append(row)
 
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-    with output_path.open("w", encoding="utf-8") as handle:
-        for row in rows:
-            handle.write(json.dumps(row, ensure_ascii=False) + "\n")
+    atomic_io.atomic_write_lines(
+        output_path, (json.dumps(row, ensure_ascii=False) for row in rows)
+    )
 
     enriched = sum(1 for row in rows if row.get("title") or row.get("author"))
     print(f"Wrote {len(rows)} attributed rows to {output_path}")

--- a/idle_hours/gutenberg_time_miner.py
+++ b/idle_hours/gutenberg_time_miner.py
@@ -445,9 +445,24 @@ def candidate_from_match(source_path: str, source_id: str | None, text: str, mat
     )
 
 
-def iter_candidates(source_path: Path, source_id: str | None, text: str, context_chars: int, max_per_file: int) -> Iterator[Candidate]:
+def iter_candidates(
+    source_path: Path,
+    source_id: str | None,
+    text: str,
+    context_chars: int,
+    max_per_file: int,
+    excluded_match_types: set[str] | None = None,
+) -> Iterator[Candidate]:
+    # Apply the match-type exclusion (e.g. ``--strict`` dropping daypart/digital)
+    # here, BEFORE the ``max_per_file`` cap counts a candidate. Counting excluded
+    # matches toward the cap meant a ``--strict --max-per-file N`` run could spend
+    # the whole budget on leading ``digital`` matches that are then all discarded,
+    # yielding far fewer than N usable rows (sometimes zero).
+    excluded = excluded_match_types or set()
     yielded = 0
     for match_type, pattern in TIME_PATTERNS:
+        if match_type in excluded:
+            continue
         for match in pattern.finditer(text):
             candidate = candidate_from_match(str(source_path), source_id, text, match_type, match, context_chars)
             if candidate is None:
@@ -506,9 +521,10 @@ def mine(args: argparse.Namespace) -> list[Candidate]:
     candidates: list[Candidate] = []
     for path, source_id in files:
         text = path.read_text(encoding="utf-8", errors="replace")
-        for candidate in iter_candidates(path, source_id, text, args.context_chars, args.max_per_file):
-            if candidate.match_type in excluded_match_types:
-                continue
+        for candidate in iter_candidates(
+            path, source_id, text, args.context_chars, args.max_per_file,
+            excluded_match_types=excluded_match_types,
+        ):
             candidates.append(candidate)
             if args.max_total and len(candidates) >= args.max_total:
                 return candidates

--- a/idle_hours/idle_hours_health.py
+++ b/idle_hours/idle_hours_health.py
@@ -69,6 +69,17 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
+def _is_int_metric(value) -> bool:
+    """True for a real integer latency value, excluding ``bool``.
+
+    ``bool`` is an ``int`` subclass, so a corrupt/hand-edited telemetry entry
+    like ``{"render_ms": true}`` would otherwise pass a bare ``isinstance(...,
+    int)`` check and be counted as a render with latency 1, skewing both the
+    render count and the percentile latencies.
+    """
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
 def _percentile(sorted_values: list[int], p: float) -> int | None:
     """Linear-interpolation percentile over a sorted list. Returns None when empty."""
     if not sorted_values:
@@ -178,7 +189,7 @@ def summarise(entries: list[dict]) -> dict:
     # ``"backoff"`` (emitted by ``_record_render_failure`` without an error
     # field) as successful renders, which would let a wedged appliance
     # report healthy as long as it was tripping the backoff threshold.
-    renders = [e for e in non_heartbeats if isinstance(e.get("render_ms"), int)]
+    renders = [e for e in non_heartbeats if _is_int_metric(e.get("render_ms"))]
     # Exclude structured action / web / quiet markers from the generic
     # error tally even if they carry an ``error`` field — they have their
     # own dedicated counts below and a failed skip action doesn't mean the
@@ -190,7 +201,7 @@ def summarise(entries: list[dict]) -> dict:
     ]
     render_latencies = sorted(e["render_ms"] for e in renders)
     display_latencies = sorted(
-        e["display_ms"] for e in renders if isinstance(e.get("display_ms"), int)
+        e["display_ms"] for e in renders if _is_int_metric(e.get("display_ms"))
     )
     last_heartbeat_ts: str | None = None
     if heartbeats:

--- a/idle_hours/merge_candidates.py
+++ b/idle_hours/merge_candidates.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable
 
+from idle_hours import atomic_io
 from idle_hours.jsonl_io import iter_jsonl
 
 BASE_DIR = Path(__file__).resolve().parent
@@ -114,10 +115,7 @@ def dedupe(records: Iterable[Record]) -> tuple[list[dict], dict]:
 
 
 def write_jsonl(path: Path, rows: list[dict]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("w", encoding="utf-8") as handle:
-        for row in rows:
-            handle.write(json.dumps(row, ensure_ascii=False) + "\n")
+    atomic_io.atomic_write_lines(path, (json.dumps(row, ensure_ascii=False) for row in rows))
 
 
 def main() -> int:
@@ -126,8 +124,7 @@ def main() -> int:
     output_path = Path(args.output).expanduser().resolve()
     summary_path = Path(args.summary).expanduser().resolve()
     write_jsonl(output_path, merged)
-    summary_path.parent.mkdir(parents=True, exist_ok=True)
-    summary_path.write_text(json.dumps(summary, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    atomic_io.atomic_write_text(summary_path, json.dumps(summary, indent=2, ensure_ascii=False) + "\n")
     print(f"Wrote {summary['deduped_rows']} deduped candidates to {output_path}")
     print(f"Removed {summary['duplicates_removed']} duplicates from {summary['input_rows']} input rows")
     print(f"Summary written to {summary_path}")

--- a/idle_hours/pick_quote.py
+++ b/idle_hours/pick_quote.py
@@ -291,9 +291,17 @@ def is_banned(row: dict, overrides: dict) -> bool:
 
 def parse_requested_minute(bucket: str, requested_time: str | None) -> int | None:
     if requested_time:
-        minute = int(requested_time.split(":", 1)[1])
-        rounded_minute = ((minute + 2) // 5) * 5
-        return 0 if rounded_minute == 60 else rounded_minute
+        # Operator-supplied times reach here via the web /api/bucket?time= path,
+        # so a malformed string (no colon, non-numeric minute) must degrade to
+        # the bucket default rather than crashing scoring with IndexError/ValueError.
+        if ":" in requested_time:
+            try:
+                minute = int(requested_time.split(":", 1)[1])
+            except ValueError:
+                minute = None
+            if minute is not None:
+                rounded_minute = ((minute + 2) // 5) * 5
+                return 0 if rounded_minute == 60 else rounded_minute
     state = bucket.split("_", 1)[1]
     return DEFAULT_BUCKET_MINUTES.get(state)
 

--- a/idle_hours/quality_filter.py
+++ b/idle_hours/quality_filter.py
@@ -7,6 +7,7 @@ import json
 import re
 from pathlib import Path
 
+from idle_hours import atomic_io
 from idle_hours.jsonl_io import iter_jsonl
 
 BASE_DIR = Path(__file__).resolve().parent
@@ -98,10 +99,9 @@ def main() -> int:
         row["quality_flags"] = quality_flags
         rows.append(row)
 
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-    with output_path.open("w", encoding="utf-8") as handle:
-        for row in rows:
-            handle.write(json.dumps(row, ensure_ascii=False) + "\n")
+    atomic_io.atomic_write_lines(
+        output_path, (json.dumps(row, ensure_ascii=False) for row in rows)
+    )
 
     print(f"Wrote {len(rows)} quality-scored candidates to {output_path}")
     print(f"Rows below 50 score: {sum(1 for r in rows if r['quality_score'] < 50)}")

--- a/idle_hours/run_clock.py
+++ b/idle_hours/run_clock.py
@@ -721,17 +721,20 @@ def _maybe_pick_random_theme(state: RuntimeState, quote_id: tuple | None) -> str
     """
     if state.theme_arg != "random" or state.manual_theme is not None:
         return None
-    quote_changed = (
-        (quote_id is not None and quote_id != state.last_random_quote_id)
-        or state.current_random_theme is None
-    )
-    if not quote_changed:
-        return None
+    # The gate check and the bag drain must happen atomically: the main loop and
+    # a concurrent button-A / web skip both call this, and a lock-free gate read
+    # would let two threads pass for the same quote_id and double-drain the bag,
+    # breaking the documented 1:1 bag-draw-to-displayed-theme invariant.
     with state.lock:
-        bag = list(state.random_theme_bag)
-        just_played = state.current_random_theme
-    new_theme, new_bag = pick_next_random_theme(bag, just_played=just_played)
-    with state.lock:
+        quote_changed = (
+            (quote_id is not None and quote_id != state.last_random_quote_id)
+            or state.current_random_theme is None
+        )
+        if not quote_changed:
+            return None
+        new_theme, new_bag = pick_next_random_theme(
+            list(state.random_theme_bag), just_played=state.current_random_theme
+        )
         state.current_random_theme = new_theme
         state.random_theme_bag = new_bag
         state.last_random_quote_id = quote_id

--- a/idle_hours/runtime_actions.py
+++ b/idle_hours/runtime_actions.py
@@ -138,7 +138,11 @@ def action_skip(args: argparse.Namespace, state: RuntimeState, *, label: str = "
             )
             run_clock._maybe_pick_random_theme(state, quote_id)
             run_clock._render_unlocked(args, state, time_str, history_path, quote_id=quote_id)
-            if quote_id is not None:
+            # Record the freshly-shown quote — unless it's the same row we just
+            # banned (a sparse bucket can fall back to the only candidate). A
+            # duplicate ledger entry would leave one copy behind after un-skip's
+            # single-entry removal, keeping the quote stuck in the history filter.
+            if quote_id is not None and (previous is None or quote_id[:2] != previous[:2]):
                 run_clock._append_history_after_render(state, history_path, quote_id)
             _emit_action(telemetry_path, "skip", label, ok=True)
             return {"ok": True, "new_quote_id": list(quote_id) if quote_id else None}

--- a/idle_hours/web_server.py
+++ b/idle_hours/web_server.py
@@ -339,6 +339,14 @@ def validate_content_overrides_payload(payload: object) -> dict:
             elif field in {"hour", "minute", "quality_score"}:
                 if isinstance(fval, bool) or not isinstance(fval, int):
                     raise ValueError(f"override {key!r}.{field} must be an int")
+                # Range-check so an out-of-bounds value can't silently re-derive
+                # a bogus bucket at bake time (e.g. minute=99 → bucket_for_time
+                # "HH:99" KeyErrors and the row gets dropped with no feedback).
+                bounds = {"hour": (0, 23), "minute": (0, 59), "quality_score": (0, 100)}[field]
+                if not bounds[0] <= fval <= bounds[1]:
+                    raise ValueError(
+                        f"override {key!r}.{field} must be in [{bounds[0]}, {bounds[1]}]"
+                    )
         cleaned[key] = dict(value)
     return cleaned
 
@@ -916,19 +924,27 @@ class CuratorHandler(BaseHTTPRequestHandler):
 
     def _api_overrides_get(self) -> None:
         ctx = self._ctx()
-        if not ctx.overrides_path.exists():
-            payload = {
-                "ban_source_ids": [],
-                "boost_source_ids": [],
-                "preferred_buckets": {},
-                "ban_quote_keys": [],
-            }
-        else:
-            payload = json.loads(ctx.overrides_path.read_text(encoding="utf-8"))
-            # Surface ban_quote_keys to the UI even on legacy files that
-            # pre-date it, so the editor doesn't have to special-case the
-            # missing key.
-            payload.setdefault("ban_quote_keys", [])
+        defaults = {
+            "ban_source_ids": [],
+            "boost_source_ids": [],
+            "preferred_buckets": {},
+            "ban_quote_keys": [],
+        }
+        payload = defaults
+        if ctx.overrides_path.exists():
+            # Fail open on a corrupt / hand-truncated / non-object file rather
+            # than 500-ing the whole overrides editor: a bad save should still
+            # let the operator see (and overwrite) the defaults.
+            try:
+                loaded = json.loads(ctx.overrides_path.read_text(encoding="utf-8"))
+            except (OSError, ValueError):
+                loaded = None
+            if isinstance(loaded, dict):
+                # Surface ban_quote_keys to the UI even on legacy files that
+                # pre-date it, so the editor doesn't have to special-case the
+                # missing key.
+                loaded.setdefault("ban_quote_keys", [])
+                payload = loaded
         self._json(HTTPStatus.OK, payload)
 
     def _api_content_overrides_get(self) -> None:

--- a/tests/test_gutenberg_time_miner.py
+++ b/tests/test_gutenberg_time_miner.py
@@ -367,6 +367,22 @@ class TestIterCandidates:
         candidates = list(gtm.iter_candidates(Path("test.txt"), None, text, 220, max_per_file=2))
         assert len(candidates) == 2
 
+    def test_max_per_file_counts_after_exclusion(self):
+        # Excluded match types (here daypart) must NOT consume the per-file
+        # budget — otherwise a --strict run could spend the whole cap on rows it
+        # then discards and yield far fewer usable candidates than requested.
+        text = (
+            "It was morning. It was dusk. It was evening. "
+            "She woke at one o'clock. By two o'clock she left. By three o'clock all was still."
+        )
+        candidates = list(gtm.iter_candidates(
+            Path("test.txt"), None, text, 220, max_per_file=2,
+            excluded_match_types={"daypart"},
+        ))
+        assert len(candidates) == 2
+        # Both kept rows are real clock matches, not the leading daypart hits.
+        assert all(c.match_type != "daypart" for c in candidates)
+
 
 # ---------------------------------------------------------------------------
 # text_files_from_inputs

--- a/tests/test_idle_hours_health.py
+++ b/tests/test_idle_hours_health.py
@@ -93,6 +93,19 @@ class TestSummarise:
         assert summary["render_count"] == 0
         assert summary["render_p50_ms"] is None
 
+    def test_bool_render_ms_not_counted_as_render(self):
+        # bool is an int subclass; a corrupt {"render_ms": true} entry must not
+        # be counted as a render-with-latency-1, which would skew both the count
+        # and the percentiles.
+        entries = [
+            {"render_ms": 100, "display_ms": 50},
+            {"render_ms": True},   # corrupt — must be ignored
+            {"display_ms": False},  # corrupt — must be ignored
+        ]
+        summary = idle_hours_health.summarise(entries)
+        assert summary["render_count"] == 1
+        assert summary["render_p50_ms"] == 100
+
 
 class TestMain:
     def test_missing_log_exits_nonzero(self, tmp_path, capsys):

--- a/tests/test_pick_quote.py
+++ b/tests/test_pick_quote.py
@@ -873,6 +873,16 @@ class TestMinuteDistancePenalty:
         # bucket is a non-standard state name so DEFAULT_BUCKET_MINUTES returns None
         assert pq.minute_distance_penalty(row, "h3_nonsense", None) == 99
 
+    def test_malformed_requested_time_falls_back_to_bucket(self):
+        # Operator-supplied junk (no colon / non-numeric minute) reaches here via
+        # the web /api/bucket?time= path and must degrade to the bucket default
+        # rather than crashing scoring with IndexError/ValueError.
+        assert pq.parse_requested_minute("h3_quarter_past", "garbage") == 15
+        assert pq.parse_requested_minute("h3_quarter_past", "03:xx") == 15
+        row = {"normalized_time": "03:15"}
+        # No crash; distance computed against the bucket-default minute (15).
+        assert pq.minute_distance_penalty(row, "h3_quarter_past", "garbage") == 0
+
     def test_exact_distance_zero(self):
         row = {"normalized_time": "03:15"}
         assert pq.minute_distance_penalty(row, "h3_quarter_past", "03:15") == 0

--- a/tests/test_run_clock.py
+++ b/tests/test_run_clock.py
@@ -1656,6 +1656,25 @@ class TestButtonHandlers:
         assert mock_append.call_args_list[1][0][1:] == ("src-new", 7)
         assert mock_render.called
 
+    def test_skip_does_not_double_append_when_pick_unchanged(self, tmp_path):
+        """Sparse bucket: the next pick is the same row we just banned. The ban
+        append must still happen, but the post-render append must be suppressed
+        so the ledger doesn't carry a duplicate (which un-skip's single-entry
+        removal would leave half-deleted, stranding the quote in the filter)."""
+        args = self._args(tmp_path)
+        state = run_clock.RuntimeState("default")
+        state.last_quote_id = ("src-x", 9, "q", "mt")
+        with patch("idle_hours.run_clock.peek_quote_id", return_value=("src-x", 9, "q", "mt")), \
+             patch("idle_hours.run_clock.render_now"), \
+             patch("idle_hours.run_clock.current_time_str", return_value="10:00"), \
+             patch("idle_hours.run_clock.current_bucket", return_value="h10_exact"), \
+             patch("idle_hours.run_clock.pick_quote_module.append_history") as mock_append:
+            short_handlers, _hold_handlers = run_clock._build_button_handlers(args, state)
+            short_handlers["A"]()
+        # Only the ban append fires; the duplicate post-render append is skipped.
+        assert mock_append.call_count == 1
+        assert mock_append.call_args_list[0][0][1:] == ("src-x", 9)
+
     def test_toggle_theme_handler_flips_and_persists(self, tmp_path):
         args = self._args(tmp_path)
         state = run_clock.RuntimeState("default")

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -583,6 +583,28 @@ class TestReadEndpoints:
         assert on_disk["boost_source_ids"] == ["1342"]
         assert on_disk["preferred_buckets"] == {"h3_exact": "141"}
 
+    def test_api_overrides_get_fails_open_on_corrupt_file(self, tmp_path, live_server):
+        # A hand-truncated / non-object overrides file must not 500 the whole
+        # editor — GET should fall open to the default schema so the operator
+        # can still see and overwrite it.
+        server, _, args = live_server
+        path = Path(args.overrides)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("[not, an, object")  # truncated, invalid JSON
+        status, body = _get(server, "/api/overrides")
+        assert status == 200
+        assert _json_body(body) == {
+            "ban_source_ids": [],
+            "boost_source_ids": [],
+            "preferred_buckets": {},
+            "ban_quote_keys": [],
+        }
+        # Valid JSON but a list (not an object) also fails open.
+        path.write_text("[1, 2, 3]")
+        status, body = _get(server, "/api/overrides")
+        assert status == 200
+        assert _json_body(body)["ban_quote_keys"] == []
+
     def test_api_history_limit(self, tmp_path, live_server):
         server, _, args = live_server
         path = Path(args.history_path)
@@ -1996,6 +2018,22 @@ class TestContentOverridesValidator:
         # hour must be an int (not bool)
         with pytest.raises(ValueError, match="must be an int"):
             web_server.validate_content_overrides_payload({"141:42": {"hour": True}})
+
+    def test_rejects_out_of_range_int_fields(self):
+        # An out-of-range minute would re-derive a bogus bucket at bake time and
+        # get silently dropped; reject it up front with a 400-worthy ValueError.
+        with pytest.raises(ValueError, match=r"\[0, 59\]"):
+            web_server.validate_content_overrides_payload({"141:42": {"minute": 99}})
+        with pytest.raises(ValueError, match=r"\[0, 23\]"):
+            web_server.validate_content_overrides_payload({"141:42": {"hour": 24}})
+        with pytest.raises(ValueError, match=r"\[0, 100\]"):
+            web_server.validate_content_overrides_payload({"141:42": {"quality_score": 101}})
+
+    def test_accepts_in_range_int_fields(self):
+        cleaned = web_server.validate_content_overrides_payload(
+            {"141:42": {"hour": 23, "minute": 0, "quality_score": 100}}
+        )
+        assert cleaned == {"141:42": {"hour": 23, "minute": 0, "quality_score": 100}}
 
 
 # ============================================================================


### PR DESCRIPTION
Batch of high-confidence fixes found in a codebase review:

- pick_quote.parse_requested_minute: guard against malformed requested_time
  (no colon / non-numeric minute). Operator input reaches this via the web
  /api/bucket?time= path and previously crashed scoring with IndexError/
  ValueError, surfacing as a 500.

- runtime_actions.action_skip: don't double-append the freshly-picked quote
  to the history ledger when a sparse bucket falls back to the same row that
  was just banned. The duplicate left one copy behind after un-skip's
  single-entry removal, stranding the quote in the anti-repeat filter.

- run_clock._maybe_pick_random_theme: perform the gate check and bag drain
  under a single state.lock. The previous lock-free gate read let the main
  loop and a concurrent button/web skip both pass for the same quote_id and
  double-drain the shuffle bag, breaking the 1:1 bag-draw invariant.

- web_server /api/overrides GET: fail open to the default schema on a
  corrupt / non-object selection_overrides.json instead of 500-ing the
  entire overrides editor.

- web_server content-override validation: range-check hour/minute/
  quality_score so an out-of-bounds value can't silently re-derive a bogus
  bucket at bake time and get dropped with no operator feedback.

- gutenberg_time_miner: apply the match-type exclusion inside iter_candidates
  so excluded matches (e.g. --strict dropping daypart/digital) no longer
  consume the --max-per-file budget and starve usable rows.

- idle_hours_health: exclude bool from the int latency check so a corrupt
  {"render_ms": true} entry isn't counted as a render with latency 1.

- enrich_metadata / quality_filter / clean_display_quotes / merge_candidates:
  route JSONL/summary output through atomic_io, matching the durability
  invariant the rest of the pipeline already follows.

Adds regression tests for each fix.