### PR TITLE
Stop two footer truncation loops from hanging the renderer

### DIFF
--- a/idle_hours/render_quote.py
+++ b/idle_hours/render_quote.py
@@ -16802,9 +16802,19 @@ def _questline_paint_footer(image: Image.Image, draw: ImageDraw.ImageDraw, quote
     font = load_font(theme_font_candidates("questline", "quote_regular"), size=8)
     # Keep the footer clear of the continue arrow on the right.
     max_w = (_QUESTLINE_BOX[2] - _QUESTLINE_BOX[0]) - 120
-    while text and draw.textlength(text, font=font) > max_w:
+    # Guard on `title`, the string that actually shrinks — not on `text`, which
+    # is rebuilt from a template each pass and stays non-empty even once the
+    # title is gone. Guarding on `text` made this a fixed point that spins
+    # forever whenever the budget is too small to fit "— from … —", which is a
+    # hard hang of the render path: fatal in-process on the curator UI's
+    # /api/preview thread, and a render_timeout plus backoff on the appliance.
+    # It is latent today only because `max_w` is a fixed constant that happens
+    # to be generous; narrowing the box or raising the font size would trip it.
+    while title and draw.textlength(text, font=font) > max_w:
         title = title[:-1]
         text = f"— from {title.rstrip()}… —"
+    if not title:
+        return  # no room for even a stub of the title — drop the footer
     bbox = draw.textbbox((0, 0), text, font=font)
     cx = (_QUESTLINE_BOX[0] + _QUESTLINE_BOX[2]) // 2
     fx = cx - (bbox[2] - bbox[0]) // 2 - bbox[0]
@@ -17178,9 +17188,14 @@ def _chrono_paint_footer(image: Image.Image, draw: ImageDraw.ImageDraw, quote_ro
     text = f"— from {title} —"
     font = load_font(theme_font_candidates("chrono", "quote_regular"), size=12)
     max_w = (_CHRONO_WINDOW[2] - _CHRONO_WINDOW[0]) - 140
-    while text and draw.textlength(text, font=font) > max_w:
+    # Same fixed-point hang as questline's footer, and fixed the same way — see
+    # the note in `_questline_paint_footer`. The two were written from the same
+    # template, so they carried the same defect.
+    while title and draw.textlength(text, font=font) > max_w:
         title = title[:-1]
         text = f"— from {title.rstrip()}… —"
+    if not title:
+        return  # no room for even a stub of the title — drop the footer
     bbox = draw.textbbox((0, 0), text, font=font)
     cx = (_CHRONO_WINDOW[0] + _CHRONO_WINDOW[2]) // 2 + 50  # nudge clear of the portrait
     fx = cx - (bbox[2] - bbox[0]) // 2 - bbox[0]

--- a/tests/test_render_quote_themes.py
+++ b/tests/test_render_quote_themes.py
@@ -18,9 +18,10 @@ custom paths add.
 from __future__ import annotations
 
 import json
+import threading
 
 import pytest
-from PIL import Image
+from PIL import Image, ImageDraw
 
 from idle_hours import render_quote as rq
 
@@ -558,3 +559,78 @@ class TestLiederRhythm:
                     f"meter {meter}/4: final sung note is not the tonic "
                     f"({sung[-1]['pitch']}) in {row.get('source_id')}:{row.get('line_number')}"
                 )
+
+
+class TestFooterTruncationTerminates:
+    """Text-shrinking loops must terminate however small the width budget is.
+
+    ``_questline_paint_footer`` and ``_chrono_paint_footer`` were written from
+    the same template and carried the same defect: the loop shrank ``title``
+    but guarded on ``text``, which is rebuilt as ``f"— from {title}… —"`` every
+    pass and therefore stays truthy after the title is exhausted. Once the
+    budget was too small to fit the bare ``"— from … —"``, the loop was a fixed
+    point and spun forever.
+
+    That is a hard hang of the render path, not a cosmetic bug: fatal in-process
+    on the curator UI's ``/api/preview`` thread, and a render_timeout plus
+    backoff on the appliance. Both were latent rather than live — the budget is
+    a fixed constant that happens to be generous — so nothing caught them, and
+    a golden fixture never would: a hang produces no pixels to compare.
+
+    These run the painter with the budget squeezed to nothing, on a worker
+    thread with a timeout, so a reintroduced hang fails in seconds instead of
+    burning the job's whole ``timeout-minutes``.
+    """
+
+    LONG_TITLE = "A Considerably Overlong Book Title That Cannot Possibly Fit" * 3
+
+    @staticmethod
+    def _run_with_timeout(fn, seconds=10):
+        done = threading.Event()
+        error: list[BaseException] = []
+
+        def target():
+            try:
+                fn()
+            except BaseException as exc:  # noqa: BLE001 - re-raised on the main thread
+                error.append(exc)
+            finally:
+                done.set()
+
+        threading.Thread(target=target, daemon=True).start()
+        finished = done.wait(seconds)
+        if error:
+            raise error[0]
+        return finished
+
+    @pytest.mark.parametrize(
+        "painter_name, box_name",
+        [
+            ("_questline_paint_footer", "_QUESTLINE_BOX"),
+            ("_chrono_paint_footer", "_CHRONO_WINDOW"),
+        ],
+    )
+    def test_terminates_with_no_width_budget(self, painter_name, box_name, monkeypatch):
+        # Squeeze the box until the width budget cannot fit even the ellipsis
+        # stub, which is the exact condition that used to spin.
+        box = getattr(rq, box_name)
+        monkeypatch.setattr(rq, box_name, (box[0], box[1], box[0] + 1, box[3]))
+        painter = getattr(rq, painter_name)
+        image = Image.new("RGB", (800, 480), rq.SPECTRA6["black"])
+        draw = ImageDraw.Draw(image)
+        row = {"display_quote": "It was half past two.", "matched_text": "half past two",
+               "title": self.LONG_TITLE, "author": "Edith Wharton"}
+        assert self._run_with_timeout(lambda: painter(image, draw, row)), (
+            f"{painter_name} did not terminate with an exhausted width budget — "
+            "the truncation loop is a fixed point again"
+        )
+
+    @pytest.mark.parametrize("theme", ("questline", "chrono"))
+    def test_frame_still_renders_with_an_absurd_title(self, theme):
+        """The normal path must survive a title no sane budget can fit."""
+        row = {"display_quote": "It was half past two when the clock struck.",
+               "matched_text": "half past two", "title": self.LONG_TITLE,
+               "author": "Edith Wharton"}
+        assert self._run_with_timeout(
+            lambda: rq.render("02:30", row, 800, 480, mode="production", theme=theme)
+        ), f"{theme} frame did not terminate with an absurd title"


### PR DESCRIPTION
Follow-up to the loose end flagged in #209.

## The bug

`_questline_paint_footer` shrinks `title` but guards the loop on `text`:

```python
text = f"— from {title} —"
while text and draw.textlength(text, font=font) > max_w:
    title = title[:-1]
    text = f"— from {title.rstrip()}… —"   # rebuilt, so never falsy
```

`text` is rebuilt from a template on every pass, so it stays truthy after the title is exhausted, and `title[:-1]` on `""` is `""`. Once the width budget is too small to fit the bare `"— from … —"`, the loop is a **fixed point and spins forever**.

## A second instance

Sweeping all seven text-shrinking loops in `render_quote.py` turned up the same defect in **`_chrono_paint_footer`**, written from the same template. The other five guard on the same string they shrink (`while text: text = text[:-1]`) and terminate correctly — including the marquee title loop, which measures `f"— {text} —"` but correctly guards on `text`.

| Loop | Shrinks | Guards on | |
|---|---|---|---|
| `_questline_paint_footer` | `title` | `text` | **hangs** |
| `_chrono_paint_footer` | `title` | `text` | **hangs** |
| `_chrono_paint_dialogue` speaker | `name` | `name` | ok |
| `_marquee_paint_credits` author | `text` | `text` | ok |
| `_marquee_paint_credits` title | `text` | `text` | ok |
| `_sampler_paint_credits` | `text` | `text` | ok |
| `_izakaya_paint_credits` | `text` | length | ok (fixed in #209) |

## Severity

Both are **latent, not live**. The budgets are fixed constants — 636 px and 604 px — that comfortably fit the stub, which is why nothing caught them. Narrowing either box, raising either font size, or widening either inset trips it.

The consequence is a hard hang of the render path, not a cosmetic defect:

- **fatal** in-process on the curator UI's `/api/preview` thread, which would wedge that worker permanently;
- a `render_timeout` plus backoff on the appliance, where the renderer runs as a subprocess under `RENDER_TIMEOUT_SECONDS`.

## The fix

Guard on `title`, the string that actually shrinks, so termination holds for **any** budget including a negative one. When the title is consumed entirely the footer is dropped rather than drawn as a bare ellipsis.

No rendered output changes for any reachable input — **no golden fixture moves**.

## The fence

`TestFooterTruncationTerminates` squeezes each box to nothing and runs the painter on a worker thread with a timeout, so a reintroduced hang fails in seconds rather than burning the CI job's whole `timeout-minutes`.

I verified the fence against the unfixed code rather than trusting it: both painters fail it, and the two whole-frame cases pass either way — which is exactly what "latent, not live" looks like from the test's point of view. Worth noting a golden fixture could never have caught this class of bug, since a hang produces no pixels to compare.

## Verification

- `pytest -n auto --dist loadscope` → **3296 passed, 4 skipped**
- `ruff check .` → clean
- no golden fixtures changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wa1REPSorwLsbagY2xA1Ps

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wa1REPSorwLsbagY2xA1Ps)_