### PR TITLE
Fix random theme repeating soon after the bag-refill boundary

### DIFF
--- a/idle_hours/run_clock.py
+++ b/idle_hours/run_clock.py
@@ -54,6 +54,8 @@ from idle_hours.runtime_theme import (  # noqa: F401  auto_theme_for + _maybe_re
     auto_theme_for,
     pick_next_random_theme,
     pick_random_theme,
+    random_theme_pool,
+    recent_window_size,
     resolve_effective_theme,
 )
 
@@ -711,8 +713,10 @@ def _maybe_pick_random_theme(state: RuntimeState, quote_id: tuple | None) -> str
 
     Picks are drained from :attr:`RuntimeState.random_theme_bag` (a shuffled
     pass through the full cycle) so every theme is shown once before any
-    repeat. When the bag empties it's refilled with a fresh shuffle, with the
-    head swapped if it would replay the just-played theme.
+    repeat. When the bag empties it's refilled with a fresh shuffle, and the
+    themes in :attr:`RuntimeState.random_theme_recent` (the last ~half-pool
+    picks) are held out of the new bag's draw-front so a theme shown at the
+    tail of one pass can't reappear at the head of the next.
 
     The gate uses :attr:`RuntimeState.last_random_quote_id` (advanced
     synchronously by this function), not ``last_quote_id`` (advanced only by
@@ -739,10 +743,16 @@ def _maybe_pick_random_theme(state: RuntimeState, quote_id: tuple | None) -> str
         if not quote_changed:
             return None
         new_theme, new_bag = pick_next_random_theme(
-            list(state.random_theme_bag), just_played=state.current_random_theme
+            list(state.random_theme_bag), recent=state.random_theme_recent
         )
         state.current_random_theme = new_theme
         state.random_theme_bag = new_bag
+        # Roll the recent-window forward (most-recent last) and cap it at
+        # ~half the pool, so the next refill keeps these themes out of the
+        # new bag's draw-front. This is what prevents a tail-of-pass theme
+        # from reappearing a pick or two into the next pass.
+        window = recent_window_size(len(random_theme_pool()))
+        state.random_theme_recent = (state.random_theme_recent + [new_theme])[-window:]
         state.last_random_quote_id = quote_id
     return new_theme
 

--- a/idle_hours/runtime_state.py
+++ b/idle_hours/runtime_state.py
@@ -59,6 +59,13 @@ class RuntimeState:
         # restart starts a fresh pass, same rationale as
         # ``current_random_theme``.
         self.random_theme_bag: list[str] = []
+        # Rolling window of the most-recently-drawn themes (most-recent last),
+        # capped at ~half the pool. Carried across the bag-refill boundary so
+        # a theme drawn at the tail of one pass can't reappear at the head of
+        # the next — the independent per-pass shuffles otherwise let the same
+        # theme recur only one or two picks later. Not persisted, same
+        # rationale as ``random_theme_bag``.
+        self.random_theme_recent: list[str] = []
         self.manual_quiet = False             # toggled by button D
         self.last_bucket: str | None = None
         self.last_quote_id: tuple | None = None

--- a/idle_hours/runtime_theme.py
+++ b/idle_hours/runtime_theme.py
@@ -89,20 +89,40 @@ def pick_random_theme() -> str:
     return random.choice(list(random_theme_pool()))
 
 
+def recent_window_size(pool_size: int) -> int:
+    """How many recent picks to hold out of the next bag's draw-front.
+
+    Picking half the pool is the value that maximises the *guaranteed*
+    minimum gap between two appearances of the same theme. Blocking the
+    last ``R`` themes from the first ``R`` draws of a fresh bag gives a
+    protected-theme gap of ``pool - R + 1`` and an unprotected-theme gap
+    of ``R + 1``; the smaller of the two is maximised when ``R = pool/2``
+    (gap ~ ``pool/2 + 1`` either way). For the 40-theme pool that's a
+    guaranteed spacing of ~21 picks instead of the old worst case of 2.
+    """
+    return max(1, pool_size // 2)
+
+
 def pick_next_random_theme(
-    bag: list[str], *, just_played: str | None = None,
+    bag: list[str], *, recent: list[str] | None = None,
 ) -> tuple[str, list[str]]:
     """Draw the next theme from a shuffled bag of unseen themes.
 
     Returns ``(theme, updated_bag)`` — the caller stores ``updated_bag``
-    on :class:`RuntimeState`. When ``bag`` is empty the bag is refilled
-    with a fresh shuffle of the full cycle; if the freshly-shuffled next
-    pick would replay ``just_played``, it's swapped with another random
-    position so back-to-back repeats don't sneak across the reshuffle
-    boundary.
+    on :class:`RuntimeState`. When ``bag`` is empty it's refilled with a
+    fresh shuffle of the full cycle.
 
-    The bag is popped from the end (``list.pop`` is O(1)), so ``bag[-1]``
-    is the "next" theme — that's the slot the swap targets.
+    ``recent`` is the caller's rolling window of the most-recently-drawn
+    themes (most-recent last). On a refill the themes in ``recent`` are
+    moved to the *head* of the new bag — and since the bag is popped from
+    the end (``list.pop`` is O(1)), the head is drawn *last*. The
+    non-recent themes fill the tail and are drawn first, so a theme shown
+    near the end of the previous pass can't reappear at the start of the
+    next one. This is the cross-boundary generalisation of the old
+    "don't replay the single just-played theme" swap: independent
+    per-pass shuffles otherwise let a tail theme recur as the second pick
+    of the next pass (a gap of 2). See :func:`recent_window_size` for why
+    the caller caps ``recent`` at half the pool.
 
     The refill draws from :func:`random_theme_pool` (= ``theme_cycle()``
     minus :data:`RANDOM_EXCLUDED_THEMES`) rather than the full cycle, so
@@ -110,11 +130,17 @@ def pick_next_random_theme(
     """
     bag = list(bag)  # never mutate the caller's list
     if not bag:
-        bag = list(random_theme_pool())
-        random.shuffle(bag)
-        if just_played is not None and len(bag) > 1 and bag[-1] == just_played:
-            swap_idx = random.randint(0, len(bag) - 2)
-            bag[-1], bag[swap_idx] = bag[swap_idx], bag[-1]
+        pool = list(random_theme_pool())
+        random.shuffle(pool)
+        if recent:
+            recent_set = set(recent)
+            # Recently-seen themes -> head (drawn last); fresh themes -> tail
+            # (drawn first). Order within each partition stays the shuffled
+            # order, so randomness is preserved on both sides of the split.
+            blocked = [t for t in pool if t in recent_set]
+            free = [t for t in pool if t not in recent_set]
+            pool = blocked + free
+        bag = pool
 
     theme = bag.pop()
     return theme, bag

--- a/tests/test_run_clock.py
+++ b/tests/test_run_clock.py
@@ -3528,17 +3528,19 @@ class TestRandomThemeMode:
         assert len(state.random_theme_bag) == len(themes) - 1
 
     def test_random_mode_no_back_to_back_repeat_across_bag_boundary(self):
-        """The reshuffle boundary must not replay the just-played theme.
+        """The reshuffle boundary must not replay a recently-played theme.
 
         We force the worst case: the just-played theme is set, and we
         construct a cycle where ``random.shuffle`` would put it at the
-        pop position. The swap must move it.
+        pop position. The recent-window block must move it to the head
+        (drawn last) so it does not recur as the first pick of the new bag.
         """
         from idle_hours.runtime_theme import random_theme_pool
         themes = list(random_theme_pool())
         just_played = themes[0]
         state = run_clock.RuntimeState("random")
         state.current_random_theme = just_played
+        state.random_theme_recent = [just_played]
         state.random_theme_bag = []
         # Force shuffle to a known order where bag[-1] == just_played.
         forced = [t for t in themes if t != just_played] + [just_played]
@@ -3546,11 +3548,33 @@ class TestRandomThemeMode:
         def _force_order(b):
             b[:] = forced  # random.shuffle mutates in place
 
-        # randint patched to a deterministic in-range swap index.
-        with patch("idle_hours.runtime_theme.random.shuffle", side_effect=_force_order), \
-             patch("idle_hours.runtime_theme.random.randint", return_value=0):
+        with patch("idle_hours.runtime_theme.random.shuffle", side_effect=_force_order):
             pick = run_clock._maybe_pick_random_theme(state, ("src", 42, "q", "m"))
         assert pick != just_played, "back-to-back repeat at reshuffle boundary"
+
+    def test_random_mode_no_near_boundary_repeat(self):
+        """A theme shown at the tail of one pass must not reappear within a
+        few picks at the head of the next — the gap-2 regression that the
+        single-theme swap missed. Drive several full passes and assert the
+        guaranteed minimum spacing holds.
+        """
+        from idle_hours.runtime_theme import random_theme_pool, recent_window_size
+        themes = list(random_theme_pool())
+        window = recent_window_size(len(themes))
+        state = run_clock.RuntimeState("random")
+        seq: list[str] = []
+        for i in range(len(themes) * 4):
+            new_quote_id = ("src", i, "q", "m")
+            pick = run_clock._maybe_pick_random_theme(state, new_quote_id)
+            seq.append(pick)
+            state.last_quote_id = new_quote_id
+        last_seen: dict[str, int] = {}
+        min_gap = len(seq)
+        for i, theme in enumerate(seq):
+            if theme in last_seen:
+                min_gap = min(min_gap, i - last_seen[theme])
+            last_seen[theme] = i
+        assert min_gap > window, f"theme repeated within {min_gap} picks (window={window})"
 
     def test_random_mode_never_picks_excluded_themes(self):
         """``diags`` renders a status panel rather than a quote — a random


### PR DESCRIPTION
The --theme random shuffle bag guaranteed every theme showed once per
pass, but each pass was an independent shuffle and the boundary guard
only prevented the single just-played theme from being the *first* pick
of the next bag. A tail-of-pass theme could still reappear as the
*second* pick of the next pass — a gap of 2, which on a ~5-min fuzzy
bucket reads as "the same theme a few minutes apart."

Generalize the single-theme swap into a rolling recent-window: carry the
last ~half-pool drawn themes across the refill and push them to the head
of the new bag (drawn last), so a recently-shown theme can't recur until
the rest of the catalogue has cycled. Half the pool is the window size
that maximizes the guaranteed minimum gap; for the 40-theme pool the
worst-case spacing goes from 2 to 21 picks.

- runtime_theme: replace the just_played swap with a recent-window block;
  add recent_window_size() helper documenting the pool/2 optimum.
- runtime_state: add random_theme_recent (not persisted, same as the bag).
- run_clock._maybe_pick_random_theme: maintain the capped recent window.
- tests: update the boundary test for the new mechanism; add a
  near-boundary regression asserting the guaranteed minimum spacing.