### PR TITLE
Fix CI badge repo casing and point README at the plumpbug.dev project page

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Idle Hours
 
-[![CI](https://github.com/gkoch02/idle-hours/actions/workflows/ci.yml/badge.svg)](https://github.com/gkoch02/idle-hours/actions/workflows/ci.yml)
+[![CI](https://github.com/gkoch02/Idle-Hours/actions/workflows/ci.yml/badge.svg)](https://github.com/gkoch02/Idle-Hours/actions/workflows/ci.yml)
 
 Idle Hours is a literary clock built from public-domain text. It picks a quote that matches the current fuzzy time bucket, renders it into an 800×480 image, and can push that image to an eInk display such as the Pimoroni Inky Impression 7.3.
 
@@ -760,3 +760,10 @@ If the clock is behaving oddly, these are the first files to inspect:
 - [`docs/CODE_OF_CONDUCT.md`](docs/CODE_OF_CONDUCT.md) — Contributor Covenant v2.1.
 
 Deeper architecture and design notes live in [`CLAUDE.md`](CLAUDE.md); skim that first when modifying the runtime or pipeline.
+
+There's also a project landing page at [plumpbug.dev/idlehours](https://plumpbug.dev/idlehours/home.html)
+(privacy/support pages too, though Idle Hours needs neither an App Store account nor
+authentication to use), maintained in the separate
+[`gkoch02/plumpbug-site`](https://github.com/gkoch02/plumpbug-site) repo alongside the
+other Plumpbug-family projects. This repo stays the source of truth for the theme gallery
+and preview PNGs that page embeds.


### PR DESCRIPTION
## Summary

- The CI badge/link in README.md used lowercase `gkoch02/idle-hours`; the actual repo is `gkoch02/Idle-Hours` (matches `git remote` and every other cross-reference to this repo, e.g. from `plumpbug-site`). GitHub redirects case-insensitively so the badge wasn't broken, just inconsistent — fixed for consistency.
- Adds a pointer to the Idle Hours landing page at plumpbug.dev, maintained in the separate `gkoch02/plumpbug-site` repo. This repo had no reference to it at all, while the sibling `BetweenUs` and `Nightdraft` repos already cross-reference that site.

Part of a pass across the Plumpbug-family repos (`plumpbug-site`, `BetweenUs`, `HomeDashboard`, `Idle-Hours`, `Nightdraft`) checking that READMEs and CLAUDE.mds are correct and reference each other where appropriate.

## Test plan

- [x] Docs-only change; no code touched.
- [x] Verified `git remote -v` in this repo and the link `plumpbug-site` uses both say `gkoch02/Idle-Hours`.
- [x] Verified `plumpbug-site`'s `docs/idlehours/` contains 9 preview PNGs, matching the "nine of the forty-five" figure already documented in that repo's own `CLAUDE.md`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EZpqMonSmmNoTm2MqMv6oc)_